### PR TITLE
RFC: Split Show into String and Show

### DIFF
--- a/text/0000-show-stabilization.md
+++ b/text/0000-show-stabilization.md
@@ -54,10 +54,10 @@ As described in the motivation section, the intended use cases for the current
 `Show` trait are actually motivations for two separate formatting traits. One
 trait will be intended for all Rust types to implement in order to easily allow
 debugging values for macros such as `assert_eq!` or general `println!`
-statements. A separate trait will be intended for Rust types which are "round
-trippable" from a string. These types can be represented as a string in a
-non-lossy fashion and are intended for general consumption by more than just
-developers.
+statements. A separate trait will be intended for Rust types which are
+faithfully represented as a string. These types can be represented as a string
+in a non-lossy fashion and are intended for general consumption by more than
+just developers.
 
 This RFC proposes naming these two traits `Show` and `String`, respectively.
 
@@ -77,7 +77,8 @@ the default specifier for Rust.
 
 An implementation of the `String` trait is an assertion that the type can be
 faithfully represented as a UTF-8 string at all times. If the type can be
-reconstructed from a string, then the following relation must be true:
+reconstructed from a string, then it is recommended, but not required, that the
+following relation be true:
 
 ```rust
 assert_eq!(foo, from_str(format!("{}", foo).as_slice()).unwrap());


### PR DESCRIPTION
Today's `Show` trait will be tasked with the purpose of providing the ability to
inspect the representation of implementors of the trait. A new trait, `String`,
will be introduced to the `std::fmt` module to in order to represent data that
can essentially be serialized to a string, typically representing the precise
internal state of the implementor.

The `String` trait will take over the `{}` format specifier and the `Show` trait
will move to the now-open `{:?}` specifier.

[Rendered](https://github.com/alexcrichton/rfcs/blob/show-and-string/text/0000-show-stabilization.md)
