### PR TITLE
Always parse macro invocations with () or [] as expressions

### DIFF
--- a/text/0000-expr-macros.md
+++ b/text/0000-expr-macros.md
@@ -1,3 +1,7 @@
+- Start Date: 2014-10-09
+- RFC PR #: (leave this empty)
+- Rust Issue #: (leave this empty)
+
 Summary
 =======
 


### PR DESCRIPTION
Parse macro invocations with parentheses or square brackets as expressions no matter the context, and require curly braces or a semicolon following the invocation to invoke a macro as a statement.

Resolves #364.

I think #208 also does this as a by-product of resolving another ambiguity with attributes.

---

Status: Active
RFC document: https://github.com/rust-lang/rfcs/blob/master/text/0378-expr-macros.md
