### PR TITLE
RFC: ES6-style unicode string escaping.

### DIFF
--- a/text/0000-es6-unicode-escapes.md
+++ b/text/0000-es6-unicode-escapes.md
@@ -46,8 +46,15 @@ The behavior would otherwise be identical.
 
 # Drawbacks
 
-This is a breaking change and updating code for it manually is annoying.
-It is however very mechanical, and we could provide scripts to automate it.
+* This is a breaking change and updating code for it manually is annoying.
+  It is however very mechanical, and we could provide scripts to automate it.
+* Formatting templates already use curly braces.
+  Having multiple curly braces pairs in the same strings that have a very
+  different meaning can be surprising:
+  `format!("\u{e8}_{e8}", e8 = "é")` would be `"è_é"`.
+  However, there is a precedent of overriding characters:
+  `\` can start an escape sequence both in the Rust lexer for strings
+  and in regular expressions.
 
 
 # Alternatives


### PR DESCRIPTION
[Rendered](https://github.com/SimonSapin/rfcs/blob/es6-unicode-escapes/text/0000-es6-unicode-escapes.md).

Remove \u203D and \U0001F4A9 unicode string escapes, and add ECMAScript 6-style \u{1F4A9} escapes instead.

Text: https://github.com/rust-lang/rfcs/blob/master/text/0446-es6-unicode-escapes.md
RFC PR: rust-lang/rfcs#446
