### PR TITLE
RFC: Remove cross-borrowing

### DIFF
--- a/active/0032-remove-cross-borrowing.md
+++ b/active/0032-remove-cross-borrowing.md
@@ -1,5 +1,5 @@
 - Start Date: 2014-06-09
-- RFC PR #: (leave this empty)
+- RFC PR #: 112
 - Rust Issue #: #10504
 
 # Summary


### PR DESCRIPTION
- Start Date: 2014-06-09
- RFC PR #: (leave this empty)
- Rust Issue #: #10504
# Summary

Remove the coercion from `Box<T>` to `&T`/`&mut T` from the language.
# Motivation

Currently, the coercion between `Box<T>` to `&mut T` can be a hazard because it can lead to surprising mutation where it was not expected. Furthermore, it is inconsistent with user-defined smart pointers because user-defined smart pointers cannot implicitly coerceto `&T` or `&mut T`.
# Detailed design

The coercion between `Box<T>` and `&T`/`&mut T` should be removed.

Note that methods that take `&self`/`&mut self` can still be called on values of type `Box<T>` without any special referencing or dereferencing. That is because the semantics of auto-deref and auto-ref conspire to make it work: the types unify after one autoderef followed by one autoref.
# Drawbacks

Borrowing from `Box<T>` to `&T`/`&mut T` may be convenient.
# Alternatives

An alternative is to apply the method autoderef/autoref rules to _all_ coercions in the language. This makes the mutability hazard more prevalent, however.

The impact of not doing this is that the coercion will remain.
# Unresolved questions

None.
