### PR TITLE
Anonymous enum types (A|B) take 2

### DIFF
--- a/text/0000-anonymous-enums.md
+++ b/text/0000-anonymous-enums.md
@@ -303,7 +303,7 @@ trait Leave { fn say_bye(&self) -> &str; }
 
 trait Talker { fn talk(&self); }
 
-impl Talker for Enter | Leave {
+impl Talker for T where T: Enter | Leave {
     fn talk(&self) {
         match self {
             x as &Enter           => { println!("hi-{}", x.say_hi()); },
@@ -357,6 +357,8 @@ something that is guaranteed to be some subset of the types.
 trait X { ... }
 trait Y { ... }
 trait Z { ... }
+
+// ...
 
 let abc : &(X | Y | Z) = ...;
 


### PR DESCRIPTION
I really liked this idea and have tried to address some of the concerns with it.

[rendered](https://github.com/scialex/rfcs/blob/anonymous-enums-2/text/0000-anonymous-enums.md)

[Previous discussion](https://github.com/rust-lang/rfcs/pull/402)

Thanks to @reem for making the original version of this.
