### PR TITLE
RFC: error interoperation

### DIFF
--- a/active/0000-error-chaining.md
+++ b/active/0000-error-chaining.md
@@ -152,7 +152,7 @@ The standard `Error` trait follows very the widespread pattern found
 in `Exception` base classes in many languages:
 
 ```rust
-pub trait Error {
+pub trait Error: Send + Any {
     fn description(&self) -> &str;
 
     fn detail(&self) -> Option<&str> { None }


### PR DESCRIPTION
This RFC improves interoperation between APIs with different error
types. It proposes to:
- Increase the flexibility of the `try!` macro for clients of multiple
  libraries with disparate error types.
- Standardize on basic functionality that any error type should have
  by introducing an `Error` trait.
- Support easy error chaining when crossing abstraction boundaries.

The proposed changes are all library changes; no language changes are
needed -- except that this proposal depends on
[multidispatch](https://github.com/rust-lang/rfcs/pull/195) happening.

[Rendered](https://github.com/aturon/rfcs/blob/error-chaining/active/0000-error-chaining.md)
