### PR TITLE
Allocator RFC, take II

### DIFF
--- a/active/0000-allocator.md
+++ b/active/0000-allocator.md
@@ -1126,7 +1126,7 @@ either one or the other, and thus it makes sense for such libraries to
 specify which, to make it easier for library clients to feed in their
 own instrumented versions of the allocators.
 
-For example, if one interested in instrumenting containers to learn
+For example, if one is interested in instrumenting containers to learn
 how well their internal resizing policy is working (with respect to
 number of invocations and amount of fragmentation being introduced),
 then one just implements an `ArrayAlloc` wrapper.  (Perhaps more


### PR DESCRIPTION
[(rendered)](https://github.com/pnkfelix/rfcs/blob/fsk-allocator-rfc/active/0000-allocator.md)
# Summary

Add a standard allocator interface and support for user-defined allocators, with the following goals:
1. Allow libraries to be generic with respect to the allocator, so that users can supply their own memory allocator and still make use of library types like `Vec` or `HashMap` (assuming that the library types are updated to be parameterized over their allocator).
   
   In particular, stateful per-container allocators are supported.
2. Support ability of garbage-collector (GC) to identify roots stored in statically-typed user-allocated objects outside the GC-heap, without sacrificing efficiency for code that does not use `Gc<T>`.
3. Do not require an allocator itself to extract metadata (such as the size of an allocation) from the initial address of the allocated block; instead, force the client to supply size at the deallocation site.
   
   In other words, do not provide a `free(ptr)`-based API. (This can improve overall performance on certain hot paths.)
4. Incorporate data alignment constraints into the API, as many allocators have efficient support for meeting such constraints built-in, rather than forcing the client to build their own re-aligning wrapper around a `malloc`-style interface.
