### PR TITLE
Higher-ranked trait bounds

### DIFF
--- a/active/0000-higher-ranked-trait-bounds.md
+++ b/active/0000-higher-ranked-trait-bounds.md
@@ -245,6 +245,12 @@ referred to
 [Simon Peyton-Jones rather thorough but quite readable paper on the topic][spj]
 or the documentation in
 `src/librustc/middle/typeck/infer/region_inference/doc.rs`.
+
+The most important point is that the rules provide for subtyping that
+goes from "more general" to "less general". For example, if I have a
+trait reference like `for<'a> FnMut(&'a int)`, that would be usable
+wherever a trait reference with a concrete lifetime, like
+`FnMut(&'static int)`, is expected.
    
 [spj]: http://research.microsoft.com/en-us/um/people/simonpj/papers/higher-rank/
 


### PR DESCRIPTION
A description of higher-ranked trait bounds, which is the remaining piece needed to make unboxed closures equal to normal closures.

[Rendered view.](https://github.com/rust-lang/rfcs/blob/master/text/0387-higher-ranked-trait-bounds.md)
