### PR TITLE
Collections Reform Part 2

### DIFF
--- a/text/0000-collections-reform-part-2.md
+++ b/text/0000-collections-reform-part-2.md
@@ -253,13 +253,12 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
 }
 
 impl<'a, K, V> OccupiedEntry<'a, K, V> {
+    fn get(&self) -> &V
+    fn get_mut(&mut self) -> &mut V
     fn into_mut(self) -> &'a mut V
     fn insert(&mut self, value: V) -> V
     fn remove(self) -> V
 }
-
-impl Deref<V> for OccupiedEntry<'a, O, V>
-impl DerefMut<V> for OccupiedEntry<'a, O, V>
 ```
 
 Replacing get/get_mut with Deref is simply a nice ergonomic improvement. Renaming `set` and `take`


### PR DESCRIPTION
This RFC shores up the finer details of collections reform. In particular, where the previous RFC
focused on general conventions and patterns, this RFC focuses on specific APIs. It also patches
up any errors that were found during implementation of part 1. Some of these changes
have already been implemented, and simply need to be ratified.

[rendered](https://github.com/Gankro/rfcs/blob/collections2/text/0000-collections-reform-part-2.md)
