### PR TITLE
RFC: int/uint portability to 16-bit CPUs

### DIFF
--- a/active/0000-intindex.md
+++ b/active/0000-intindex.md
@@ -2,6 +2,11 @@
 - RFC PR #: (leave this empty)
 - Rust Issue #: (leave this empty)
 
+# Replacement
+
+## I propose to withdraw this RFC in favor of the single-purpose [RFC: Renaming int/uint (PR #464)](https://github.com/rust-lang/rfcs/pull/464).
+
+
 # Summary
 
 Either rename the types `int` and `uint` to `index` and `uindex` to avoid


### PR DESCRIPTION
Both Issue #14758 and Issue #9940 call for RFCs.

This RFC summarizes those discussions, explains the core issue of
code portability to 16-bit CPUs (also of 64-bit code to 32-bit CPUs),
explains what's meant by "default" integer types, makes 2 specific
proposals, and proposes coding style for integer sizing.
