### PR TITLE
Convenience syntax for module imports (was #108)

### DIFF
--- a/0000-mod.md
+++ b/0000-mod.md
@@ -1,0 +1,59 @@
+- Start Date: 2014-06-06
+- RFC PR #: (leave this empty)
+- Rust Issue #: (leave this empty)
+- Author: Tommit (edited by nrc)
+
+
+# Summary
+
+Add syntax sugar for importing a module and items in that module in a single
+view item.
+
+
+# Motivation
+
+Make use clauses more concise.
+
+
+# Detailed design
+
+The `mod` keyword may be used in a braced list of modules in a `use` item to
+mean the prefix module for  that list. For example, writing `prefix::{mod,
+foo};` is equivalent to writing
+
+```
+use prefix;
+use prefix::foo;
+```
+
+The `mod` keyword cannot be used outside of braces, nor can it be used inside
+braces which do not have a prefix path. Both of the following examples are
+illegal:
+
+```
+use module::mod;
+use {mod, foo};
+```
+
+A programmer may write `mod` in a module list with only a single item. E.g.,
+`use prefix::{mod};`, although this is considered poor style and may be forbidden
+by a lint. (The preferred version is `use prefix;`).
+
+
+# Drawbacks
+
+Another use of the `mod` keyword.
+
+We introduce a way (the only way) to have paths in use items which do not
+correspond with paths which can be used in the program. For example, with `use
+foo::bar::{mod, baz};` the programmer can use `foo::bar::baz` in their program
+but not `foo::bar::mod` (instead `foo::bar` is imported).
+
+# Alternatives
+
+Don't do this.
+
+
+# Unresolved questions
+
+N/A


### PR DESCRIPTION
Use the `mod` keyword in a module list to make the use section more concise.

Originally submitted as RFC PR #108 by @Tommit.
