### PR TITLE
Change precedence of `+` in type grammar

### DIFF
--- a/text/0000-precedence-of-plus.md
+++ b/text/0000-precedence-of-plus.md
@@ -65,9 +65,9 @@ More fully, the type grammar is as follows (EBNF notation):
          | ...
          | '(' SUM ')'
     SUM  = TYPE { '+' TYPE }
-    PATH = IDS '<' SUM { ',' SUM } '>' '->' TYPE
-         | IDS '(' SUM { ',' SUM } '>' '->' TYPE
-    IDS  = ID { :: ID }
+    PATH = IDS '<' SUM { ',' SUM } '>'
+         | IDS '(' SUM { ',' SUM } ')' '->' TYPE
+    IDS  = ['::'] ID { '::' ID }
 
 Where clauses would use the following grammar:
 


### PR DESCRIPTION
Update type grammar to make `+` have lower precedence, consistent with the expression grammar, resolving a grammatical ambiguity.

Summary of impact (non-normative, from the RFC):

``` rust
// Before                             After                         Note
// ~~~~~~                             ~~~~~                         ~~~~
   &Object+Send                       &(Object+Send)
   &'a Object+'a                      &'a (Object+'a)
   Box<Object+Send>                   Box<Object+Send>
   foo::<Object+Send,int>(...)        foo::<Object+Send,int>(...)
   Fn() -> Object+Send                Fn() -> (Object+Send)         // (*)
   Fn() -> &Object+Send               Fn() -> &(Object+Send)

// (*) Must yield a type error
```

[Rendered view](https://github.com/nikomatsakis/rfcs/blob/precedence-of-plus/text/0000-precedence-of-plus.md)
