### PR TITLE
Give pre-RFC suggestions and clarify PR process

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ Furthermore, the fact that a given RFC has been accepted and is
 'active' implies nothing about what priority is assigned to its
 implementation, nor does it imply anything about whether a Rust
 developer has been assigned the task of implementing the feature.
+While it is not *necessary* that the author of the RFC also write the
+implementation, it is by far the most effective way to see an RFC
+through to completion: authors should not expect that other project
+developers will take on responsibility for implementing their accepted
+feature.
 
 Modifications to active RFC's can be done in followup PR's.  We strive
 to write each RFC in a manner that it will reflect the final design of


### PR DESCRIPTION
Based on workweek discussions here are some minor updates to the RFC process.

TL;DR is that we are no longer going to do RFC approvals at the meeting, are going to try to have more ad-hoc meetings involving a wider group of contributors, will insist on summaries of those meetings being delivered back to the PR threads, core team will make final decisions based on discussion in the thread.
We will try to invite community stakeholders to more weekly meetings to discuss their RFCs as needed. I've also added some text about how to properly prepare _before_ submitting an RFC.
