### PR TITLE
Clarify definition of "input positions" in lifetime elision RFC.

### DIFF
--- a/active/0039-lifetime-elision.md
+++ b/active/0039-lifetime-elision.md
@@ -100,8 +100,7 @@ Lifetime positions can appear as either "input" or "output":
   input position and two lifetimes in output position.
   Note that the input positions of a `fn` method definition do not
   include the lifetimes that occur in the method's `impl` header
-  `impl` (nor lifetimes that occur in the trait header, for a default
-  method).
+  (nor lifetimes that occur in the trait header, for a default method).
 
 
 * For `impl` headers, input refers to the lifetimes appears in the type
@@ -188,13 +187,6 @@ impl<'a> Bar<'a> for &'a str { fn fresh<'b>(&'b self) -> &'b int { ... } } // ex
 
 impl Bar for &str {
   fn bound(&'a self) -> &'a int { ... } fn fresh(&self) -> &int { ... }    // ILLEGAL: unbound 'a
-}
-
-impl<'a> Bar<'a> for &'a str {
-  fn bound(&'a self) -> &'a int { ... } fn fresh(&self) -> &int { ... }              // elided
-}
-impl<'a> Bar<'a> for &'a str {
-  fn bound(&'a self) -> &'a int { ... } fn fresh<'b>(&'b self) -> &'b int { ... }    // expanded
 }
 
 ```


### PR DESCRIPTION
Explicitly note that lifetimes from the `impl` (and `trait`/`struct`) are not considered "input positions" for the purposes of expanded `fn` definitions.

Added a collection of examples illustrating this.

Drive-by: Addressed a review comment from @chris-morgan [here](https://github.com/rust-lang/rfcs/pull/141#discussion_r14227369).

Fix #165.
