### PR TITLE
auto-tupling and auto-unit'ing for variable arity fns

### DIFF
--- a/active/0000-auto-tupling-at-call-sites.md
+++ b/active/0000-auto-tupling-at-call-sites.md
@@ -435,5 +435,3 @@ in the latter scenario?  Would it rewrite to:
 <Baz as Foo>::bar(1u8, '2', (), (), ());
 ```
 or would it be flagged as an error by the compiler?
-
-None yet.


### PR DESCRIPTION
### Summary

Add support for default and variable-arity functions via a small language feature and a simple programming pattern.  The language feature is solely a pair of changes to the treatment of function call-sites:
- If there are excess arguments at a given call site, then automatically turn convert excess arguments into a tuple of the final argument and the excess arguments.  I call this "auto-tupling."
- If there are insufficient arguments at a given call site, then automatically replace each of the omitted arguments with the unit value `()`.  I call this "auto-unit'ing."

The above two transformations can be used in tandem with the trait system as a way to express optional parameters and multiple-arity functions.

[(rendered)](https://github.com/pnkfelix/rfcs/blob/fsk-auto-tupling/active/0000-auto-tupling-at-call-sites.md)
