### PR TITLE
Change type deduction rules to allow integer literals to be deduced as floats.

### DIFF
--- a/active/0000-make-integer-literals-coerce-to-floats.md
+++ b/active/0000-make-integer-literals-coerce-to-floats.md
@@ -8,13 +8,17 @@ Currently, numeric literals like "1" can become either signed or unsigned intege
 
 # Motivation
 
-Having unnecessary type annotations adds noise to code and makes it harder to follow. Rust's type deduction mechanism greatly reduces the number of type annotations needed for a program, but there are still some spots where it misses.
+Having unnecessary type annotations adds noise to code and makes it harder to follow. Rust's type deduction mechanism greatly reduces the number of type annotations needed for a program, but there are still some spots where it is overly conservative.
 
 # Detailed design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
-with the language to understand, and for somebody familiar with the compiler to implement.
-This should get into specifics and corner-cases, and include examples of how the feature is used.
+In the current compiler, any integer literal without specific type annotation is deduced to have type "generic integer", which is then narrowed as required by its interaction with parts of the program that do have their types defined, such as function parameters and variables that do have explicit types. It can be deduced to be any of `i8, i16, i32, i64, int, u8, u16, u32, u64, uint`.
+
+This RFC propses adding `f32` and `f64` to that list. The "generic integer" will be renamed "generic number", and it will have its type determined by the rest of its interactions, as it is now. The difference is that when an operation like `+ 3.0` or `cos` is applied to it, its type will be narrowed to "generic float" instead of having the compiler give an error.
+
+The compiler will still warn when a literal is assigned to a type that cannot exactly represent that value, the same way that it does on `let x: u8 = 256;`.
+
+This RFC does not propose allowing generic floats to coerce into integers. Adding the decimal point is an explicit annotation that the number is not intended to be integral.
 
 # Drawbacks
 
@@ -28,6 +32,6 @@ Leaving it as it is.
 
 # Unresolved questions
 
-Should a literal still be coerced if it's too big for any float to exactly equal it?
+Should a literal still be coerced without warning if it's too big for any float to exactly equal it? For example, `2^60 + 1` cannot be exactly represented as a `f32` or `f64`, but unlike `1000u8` it does have a very close approximation.
 
-Should a literal that is very large be coerced if it does happen to have an exact float representation? 
+Should a literal that is very large be coerced without warning if it does happen to have an exact float representation? For example, `2^60` does have an exact `f32` representation, but `2^60 + 1` and `2^60 - 1` do not.


### PR DESCRIPTION
This is an issue that came up in IRC today. It seemed strange to me that a program like `let num: f32 = 1;` wouldn't pass the type checking rules while `let num = 1f32;` does, so I'm proposing this change to make it work.
