### PR TITLE
Unify attributes and macros to use `@` sigil, redux

### DIFF
--- a/active/0000-macro-attribute-syntax.md
+++ b/active/0000-macro-attribute-syntax.md
@@ -373,8 +373,7 @@ where attributes and macros may appear.
   only expressions that begin with a keyword would permit attributes.
   (Due to ambiguities around `@attr[]`.)
 
-The author is of the opinion that we ought to be stricter in both
-cases.
+The author is vaguely of the opinion that we ought to be stricter.
 
 [PR]: https://github.com/pcwalton/rfcs/blob/unify-attributes-and-macros/active/0000-unify-attributes-and-macros.md
 [3740]: https://github.com/rust-lang/rust/issues/3740


### PR DESCRIPTION
A revised version of @pcwalton's RFC, incorporating a more precise description of conflicts and a description of feedback.

[Rendered view.](https://github.com/nikomatsakis/rfcs/blob/macros-and-attrs/active/0000-macro-attribute-syntax.md)
