### PR TITLE
Reserve `abstract`, `final`, and `override` as possible keywords.

### DIFF
--- a/0000-keywords.md
+++ b/0000-keywords.md
@@ -1,0 +1,35 @@
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+Reserve `abstract`, `final`, and `override` as possible keywords.
+
+# Motivation
+
+We intend to add some mechanism to Rust to support more efficient inheritance
+(see, e.g., RFC PRs #245 and #250, and this
+[thread](http://discuss.rust-lang.org/t/summary-of-efficient-inheritance-rfcs/494/43)
+on discuss). Although we have not decided how to do this, we do know that we
+will. Any implementation is likely to make use of keywords `virtual` (already
+used, to remain reserved), `abstract`, `final`, and `override`, so it makes
+sense to reserve these now to make the eventual implementation as backwards
+compatible as possible.
+
+# Detailed design
+
+Make `abstract`, `final`, and `override` reserved keywords.
+
+# Drawbacks
+
+Takes a few more words out of the possible vocabulary of Rust programmers.
+
+# Alternatives
+
+Don't do this and deal with it when we have an implementation. This would mean
+bumping the language version, probably.
+
+# Unresolved questions
+
+N/A


### PR DESCRIPTION
[Just like it says in the title](https://github.com/nick29581/rfcs/compare/rust-lang:master...nick29581:keywords?expand=1&name=keywords&short_path=aa61e4f#diff-aa61e4fc5538090e1fb39293295e7eb3)
