### PR TITLE
RFC: Remove runtime system, and move libgreen into an external library

### DIFF
--- a/active/0000-remove-runtime.md
+++ b/active/0000-remove-runtime.md
@@ -132,7 +132,8 @@ several problems in practice.
   style of lightweight tasks is used in Servo, but also shows up in
   [java.util.concurrent's exectors](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html)
   and [Haskell's par monad](https://hackage.haskell.org/package/monad-par),
-  among many others.
+  among many others. These lighter weight models do not fit into the current
+  runtime system.
 
   On the other hand, green threading systems designed explicitly to support I/O
   may also want to provide low-level access to the underlying event loop -- an


### PR DESCRIPTION
This RFC proposes to remove the _runtime system_ that is currently part of the
standard library, which currently allows the standard library to support both
native and green threading. In particular:
- The `libgreen` crate and associated support will be moved out of tree, into a
  separate Cargo package.
- The `librustrt` (the runtime) crate will be removed entirely.
- The `std::io` implementation will be directly welded to native threads and
  system calls.
- The `std::io` module will remain completely cross-platform, though _separate_
  platform-specific modules may be added at a later time.

[Rendered](https://github.com/aturon/rfcs/blob/remove-runtime/active/0000-remove-runtime.md)

This is a follow-up to [an earlier RFC](https://github.com/rust-lang/rfcs/pull/219).
