### PR TITLE
RFC: Coercible and HasPrefix for Zero Cost Coercions

### DIFF
--- a/active/0000-zero-cost-coercions.md
+++ b/active/0000-zero-cost-coercions.md
@@ -58,7 +58,7 @@ fn coerce<U, T: Coercible<U>>(x: T) -> U { unsafe { transmute(x) } }
 
 The trait is wired-in to the compiler, and user-defined impls of it are highly restricted as
 described in the implementation section talking about roles. `coerce()` would coerce between
-any two types where the target type "is a proper subtype of" the input type. Note that `coerce`
+any two types where the target type "is a subtype of" the input type. Note that `coerce`
 is never a virtual call, as it is not a method of `Coercible`: `Coercible<T>` doesn't have a
 vtable, and is considered a built-in "kind" alongside `Copy`, `Send`, etc.
 
@@ -68,7 +68,7 @@ being implicit/automatic, `Coercible` captures and exposes only the thing which 
 the zero-cost conversions, and for a much wider range of scenarios.
 
 There would be another such wired-in trait called `HasPrefix`. `T: HasPrefix<U>` corresponds to `T`
-starts-with `U`, while `T: Coercible<U>` corresponds to `T` is-a-proper-subtype-of `U`.
+starts-with `U`, while `T: Coercible<U>` corresponds to `T` is-a-subtype-of `U`.
 
 ```rust
 trait HasPrefix<T> { }
@@ -146,7 +146,7 @@ impl<A, B: HasPrefix<A>, C: HasPrefix<B>> HasPrefix<A> for C { }
 impl<A, B: Coercible<A>, C: Coercible<B>> Coercible<A> for C { }
 ```
 
-Is-a-proper-subtype-of implies starts-with:
+Is-a-subtype-of implies starts-with:
 
 ```rust
 impl<A, B: Coercible<A>> HasPrefix<A> for B { }


### PR DESCRIPTION
This is largely based on (with lots of copied text) @glaebhoerl's proposal in mozilla/rust#9912, but with a few changes:
- I formalized the idea of "contexts" by using GHC's roles.
- I used this role system to include user-defined pointers and data structures.
- I dropped contravariance for simplicity. This may have been a bad idea, but it's unclear how useful contravariance is.

[rendered draft](https://github.com/rust-lang/rfcs/blob/87490dd413db62047748b869952a2edc033ee16c/active/0000-zero-cost-coercions.md)
