### PR TITLE
RFC: Overhaul Cargo's build command support

### DIFF
--- a/text/0000-cargo-build-command.md
+++ b/text/0000-cargo-build-command.md
@@ -160,7 +160,7 @@ If conflicts arise from having multiple packages in a dependency graph linking
 to the same C library, the C dependency should be refactored into a common
 Cargo-packaged dependency.
 
-It is illegal to define `link` without also defining `build`.
+It is illegal to define `links` without also defining `build`.
 
 ## Platform-specific dependencies
 
@@ -179,7 +179,7 @@ git = "https://github.com/user/crypt32-rs"
 path = "winhttp"
 ```
 
-Here the top-level configuration key `platform` will be a table whose sub-keys
+Here the top-level configuration key `target` will be a table whose sub-keys
 are target triples. The dependencies section underneath is the same as the
 top-level dependencies section in terms of functionality.
 
@@ -327,7 +327,7 @@ cargo:include=/path/to/foo/include
 ```
 
 Each line that begins with `cargo:` is interpreted as a line of metadata for
-Cargo to store. The remainig part of the line is of the form `key=value` (like
+Cargo to store. The remaining part of the line is of the form `key=value` (like
 environment variables).
 
 This output is similar to the pre-built libraries section above in that most


### PR DESCRIPTION
This RFC is targeted at overhauling the `build` command in Cargo manifests to be
more robust and fully functional for building and linking native code. While
largely targeted at Cargo, this RFC includes a few minor changes to the compiler
itself, hence posting this RFC in this repository.

The high level summary of this RFC is:
1. Instead of having the `build` command be some form of script, it will be a
   rust command instead
2. Establish a namespace of `foo-sys` packages which represent the native
   library `foo`. These packages will have Cargo-based dependencies between
   `*-sys` packages to express dependencies among C packages themselves.
3. Establish a set of standard environment variables for build commands which
   will instruct how `foo-sys` packages should be built in terms of dynamic or
   static linkage, as well as providing the ability to override where a package
   comes from via environment variables.

[Rendered](https://github.com/alexcrichton/rfcs/blob/cargo-linkage/text/0000-cargo-build-command.md)
