### PR TITLE
Fix oversight in README.md; the `active/` directory no longer exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ is 'active' and may be implemented with the goal of eventual inclusion
 into Rust.
 
 * Fork the RFC repo http://github.com/rust-lang/rfcs
-* Copy `0000-template.md` to `active/0000-my-feature.md` (where
+* Copy `0000-template.md` to `text/0000-my-feature.md` (where
 'my-feature' is descriptive. don't assign an RFC number yet).
 * Fill in the RFC
 * Submit a pull request. The pull request is the time to get review of


### PR DESCRIPTION
Fix oversight in README.md; the `active/` directory no longer exists.
