### PR TITLE
RFC template: move "Drawbacks" section after "Detailed design"

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -10,15 +10,15 @@ One para explanation of the feature.
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
-# Drawbacks
-
-Why should we *not* do this?
-
 # Detailed design
 
 This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
 with the language to understand, and for somebody familiar with the compiler to implement.
 This should get into specifics and corner-cases, and include examples of how the feature is used.
+
+# Drawbacks
+
+Why should we *not* do this?
 
 # Alternatives
 


### PR DESCRIPTION
Having "Drawbacks" earlier in the document than "Detailed design" makes
it awkward to discuss drawbacks that reference details of the design.
This encourages authors to either violate causality by referencing
details before they are introduced or to neglect the "Drawbacks" section
entirely and just sprinkle the discussion of drawbacks throught
"Detailed design".
