### PR TITLE
Make brackets optional for single attributes

### DIFF
--- a/text/0000-attributes-optional-brackets.md
+++ b/text/0000-attributes-optional-brackets.md
@@ -1,0 +1,39 @@
+- Start Date: 2014-11-26
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+
+# Summary
+
+Make brackets in attributes optional for single attributes using the `#attr` or `#attr(arg)` syntax. They remain mandatory for attributes using the assignment `#[attr = arg]` syntax, and may also be used to specify multiple attributes at once: `#[attr1, attr2, attr3]`, as today, although this is equivalent to `#attr1 #attr2 #attr3`, which may be preferred in practice.
+
+This is fully backwards compatible: all existing syntax remains legal, with the same meaning.
+
+
+# Motivation
+
+The brackets are visual clutter, syntactic noise, and serve no real purpose.
+
+`#attribute` looks like a hashtag, and is a good mnemonic for metadata, which attributes and hashtags both are.
+
+Note that this is purely an incremental change, and does *not* preclude subsequent further changes (such as removing the `=` form entirely, should we want to).
+
+
+# Detailed design
+
+Refer to *Summary*.
+
+
+# Drawbacks
+
+None!
+
+
+# Alternatives
+
+[RFC 483](https://github.com/rust-lang/rfcs/pull/483): Use `@` instead.
+
+
+# Unresolved questions
+
+None.


### PR DESCRIPTION
This is an alternative to #483: instead of changing attributes to `@`, just make the brackets optional for `#`. 

Note that I'm not _opposed_ to #483, and am only presenting this as an alternative to consider, although I have a slight preference for it. From a practical perspective, it has the benefit of being backwards compatible.

Splicing in my comment from the other RFC:

> I'd be fine with `@` as well. It's a somewhat nicer symbol... precisely _because_ it's a nicer symbol, however, it has a lot of possibility as potential syntax for future language features we haven't even thought of yet, whereas `#` is most likely too ugly to use for anything else. So keeping `#` for attributes would be a more efficient use of limited ASCII real estate.

[CLICKME](https://github.com/glaebhoerl/rfcs/blob/attributes-optional-brackets/text/0000-attributes-optional-brackets.md)
