### PR TITLE
Add limited CTFE

### DIFF
--- a/active/0000-limited-ctfe.md
+++ b/active/0000-limited-ctfe.md
@@ -204,7 +204,8 @@ take arbitrary expressions as arguments, e.g., `sizeof(1L) == sizeof(long)`.
 Rust also has a function that can do this: `size_of_val<T>(val: T)` which then
 calls `size_of::<T>()`. Unfortunately `size_of_val` is a real function and not
 a `extern "rust-intrinsic"`. Thus you cannot use it in programs that wish to
-avoid `libcore`. Note that this would not be a problem with the two
-alternatives above.
+avoid `libcore`. How could this be done? Note that this would not be a problem with
+the two alternatives above.
 - There are many more intrinsic (math) functions which could be evaluated at
-compile time.
+compile time. Should these functions be allowed in constant expressions? Note that
+this is not possible with the two alternatives above.


### PR DESCRIPTION
Implement compile time evaluation of a limited set of compiler-internal functions:
- `size_of`
- `min_align_of`
- `pref_align_of`

[Rendered](https://github.com/rust-lang/rfcs/blob/ae649dada8f4f15ad2d9ae9a62e10119cdb4c5ec/active/0000-limited-ctfe.md)

[Old rendered link (not working)](https://github.com/mahkoh/rfcs/blob/ctfe/active/0000-limited-ctfe.md)

EDIT: Fixed rendered link / Centril