### PR TITLE
Prohibit unused type parameters in impls.

### DIFF
--- a/text/0000-no-unused-impl-parameters.md
+++ b/text/0000-no-unused-impl-parameters.md
@@ -1,0 +1,118 @@
+- Start Date: 2014-11-06
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+Disallow impls from having type parameters that do not appear in
+either the trait reference or the self type of the impl.
+
+# Motivation
+
+Today it is legal to have impls with type parameters that are
+effectively unconstrainted. This RFC proses to make these illegal by
+requiring that all impl type parameters must appear in either the self
+type of the impl or, if the impl is a trait impl, an (input) type
+parameter of the trait reference.
+
+There are many reasons to make this change. First, impls are not
+explicitly instantiated or named, so there is no way for users to
+manually specify the values of type variables; the values must be
+inferred. If the type parameters do not appear in the trait reference
+or self type, however, there is no basis on which to infer them; this
+almost always yields an error in any case (unresolved type variable),
+though there are some corner cases where the inferencer can find a
+constraint.
+
+Second, permitting unconstrained type parameters to appear on impls
+can potentially lead to ill-defined semantics later on. The current
+way that the language works for cross-crate inlining is that the body
+of the method is effectively reproduced within the target crate, but
+in a fully elaborated form where it is as if the user specified every
+type explicitly that they possibly could. This should be sufficient to
+reproduce the same trait selections, even if the crate adds additional
+types and additional impls -- but this cannot be guaranteed if there
+are free-floating type parameters on impls, since their values are not
+written anywhere. (This semantics, incidentally, is not only
+convenient, but also required if we wish to allow for specialization
+as a possibility later on.)
+
+Finally, there is little to no loss of expressiveness. The type
+parameters in question can always be moved somewhere else.
+
+Here are some examples to clarify what's allowed and disallowed. In
+each case, we also clarify how the example can be rewritten to be
+legal.
+
+```rust
+// Legal:
+// - A is used in the self type.
+// - B is used in the input trait type parameters.
+impl<A,B> SomeTrait<Option<B>> for Foo<A> {
+    type Output = Result<A, IoError>;
+}
+
+// Legal:
+// - A and B are used in the self type
+impl<A,B> Vec<(A,B)> {
+    ...
+}
+
+// Illegal:
+// - A does not appear in the self type nor trait type parameters.
+//
+// This sort of pattern can generally be written by making `Bar` carry
+// `A` as a phantom type parameter, or by making `Elem` an input type
+// of `Foo`.
+impl<A> Foo for Bar {
+    type Elem = A; // associated types do not count
+    ...
+}
+
+// Illegal: B does not appear in the self type.
+//
+// Note that B could be moved to the method `get()` with no
+// loss of expressiveness.
+impl<A,B:Default> Foo<A> {
+    fn do_something(&self) {
+    }
+    
+    fn get(&self) -> B {
+        B::Default
+    }
+}
+```
+
+# Detailed design
+
+Require that every impl type parameter appears textually within the
+input type parameters of the trait reference or the impl self
+type. Even if we introduce variance in the future, this is sufficient
+to ensure that the type parameter is constrained modulo lifetimes;
+lifetimes are not taken into account when selecting traits.
+
+# Drawbacks
+
+This pattern requires a non-local rewrite to reproduce:
+
+```
+impl<A> Foo for Bar {
+    type Elem = A; // associated types do not count
+    ...
+}
+```
+
+# Alternatives
+
+To make these type parameters well-defined, we could also create a
+syntax for specifying impl type parameter instantiations and/or have
+the compiler track the full tree of impl type parameter instantiations
+at type-checking time and supply this to the translation phase. This
+approach rules out the possibility of impl specialization.
+
+# Unresolved questions
+
+I am not 100% certain whether it is safe to permit impl type
+parameters that only appear in associated types of impls. I am working
+through this in the meantime, but for now it seems safer to simply be
+restrictive.


### PR DESCRIPTION
For well-defined semantics, we must ensure that impls do not have type parameters that do not appear within the trait or self-type.

[Rendered view.](https://github.com/nikomatsakis/rfcs/blob/unused-impl-parameters/text/0000-no-unused-impl-parameters.md)