### PR TITLE
RFC: numerics reform

### DIFF
--- a/active/0000-num-reform.md
+++ b/active/0000-num-reform.md
@@ -378,6 +378,12 @@ working with C-like enums. However, such a replacement is outside of
 the scope of this RFC, so these traits are left (as `#[experimental]`)
 for now. A follow-up RFC proposing a better solution should appear soon.
 
+In the meantime, see
+[this proposal](https://github.com/rust-lang/rust/issues/10418) and
+the discussion on
+[this issue](https://github.com/rust-lang/rust/issues/10272) about
+`Ordinal` for the rough direction forward.
+
 # Drawbacks
 
 This RFC somewhat reduces the potential for writing generic numeric
@@ -419,4 +425,8 @@ allowing removal of more traits but a less clear-cut semantics.
 
 This RFC does not propose a replacement for
 `#[deriving(FromPrimitive)]`, leaving the relevant traits in limbo
-status.
+status. (See
+[this proposal](https://github.com/rust-lang/rust/issues/10418) and
+the discussion on
+[this issue](https://github.com/rust-lang/rust/issues/10272) about
+`Ordinal` for the rough direction forward.)


### PR DESCRIPTION
This RFC is preparation for API stabilization for the `std::num` module.  The goal is to finish the simplification efforts started in [@bjz's reversal of the numerics hierarcy](https://github.com/rust-lang/rust/issues/10387).

Broadly, the proposal is to collapse the remaining numeric hierarchy in `std::num`, and to provide only limited support for generic programming (roughly, only over primitive numeric types that vary based on size).  Traits giving detailed numeric hierarchy can and should be provided separately through the Cargo ecosystem.

Thus, this RFC proposes to flatten or remove most of the traits currently provided by `std::num`, and generally to simplify the module as much as possible in preparation for API stabilization.

[Rendered](https://github.com/aturon/rfcs/blob/num-reform/active/0000-num-reform.md)
