### PR TITLE
Remove markers and replace with a default rule for unused type/lifetime parameters

### DIFF
--- a/active/0000-variance.md
+++ b/active/0000-variance.md
@@ -38,8 +38,9 @@ for a vector was defined as follows:
     }
     
 Here of course, the lifetime `'a` is not used, and hence the inference
-algorithm again infers bivariance. This is certainly not what was
-intended.
+algorithm again infers bivariance. This effectively means that the
+lifetime parameter `'a` is completely ignored, which is certainly not
+what was intended.
 
 The current way to control the inference algorithm is to employ marker
 types like `CovariantType` or `ContravariantLifetime`. These are
@@ -47,12 +48,28 @@ maximally flexible but also dangerous as defaults -- if you don't know
 that you need to use them, you will get very lax typing, much laxer
 than you might expect.
 
+I'd like to remove the need for marker types altogether. Currently
+they are used to opt out of the builtin kinds, but we are moving to an
+opt-in system which makes those markers unnecessary. The remaining
+place marker types are used is for specifying variance, but with this
+proposal they will not be needed there either.
+
 # Detailed design
 
-I'd like to change the default behavior of the inference algorithm as
-follows: **If a type or lifetime parameter is not used within the body
-of a type, we default to covariance for types and contravariance for
-lifetimes.**
+The proposal has three parts:
+
+1. Change the default behavior of the inference algorithm as follows:
+   If a type or lifetime parameter is not used within the body of a
+   type, we default to covariance for types and contravariance for
+   lifetimes.
+2. Treat `Unsafe<T>` as invariant with respect to `T`. This is not
+   strictly necessary (the current behavior can be simulated,
+   described below), but it's more convenient for users.
+3. Remove the marker types for variance inference.
+
+Let's address each part in turn.
+
+## Change 1. Adjust how inference algorithm treats unused parameters.
 
 This change chooses as defaults what I believe most people would expect.
 More specifically, if you write a struct with an unused type parameter `T`:
@@ -70,16 +87,69 @@ Similarly, if you write a struct with an unused lifetime parameter `'a`:
     
 That is equivalent to a struct containing a reference of lifetime `'a`:
 
-    struct Bar<'a> { f: &'a () } // Note: 'a is not used
+    struct Bar<'a> { f: &'a () } // Bar<'a> above equivalent to this
     
 This is what I intuitively expect when I see `Foo<T>` or `Bar<'a>`.
+
+## Change 2. Treat `Unsafe<T>` as invariant in the inference analysis.
+
+We've already decided that interior mutability which does not build on
+`Unsafe<T>` is undefined behavior (this is needed to prevent segfaults
+and so forth from static constants). Therefore, since `Unsafe<T>` is
+built into the language rules, it just makes sense for `Unsafe<T>` to
+be known to the variance inference as well. The inference algorithm
+can treat `T` as invariant, which means there will be no need for a
+marker type here.
+
+This is more convenient for users since an `Unsafe` static constant
+can be created with having to write out any markers:
+
+```
+// Before
+static UNSAFE_ZERO: Unsafe<uint> = Unsafe { value: 0,
+                                            marker: marker::InvariantType };
+                                            
+// After:                                            
+static UNSAFE_ZERO: Unsafe<uint> = Unsafe { value: 0 };
+```
+
+Note that we could not make this change, but it would require keeping
+markers or something equivalent to markers, as described in the next
+section.
+
+## Change 3. Remove marker types.
+
+If we change the algorithm as described above, then I think there is
+no longer any need for marker types.
+
+One reason for this is that their effect can be completely simulated:
+
+```
+struct CovariantType<T>;
+struct ContravariantType<T> { m: CovariantType<fn(T)> }
+struct InvariantType<T> { m: CovariantType<fn(T) -> T> }
+struct CovariantLifetime<'a> { m: CovariantType<fn(&'a int)> }
+struct ContravariantLifetime<'a>;
+struct InvariantLifetime<'a> { m: CovariantType<fn(&'a int) -> &'a int> }
+```
+
+But the real reason for this change is not precisely that the current
+markers can be simulated; it's more that I don't see the need for
+them. Previously, there were two known situations where inference
+was insufficient and markers were needed:
+
+1. Unused lifetimes not capturing the expected constraint. Addressed by
+   Change 1 above.
+2. Interior mutability (`Cell<T>`, `RefCell<T>`), which should be invariant
+   with respect to `T`. This is addressed by Change 2.
 
 # Alternatives
 
 There are many possible alternatives:
 
 **Keep the current system, with the attendant risks.** I think we'll
-see more and more bugs this way.
+see broken code this way, where users are not getting the type system
+guarantees they think they are getting.
 
 **Default to invariance for unused type parameters, not covariance.**
 This would mean that, e.g., `Foo<&'static int>` is not a subtype of
@@ -87,6 +157,11 @@ This would mean that, e.g., `Foo<&'static int>` is not a subtype of
 it's slightly more intuitive to follow the rule that unused type
 parameters act *as if* they appeared the struct had a member of that
 type.
+
+**Make it an error to have an unused type or lifetime parameters,
+except for in marker types.** This is the most explicit system, but
+also requires that we keep marker types (which are undeniably awkward)
+and requires the most direct interaction with variance annotations.
 
 # Unresolved questions
 


### PR DESCRIPTION
Inspired by @edwardw's PR mozilla/rust#12828, this RFC proposes a small change to the behavior of variance inference if a type or lifetime parameter is unused. The goal is to more accurately capture user's intended behavior.
