### PR TITLE
Clarify that removing language features requires an RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ changes to the Rust distribution. What constitutes a "substantial"
 change is evolving based on community norms, but may include the following.
 
    - Any semantic or syntactic change to the language that is not a bugfix.
+   - Removing language features, including those that are feature-gated.
    - Changes to the interface between the compiler and libraries, 
 including lang items and intrinsics.
    - Additions to `std`

--- a/active/0001-rfc-process.md
+++ b/active/0001-rfc-process.md
@@ -34,6 +34,7 @@ changes to the Rust distribution. What constitutes a "substantial"
 change is evolving based on community norms, but may include the following.
 
    - Any semantic or syntactic change to the language that is not a bugfix.
+   - Removing language features, including those that are feature-gated.
    - Changes to the interface between the compiler and libraries,
 including lang items and intrinsics.
    - Additions to `std`


### PR DESCRIPTION
This is a small addition to RFC 1 stating that removing language features, even those behind a feature gate, requires an RFC.
