### PR TITLE
RFC: cmp and ops reform

### DIFF
--- a/text/0000-cmp-ops-reform.md
+++ b/text/0000-cmp-ops-reform.md
@@ -5,7 +5,7 @@
 # Summary
 
 This RFC proposes a number of design improvements to the `cmp` and
-`ord` modules in preparation for 1.0. The impetus for these
+`ops` modules in preparation for 1.0. The impetus for these
 improvements, besides the need for stabilization, is that we've added
 several important language features (like multidispatch) that greatly
 impact the design. Highlights:
@@ -317,7 +317,8 @@ pub trait IndexSet<Idx> {
 }
 ```
 
-(This idea is borrowed from [@sfackler's earlier RFC](https://github.com/rust-lang/rfcs/pull/159/files).)
+(This idea is borrowed from
+[@sfackler's earlier RFC](https://github.com/rust-lang/rfcs/pull/159/files).)
 
 The motivation for this trait is cases like `map["key"] = val`, which
 should correspond to an *insertion* rather than a mutable lookup. With


### PR DESCRIPTION
This RFC proposes a number of design improvements to the `cmp` and
`ops` modules in preparation for 1.0. The impetus for these
improvements, besides the need for stabilization, is that we've added
several important language features (like multidispatch) that greatly
impact the design. Highlights:
- Make basic unary and binary operators work by value and use associated types.
- Generalize comparison operators to work across different types; drop `Equiv`.
- Refactor slice notation in favor of _range notation_ so that special
  traits are no longer needed.
- Add `IndexSet` to better support maps.
- Clarify ownership semantics throughout.

[Rendered](https://github.com/aturon/rfcs/blob/cmp-ops-reform/text/0000-cmp-ops-reform.md)
