### PR TITLE
RFC: Resolve numerous naming conventions

### DIFF
--- a/active/0000-conventions-galore.md
+++ b/active/0000-conventions-galore.md
@@ -201,7 +201,7 @@ method that is the dominant functionality of the trait, consider using the same
 name for the trait itself. This is already the case for `Clone` and `ToCStr`,
 for example.
 
-According to these rules, `Encodable` should be `Encode`.
+According to these rules, `Encodable` should probably be `Encode`.
 
 There are some open questions about these rules; see Unresolved Questions below.
 
@@ -212,18 +212,27 @@ Our lint names are
 seem like a minor concern, when we hit 1.0 the lint names will be locked down,
 so it's worth trying to clean them up now.
 
-This RFC proposes that:
+The basic rule is: the lint name should make sense when read as "allow
+*lint-name*" or "allow *lint-name* items". For example, "allow
+`deprecated` items" and "allow `dead_code`" makes sense, while "allow
+`unsafe_block`" is ungrammatical (should be plural).
 
-* Lint names should state the bad thing being checked for, e.g. `deprecated`,
-  so that `#[allow(deprecated)]` reads correctly.
+Specifically, this RFC proposes that:
+
+* Lint names should state the bad thing being checked for,
+  e.g. `deprecated`, so that `#[allow(deprecated)]` (items) reads
+  correctly. Thus `ctypes` is not an appropriate name; `improper_ctypes` is.
 
 * Lints that apply to arbitrary items (like the stability lints) should just
   mention what they check for: use `deprecated` rather than `deprecated_items`.
-  This keeps lint names short.
+  This keeps lint names short. (Again, think "allow *lint-name* items".)
 
 * If a lint applies to a specific grammatical class, mention that class and use
   the plural form: use `unused_variables` rather than `unused_variable`.
   This makes `#[allow(unused_variables)]` read correctly.
+
+* Lints that catch unnecessary, unused, or useless aspects of code
+  should use the term `unused`, e.g. `unused_imports`, `unused_typecasts`.
 
 * Use snake case in the same way you would for function names.
 


### PR DESCRIPTION
This is a conventions RFC for settling a number of remaining naming conventions:
- Referring to types in method names
- Iterator type names
- Additional iterator method names
- Getter/setter APIs
- Associated types
- Trait naming
- Lint naming
- Suffix ordering
- Prelude traits

It also proposes to standardize on lower case error messages within the compiler
and standard library.

[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md)
