### PR TITLE
RFC: Change syntax of subslice matching

### DIFF
--- a/active/0000-subslice-syntax-change.md
+++ b/active/0000-subslice-syntax-change.md
@@ -41,6 +41,11 @@ grammar syntax as in Rust manual):
     slice_pattern : "[" [[pattern | subslice_pattern] ","]* "]" ;
     subslice_pattern : ["mut"? ident]? ".." ["@" slice_pattern]? ;
 
+To compare, currently it looks like:
+
+    slice_pattern : "[" [[pattern | subslice_pattern] ","]* "]" ;
+    subslice_pattern : ".." ["mut"? ident ["@" slice_pattern]?]? ;
+
 # Drawbacks
 
 Backward incompatible.


### PR DESCRIPTION
Change syntax of subslices matching from `..xs` to `xs..` to be more consistent with the rest of the language and allow future backwards compatible improvements.

[Rendered](https://github.com/krdln/rfcs/blob/slicematching-dots/active/0000-subslice-syntax-change.md)
