### PR TITLE
Relative paths by default.

### DIFF
--- a/text/0000-relative-paths-by-default.md
+++ b/text/0000-relative-paths-by-default.md
@@ -22,6 +22,9 @@ refactoring such as renaming modules harder. The cases that require
 absolute paths should be rarer than the ones that require relative paths,
 given a reasonable module structure.
 
+Note that this creates a nice analogy with the file system, with `::`
+instead of `/`.
+
 # Detailed design
 
 The original grammar for paths (from the reference) is:
@@ -44,6 +47,12 @@ The behavior is simple:
   where n is the number of `super::` prefixes.
 - Having no prefix makes the path a relative path (i.e. starts from the
   current module).
+
+Note that `use foo::bar` should behave as if the contents of `foo::bar`
+(`self::foo::bar` in the current syntax) is copied into the current module
+(`self`). The analogy to the file system is creating a soft link named `bar`
+pointing to `foo/bar`. As a consequence, `use foo::bar` followed by
+`use bar::baz` is valid.
 
 # Drawbacks
 

--- a/text/0000-relative-paths-by-default.md
+++ b/text/0000-relative-paths-by-default.md
@@ -1,0 +1,60 @@
+- Start Date: 2015-01-09
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+All paths should be relative by default. The current design requires the
+`self::` prefix to be relative in `use` statements.
+
+Global paths should require a new `crate::` prefix. The current design has
+global paths by default in `use` statements.
+
+# Motivation
+
+Currently, `use` statements have global paths by default, but other paths
+are relative paths by default. This causes confusion for beginners due to
+the inconsistencies.
+
+Additionally, this encourages misusing global paths when relative paths
+are more logical (e.g. when importing from a sibling module). This makes
+refactoring such as renaming modules harder. The cases that require
+global paths should be rarer than the ones that require local paths,
+given a reasonable module structure.
+
+# Detailed design
+
+The original grammar for paths (from the reference) is:
+
+```
+expr_path : [ "::" ] ident [ "::" expr_path_tail ] + ;
+```
+
+The new grammar (which includes some clean up) is:
+
+```
+expr_path : [ "crate::" | "super::" + ] ? ident [ "::" expr_path_tail ] + ;
+```
+
+The behavior is simple:
+
+- The `crate::` prefix makes the path a global path (i.e. starts from
+  the crate root).
+- The `super::` prefix makes the path start from the nth ancestor module,
+  where n is the number of `super::` prefixes.
+- Having no prefix makes the path a local path (i.e. starts from the
+  current module).
+
+# Drawbacks
+
+This breaks *a lot* of code.
+
+# Alternatives
+
+- Use the existing `::` prefix instead of the `crate::` prefix. However, I
+think that this might cause some confusion for beginners.
+- The status quo has problems as mentioned in the Motivation section.
+
+# Unresolved questions
+
+Unknown

--- a/text/0000-relative-paths-by-default.md
+++ b/text/0000-relative-paths-by-default.md
@@ -7,19 +7,19 @@
 All paths should be relative by default. The current design requires the
 `self::` prefix to be relative in `use` statements.
 
-Global paths should require a new `crate::` prefix. The current design has
-global paths by default in `use` statements.
+Absolute paths should require a new `crate::` prefix. The current design has
+absolute paths by default in `use` statements.
 
 # Motivation
 
-Currently, `use` statements have global paths by default, but other paths
+Currently, `use` statements have absolute paths by default, but other paths
 are relative paths by default. This causes confusion for beginners due to
 the inconsistencies.
 
-Additionally, this encourages misusing global paths when relative paths
+Additionally, this encourages misusing absolute paths when relative paths
 are more logical (e.g. when importing from a sibling module). This makes
 refactoring such as renaming modules harder. The cases that require
-global paths should be rarer than the ones that require local paths,
+absolute paths should be rarer than the ones that require relative paths,
 given a reasonable module structure.
 
 # Detailed design
@@ -38,11 +38,11 @@ expr_path : [ "crate::" | "super::" + ] ? ident [ "::" expr_path_tail ] + ;
 
 The behavior is simple:
 
-- The `crate::` prefix makes the path a global path (i.e. starts from
+- The `crate::` prefix makes the path an absolute path (i.e. starts from
   the crate root).
 - The `super::` prefix makes the path start from the nth ancestor module,
   where n is the number of `super::` prefixes.
-- Having no prefix makes the path a local path (i.e. starts from the
+- Having no prefix makes the path a relative path (i.e. starts from the
   current module).
 
 # Drawbacks


### PR DESCRIPTION
I believe that absolute paths by default in `use` statements are a bad idea.