### PR TITLE
RFC: conventions for placement of unsafe APIs

### DIFF
--- a/active/0000-unsafe-api-location.md
+++ b/active/0000-unsafe-api-location.md
@@ -140,6 +140,11 @@ There are a few alternatives:
   some_string.slice_unchecked(start, end)
   ```
 
+* Another suggestion by @kballard is to keep the basic structure of `raw`
+  submodules, but use associated types to improve the ergonomics. Details (and
+  discussions of pros/cons) are in
+  [this comment](https://github.com/rust-lang/rfcs/pull/240/files#r17572875).
+
 * Use `raw` submodules to group together *all* manipulation of low-level
   representations. No module in `std` currently does this; existing modules
   provide some free functions in `raw`, and some unsafe methods, without a clear


### PR DESCRIPTION
This is a _conventions RFC_ for settling the location of `unsafe` APIs relative
to the types they work with, as well as the use of `raw` submodules.

The brief summary is:
- Unsafe APIs should be made into methods or static functions in the same cases
  that safe APIs would be.
- `raw` submodules should be used only to provide APIs directly on low-level
  representations.

[Rendered](https://github.com/aturon/rfcs/blob/unsafe-api-location/active/0000-unsafe-api-location.md)
