### PR TITLE
Change array syntax to prevent ambiguity introduced by RFC 439

### DIFF
--- a/text/0000-new-array-repeat-syntax.md
+++ b/text/0000-new-array-repeat-syntax.md
@@ -7,7 +7,7 @@
 Under this RFC, the syntax to specify the type of a fixed-length array
 containing `N` elements of type `T` would be changed to `[T; N]`. Similarly, the
 syntax to construct an array containing `N` duplicated elements of value `x`
-would be changed to `[x, N]`.
+would be changed to `[x; N]`.
 
 # Motivation
 


### PR DESCRIPTION
**Update:** This request is now about syntax resembling `[x; N]` rather than `[N of x]`. I am still open to changing this if needed, but we need a decision very soon. The other leading candidate is `[x for N]`.

This is an alternative to #498.

The change is not complex; most of the length of the RFC is due to my getting carried away when listing alternatives. I'm still open to changing details (e.g. `[x by N]` or `[x for N]` instead of `[N of x]`), but this is my current preference, and I feel that something along these lines is preferable to fixing this via a change to the RFC 439 range syntax.

[Rendered View](https://github.com/quantheory/rfcs/blob/master/text/0000-new-array-repeat-syntax.md)
