### PR TITLE
RFC: Added "Debug Info"

### DIFF
--- a/text/0000-debug-info.md
+++ b/text/0000-debug-info.md
@@ -60,7 +60,7 @@ for the `DebugLocationMarker` are `Copy`, `Eq` and `PartialEq`.
 
 ## The Debug Info
 
-the `inspect_debug_location` function returns a `DebugInfo` object that has as much
+The `inspect_debug_location` function returns a `DebugInfo` object that has as much
 debug information as available for the given location:
 
 ```rust


### PR DESCRIPTION
Because of the discussion in #466 I am proposing a more efficient way to freeze and inspect debug information.  This would allow an implementation to just keep track of the instruction pointer and later using `DWARF` information (or other) to locate the debug info.

[Rendered View](https://github.com/mitsuhiko/rfcs/blob/debug-info/text/0000-debug-info.md)
