### PR TITLE
RFC: CStr, the dereferenced complement to CString

### DIFF
--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -134,7 +134,7 @@ convey string data from Rust to C-style APIs.
 While it's not possible outside of unsafe code to unintentionally copy out
 or modify the nominal value of `CStr` under an immutable reference, some
 unforeseen trouble or confusion can arise due to the structure having a
-bogus size. A separate [RFC PR](https://github.com/rust-lang/rfcs/issues/709),
+bogus size. A separate [RFC](https://github.com/rust-lang/rfcs/issues/813),
 if accepted, will solve this by opting out of `Sized`.
 
 # Alternatives
@@ -153,7 +153,7 @@ is established.
 # Unresolved questions
 
 `CStr` can be made a
-[truly unsized type](https://github.com/rust-lang/rfcs/issues/709),
+[truly unsized type](https://github.com/rust-lang/rfcs/issues/813),
 pending on that proposal's approval.
 
 Need a `Cow`?

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -82,7 +82,7 @@ In cases when an FFI function returns a pointer to a non-owned C string,
 it might be preferable to wrap the returned string safely as a 'thin'
 `&CStr` rather than scan it into a slice up front. To facilitate this,
 conversion from a raw pointer should be added (with an inferred lifetime
-as per another proposed [RFC](https://github.com/rust-lang/rfcs/pull/556)):
+as per [the established convention](https://github.com/rust-lang/rfcs/pull/556)):
 ```rust
 impl CStr {
     pub unsafe fn from_ptr<'a>(ptr: *const libc::c_char) -> &'a CStr {

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -76,26 +76,6 @@ impl Deref for CString {
 }
 ```
 
-## Static C strings
-
-An important special case is producing `CStr` references from static Rust
-data, primarily from literals. To avoid copying the data, it is required that
-the source slice is null-terminated. The conversion function is otherwise
-safe:
-
-```rust
-impl CStr {
-    pub fn from_static_bytes(bytes: &'static [u8]) -> &'static CStr { ... }
-}
-```
-
-As this function mostly works with literal data, it only asserts that the
-slice is terminated by a zero byte. It's the responsibility of the programmer
-to ensure that the static data does not contain any unintended interior NULs
-(the program will not crash, but the string will be interpreted up to the
-first `'\0'` encountered). For non-literal data, `CStrBuf::from_bytes` or
-`CStrBuf::from_vec` should be preferred.
-
 ## Returning C strings
 
 In cases when an FFI function returns a pointer to a non-owned C string,

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -14,7 +14,8 @@ fn safe_puts(s: &CStr) {
 }
 
 fn main() {
-    safe_puts(c_str!("Look ma, a `&'static CStr` from a literal!"));
+    let s = CString::from_slice("A Rust string");
+    safe_puts(s);
 }
 ```
 
@@ -89,24 +90,6 @@ to ensure that the static data does not contain any unintended interior NULs
 (the program will not crash, but the string will be interpreted up to the
 first `'\0'` encountered). For non-literal data, `CStrBuf::from_bytes` or
 `CStrBuf::from_vec` should be preferred.
-
-## c_str!
-
-For added convenience in passing literal string data to FFI functions,
-a macro is provided that appends a literal with `"\0"` and returns it
-as `&'static CStr`:
-```rust
-#[macro_export]
-macro_rules! c_str {
-    ($lit:expr) => {
-        $crate::ffi::CStr::from_static_str(concat!($lit, "\0"))
-    }
-}
-```
-Going forward, it would be good to make `c_str!` also accept byte strings
-on input, through a [byte string concatenation
-macro](https://github.com/rust-lang/rfcs/pull/566). Ultimately, it could be
-made workable in static expressions through a compiler plugin.
 
 ## Returning C strings
 

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -154,6 +154,9 @@ is established.
 
 # Unresolved questions
 
+The present function `c_str_to_bytes(&ptr)` may be deprecated in favor of
+the more composable `CStr::from_raw(ptr).to_bytes()`.
+
 `CStr` can be made a
 [truly unsized type](https://github.com/rust-lang/rfcs/issues/709),
 pending on that proposal's approval.

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -96,7 +96,8 @@ first `'\0'` encountered). For non-literal data, `CStrBuf::from_bytes` or
 In cases when an FFI function returns a pointer to a non-owned C string,
 it might be preferable to wrap the returned string safely as a 'thin'
 `&CStr` rather than scan it into a slice up front. To facilitate this,
-conversion from a raw pointer should be added:
+conversion from a raw pointer should be added (with an inferred lifetime
+as per another proposed [RFC](https://github.com/rust-lang/rfcs/pull/556)):
 ```rust
 impl CStr {
     pub unsafe fn from_raw<'a>(ptr: *const libc::c_char) -> &'a CStr {

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -113,13 +113,10 @@ made workable in static expressions through a compiler plugin.
 In cases when an FFI function returns a pointer to a non-owned C string,
 it might be preferable to wrap the returned string safely as a 'thin'
 `&CStr` rather than scan it into a slice up front. To facilitate this,
-conversion from a raw pointer should be added (using the
-[lifetime anchor](https://github.com/rust-lang/rfcs/pull/556) convention):
+conversion from a raw pointer should be added:
 ```rust
 impl CStr {
-    pub unsafe fn from_raw_ptr<'a, T: ?Sized>(ptr: *const libc::c_char,
-                                              life_anchor: &'a T)
-                                             -> &'a CStr
+    pub unsafe fn from_raw_ptr<'a>(ptr: *const libc::c_char) -> &'a CStr
     { ... }
 }
 ```

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -105,7 +105,7 @@ conversion from a raw pointer should be added (with an inferred lifetime
 as per another proposed [RFC](https://github.com/rust-lang/rfcs/pull/556)):
 ```rust
 impl CStr {
-    pub unsafe fn from_raw<'a>(ptr: *const libc::c_char) -> &'a CStr {
+    pub unsafe fn from_ptr<'a>(ptr: *const libc::c_char) -> &'a CStr {
         ...
     }
 }
@@ -166,7 +166,7 @@ is established.
 # Unresolved questions
 
 The present function `c_str_to_bytes(&ptr)` may be deprecated in favor of
-the more composable `CStr::from_raw(ptr).to_bytes()`.
+the more composable `CStr::from_ptr(ptr).to_bytes()`.
 
 `CStr` can be made a
 [truly unsized type](https://github.com/rust-lang/rfcs/issues/709),

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -104,6 +104,13 @@ impl CStr {
 An odd consequence is that it is valid, if wasteful, to call `to_bytes` on
 `CString` via auto-dereferencing.
 
+## Remove c_str_to_bytes
+
+The functions `c_str_to_bytes` and `c_str_to_bytes_with_nul`, with their
+problematic lifetime semantics, are deprecated and eventually removed
+in favor of composition of the functions described above:
+`c_str_to_bytes(&ptr)` becomes `CStr::from_ptr(ptr).to_bytes()`.
+
 ## Proof of concept
 
 The described changes are implemented in crate
@@ -144,9 +151,6 @@ incompatible helper types in public APIs until a dominant de-facto solution
 is established.
 
 # Unresolved questions
-
-The present function `c_str_to_bytes(&ptr)` may be deprecated in favor of
-the more composable `CStr::from_ptr(ptr).to_bytes()`.
 
 `CStr` can be made a
 [truly unsized type](https://github.com/rust-lang/rfcs/issues/709),

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -134,9 +134,7 @@ in favor of composition of the functions described above:
 ## Proof of concept
 
 The described interface changes are implemented in crate
-[c_string](https://github.com/mzabaluev/rust-c-str), with a difference
-that the `CStr` token type has a bogus static size, as a compromise to
-offer better performance in current Rust.
+[c_string](https://github.com/mzabaluev/rust-c-str).
 
 # Drawbacks
 

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -130,12 +130,18 @@ The described changes are implemented in crate
 
 # Drawbacks
 
-The change of the deref type is another breaking change to `CString`.
+The change of the deref target is another breaking change to `CString`.
 In practice the main purpose of borrowing from `CString` is to obtain a
 raw pointer with `.as_ptr()`; for code which only does this and does not
 expose the slice in type annotations, parameter signatures and so on,
 the change should not be breaking since `CStr` also provides
 this method.
+
+Making the deref target practically unsized throws away the length information
+intrinsic to `CString` and makes it less useful as a container for bytes.
+This is countered by the fact that there are general purpose byte containers
+in the core libraries, whereas `CString` addresses the specific need to
+convey string data from Rust to C-style APIs.
 
 While it's not possible outside of unsafe code to unintentionally copy out
 or modify the nominal value of `CStr` under an immutable reference, some

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -99,22 +99,24 @@ it might be preferable to wrap the returned string safely as a 'thin'
 conversion from a raw pointer should be added:
 ```rust
 impl CStr {
-    pub unsafe fn from_raw_ptr<'a>(ptr: *const libc::c_char) -> &'a CStr
-    { ... }
+    pub unsafe fn from_raw<'a>(ptr: *const libc::c_char) -> &'a CStr {
+        ...
+    }
 }
 ```
 
-For getting a slice out of a `CStr` reference, method `parse_as_bytes` is
-provided. The name is chosen to reflect the linear cost of calculating the
-length.
+For getting a slice out of a `CStr` reference, method `to_bytes` is
+provided. The name is preferred over `as_bytes` to reflect the linear cost
+of calculating the length.
 ```rust
 impl CStr {
-    pub fn parse_as_bytes(&self) -> &[u8] { ... }
+    pub fn to_bytes(&self) -> &[u8] { ... }
+    pub fn to_bytes_with_nul(&self) -> &[u8] { ... }
 }
 ```
 
-An odd consequence is that it is valid, if wasteful, to call
-`parse_as_bytes` on `CString` via auto-dereferencing.
+An odd consequence is that it is valid, if wasteful, to call `to_bytes` on
+`CString` via auto-dereferencing.
 
 ## Proof of concept
 

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -118,7 +118,7 @@ The described changes are implemented in crate
 
 # Drawbacks
 
-The change of the deref target is another breaking change to `CString`.
+The change of the deref target type is another breaking change to `CString`.
 In practice the main purpose of borrowing from `CString` is to obtain a
 raw pointer with `.as_ptr()`; for code which only does this and does not
 expose the slice in type annotations, parameter signatures and so on,

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -172,9 +172,4 @@ is established.
 [truly unsized type](https://github.com/rust-lang/rfcs/issues/709),
 pending on that proposal's approval.
 
-There is room for a helper type wrapping an allocated C string with a supplied
-deallocation function to invoke when dropped. That type should also dereference
-to `CStr`. My library crate [c_string](https://crates.io/crates/c_string)
-provides an example in `OwnedCString`.
-
 Need a `Cow`?

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -78,17 +78,18 @@ impl Deref for CString {
 
 ## Static C strings
 
-A way to create `CStr` references from static Rust expressions asserted as
-null-terminated string or byte slices is provided by a couple of functions:
+An important special case is producing `CStr` references from static Rust
+data, primarily from literals. To avoid copying the data, it is required that
+the source slice is null-terminated. The conversion function is otherwise
+safe:
 
 ```rust
 impl CStr {
     pub fn from_static_bytes(bytes: &'static [u8]) -> &'static CStr { ... }
-    pub fn from_static_str(s: &'static str) -> &'static CStr { ... }
 }
 ```
 
-As these functions mostly work with literals, they only assert that the
+As this function mostly works with literal data, it only asserts that the
 slice is terminated by a zero byte. It's the responsibility of the programmer
 to ensure that the static data does not contain any unintended interior NULs
 (the program will not crash, but the string will be interpreted up to the
@@ -126,7 +127,7 @@ An odd consequence is that it is valid, if wasteful, to call `to_bytes` on
 ## Proof of concept
 
 The described changes are implemented in crate
-[c_string](https://github.com/mzabaluev/rust-c-str/tree/v0.3.0).
+[c_string](https://github.com/mzabaluev/rust-c-str).
 
 # Drawbacks
 

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -128,3 +128,5 @@ There is room for a helper type wrapping an allocated C string with a supplied
 deallocation function to invoke when dropped. That type should also dereference
 to `CStr`. My library crate [c_string](https://crates.io/crates/c_string)
 provides an example in `OwnedCString`.
+
+Need a `Cow`?

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -150,6 +150,11 @@ expose the slice in type annotations, parameter signatures and so on,
 the change should not be breaking since `CStr` also provides
 this method.
 
+While it's not possible outside of unsafe code to unintentionally copy out
+or modify the nominal value of `CStr` under an immutable reference, some
+unforeseen trouble or confusion can arise due to the structure having a
+bogus size.
+
 # Alternatives
 
 `CStr` could be made a newtype on DST `[libc::c_char]`, allowing no-cost

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -152,6 +152,11 @@ this method.
 
 # Alternatives
 
+`CStr` could be made a newtype on DST `[libc::c_char]`, allowing no-cost
+slices. It's not clear if this is useful, and the need to calculate length
+up front might prevent some optimized uses possible with the 'thin'
+reference.
+
 The users of Rust can turn to third-party libraries for better convenience
 and safety when working with C strings. This can result in proliferation of
 incompatible helper types in public APIs until a dominant de-facto solution

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -103,7 +103,7 @@ made workable in static expressions through a compiler plugin.
 
 ## Proof of concept
 
-The described additions are implemented in crate
+The described changes are implemented in crate
 [c_string](https://github.com/mzabaluev/rust-c-str/tree/v0.3.0).
 
 # Drawbacks

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -99,7 +99,7 @@ as `&'static CStr`:
 #[macro_export]
 macro_rules! c_str {
     ($lit:expr) => {
-        $crate::ffi::static_c_str_from_str(concat!($lit, "\0"))
+        $crate::ffi::CStr::from_static_str(concat!($lit, "\0"))
     }
 }
 ```

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -77,10 +77,10 @@ A way to create `CStr` references from static Rust expressions asserted as
 null-terminated string or byte slices is provided by a couple of functions:
 
 ```rust
-fn static_c_str_from_bytes(bytes: &'static [u8]) -> &'static CStr
-```
-```rust
-fn static_c_str_from_str(s: &'static str) -> &'static CStr
+impl CStr {
+    pub fn from_static_bytes(bytes: &'static [u8]) -> &'static CStr { ... }
+    pub fn from_static_str(s: &'static str) -> &'static CStr { ... }
+}
 ```
 
 As these functions mostly work with literals, they only assert that the

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -73,8 +73,8 @@ impl Deref for CString {
 
 ## Static C strings
 
-A way to create static references asserted as null-terminated strings is
-provided by a couple of functions:
+A way to create `CStr` references from static Rust expressions asserted as
+null-terminated string or byte slices is provided by a couple of functions:
 
 ```rust
 fn static_c_str_from_bytes(bytes: &'static [u8]) -> &'static CStr
@@ -82,6 +82,13 @@ fn static_c_str_from_bytes(bytes: &'static [u8]) -> &'static CStr
 ```rust
 fn static_c_str_from_str(s: &'static str) -> &'static CStr
 ```
+
+As these functions mostly work with literals, they only assert that the
+slice is terminated by a zero byte. It's the responsibility of the programmer
+to ensure that the static data does not contain any unintended interior NULs
+(the program will not crash, but the string will be interpreted up to the
+first `'\0'` encountered). For non-literal data, `CStrBuf::from_bytes` or
+`CStrBuf::from_vec` should be preferred.
 
 ## c_str!
 

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -153,7 +153,8 @@ this method.
 While it's not possible outside of unsafe code to unintentionally copy out
 or modify the nominal value of `CStr` under an immutable reference, some
 unforeseen trouble or confusion can arise due to the structure having a
-bogus size.
+bogus size. A separate [RFC PR](https://github.com/rust-lang/rfcs/issues/709),
+if accepted, will solve this by opting out of `Sized`.
 
 # Alternatives
 
@@ -169,6 +170,10 @@ incompatible helper types in public APIs until a dominant de-facto solution
 is established.
 
 # Unresolved questions
+
+`CStr` can be made a
+[truly unsized type](https://github.com/rust-lang/rfcs/issues/709),
+pending on that proposal's approval.
 
 There is room for a helper type wrapping an allocated C string with a supplied
 deallocation function to invoke when dropped. That type should also dereference

--- a/text/0000-c-str-deref.md
+++ b/text/0000-c-str-deref.md
@@ -157,8 +157,9 @@ slices. It's not clear if this is useful, and the need to calculate length
 up front might prevent some optimized uses possible with the 'thin'
 reference.
 
-The users of Rust can turn to third-party libraries for better convenience
-and safety when working with C strings. This can result in proliferation of
+If the proposed enhancements or other equivalent facilities are not adopted,
+users of Rust can turn to third-party libraries for better convenience
+and safety when working with C strings. This may result in proliferation of
 incompatible helper types in public APIs until a dominant de-facto solution
 is established.
 


### PR DESCRIPTION
Change the `Deref` target of `CString` to a token type `CStr`.
Add helper functions and macros to produce `CStr` references out of static string data.

[Rendered](https://github.com/mzabaluev/rust-rfcs/blob/c-str-deref/text/0000-c-str-deref.md)