### PR TITLE
Added RFC for multiple trait implementations for a single impl block

### DIFF
--- a/active/0000-multiple-traits-per-impl.md
+++ b/active/0000-multiple-traits-per-impl.md
@@ -8,7 +8,7 @@ Provide syntax to allow multiple traits to be implemented in a single `impl` blo
 
 # Motivation
 
-The current syntax for implementing multiple Traits is quite verbose, and this simple syntactic change will make code more understandable than mountains of boilerplate
+The current syntax for implementing multiple traits is quite verbose, and this simple syntactic change will make code more understandable than useless boilerplate
 
 # Drawbacks
 
@@ -25,11 +25,11 @@ impl MyFirstTrait + MySecondTrait for MyStruct { //the RFC will allow this
 }
 ```
 
-The plus sign `+` is used as it holds consistent to the current syntax for multiple Traits used in bounds.
+The plus sign `+` is used as it holds consistent to the current syntax for multiple traits used in bounds.
 
 # Alternatives
 
-* Keeping the current syntax is not too bad, but this syntax would be quite helpful, and possibly make it more readable and understandable.
+* Keeping the current syntax is not too bad, but this syntax would be quite helpful, and possibly make code more readable and understandable.
 
 * Instead of a plus sign `+` a comma `,` could be used, for consistency with other languages. However keeping consistency with Rust is more beneficial than with other languages.
 


### PR DESCRIPTION
This pull request will allow the following syntax:

``` rust
impl MyFirstTrait + MySecondTrait for MyStruct { //the RFC will allow this 
    //... method impls here
}
```

As said in the [reddit thread](http://www.reddit.com/r/rust/comments/25hsft/potential_rfc_for_multiple_trait_implementations/), this RFC wold probably be a post 1.0 thing, but I wanted to get conversation started for this.

Also I would not be able to implement this, I would love to be able to, but the knowledge is not in my brain!

Any feedback? Would love to read more.
