### PR TITLE
Make transmute_copy<T,U> with sizeof T != sizeof U a compile time error.

### DIFF
--- a/text/0000-transmute_copy.md
+++ b/text/0000-transmute_copy.md
@@ -1,0 +1,29 @@
+- Start Date: 2015-02-03
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+Make `transmute_copy<T,U>` with `sizeof T != sizeof U` a compile time error.
+
+# Motivation
+
+Given the name, it's reasonable to assume that `transmute_copy` is just a
+`transmute` that doesn't consume the value. However, `transmute_copy` does not
+check at compile time that the sizes match and if `sizeof U > sizeof T`, the
+behavior might be undefined at runtime.
+
+# Detailed design
+
+Change the implementation of `transmute_copy` to
+
+```rust
+pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
+    transmute(ptr::read(src as *const T))
+}
+```
+
+# Drawbacks
+
+Sometimes one wants to read a prefix of `T`, i.e., `sizeof U < sizeof T`. This
+is still possible via `ptr::read(src as *const T as *const U)`.

--- a/text/0000-transmute_copy.md
+++ b/text/0000-transmute_copy.md
@@ -15,13 +15,7 @@ behavior might be undefined at runtime.
 
 # Detailed design
 
-Change the implementation of `transmute_copy` to
-
-```rust
-pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
-    transmute(ptr::read(src as *const T))
-}
-```
+Turn `transmute_copy` into an intrinsic that compares the size at compile time.
 
 # Drawbacks
 


### PR DESCRIPTION
Make `transmute_copy<T,U>` with `sizeof T != sizeof U` a compile time error.

[rendered](https://github.com/mahkoh/rfcs/blob/transmute_copy/text/0000-transmute_copy.md)