### PR TITLE
Revised UFCS proposal

### DIFF
--- a/active/0000-ufcs.md
+++ b/active/0000-ufcs.md
@@ -92,7 +92,7 @@ Note that there is a subtle distinction between the following paths:
     <ToStr>::to_str
     
 In the former, we are selecting the member `to_str` from the trait `ToStr`.
-The result is a function whose type is basically to_struivalent to:
+The result is a function whose type is basically equivalent to:
 
     fn to_str<Self:ToStr>(self: &Self) -> String
     


### PR DESCRIPTION
A proposal to add an unambiguous syntax for referring to methods and other associated items. An adapted version of the original proposal by @nick29581.

---

currently active: https://github.com/rust-lang/rfcs/blob/master/text/0132-ufcs.md
