### PR TITLE
Raw pointer coercion

### DIFF
--- a/active/0000-raw-pointer-coercion.md
+++ b/active/0000-raw-pointer-coercion.md
@@ -32,7 +32,7 @@ impl TWrapper {
         unsafe { non_mutating_operation(self.raw as *const T); }
     }
 
-    fn mutating_operation(&self) {
+    fn mutating_operation(&mut self) {
         unsafe { mutating_operation(self.raw); }
     }
 }


### PR DESCRIPTION
`*mut T` and `&mut T` should coerce to `*const T`.

[Rendered](https://github.com/mahkoh/rfcs/blob/raw_coerce/active/0000-raw-pointer-coercion.md)
