### PR TITLE
Unify and nest structs and enums

### DIFF
--- a/0000-enum-struct.md
+++ b/0000-enum-struct.md
@@ -438,7 +438,7 @@ can always be accessed.
 If a method is overridden, we should still be able to call it. C++ uses `::`
 syntax to allow this. In the example above we use `Foo::bar(self)` to indicate
 static dispatch of an overridden method. I'm not sure if this is currently
-valid Rust or if it is the optimal tsolution. But it looks nice to me and we
+valid Rust or if it is the optimal solution. But it looks nice to me and we
 need something for such a situation.
 
 ## Generics


### PR DESCRIPTION
Another alternative to RFC #5 and an extension/variant of RFC #11.

Unify enums and structs by allowing enums to have fields, and structs to have
variants. Allow nested enums/structs. Virtual dispatch of methods on struct/enum
pointers. Remove struct variants. Treat enum variants as first class. Possibly
remove nullary structs and tuple structs.
