### PR TITLE
RFC: Deprecate std::fmt::format in favor of String::format

### DIFF
--- a/text/0000-String-format.md
+++ b/text/0000-String-format.md
@@ -1,0 +1,33 @@
+- Start Date: 2015-02-04
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+Deprecate `std::fmt::format` (to be removed before 1.0) in favor of `String::format`.
+
+# Motivation
+
+It's available with libstd or just with libcollections.  Also, it's a more
+descriptive name; it says what you get.
+
+# Detailed design
+
+What it says on the tin.
+
+There's no visible change for users of the `format!` macro, except that it
+works without libstd (see [#21912](https://github.com/rust-lang/rust/pull/21912)).
+
+# Drawbacks
+
+None! Perfect RFC!
+
+# Alternatives
+
+`std::fmt::format` is the only bit that's not a facade of `core::fmt`. It could
+be a facade of `collections::fmt` instead, in which case the `format!` macro
+would use `$crate::fmt::format`.  This was acrichto's suggestion.
+
+# Unresolved questions
+
+None! Perfect RFC!

--- a/text/0000-String-format.md
+++ b/text/0000-String-format.md
@@ -15,8 +15,7 @@ descriptive name; it says what you get.
 
 What it says on the tin.
 
-There's no visible change for users of the `format!` macro, except that it
-works without libstd (see [#21912](https://github.com/rust-lang/rust/pull/21912)).
+There's no visible change for users of the `format!` macro.
 
 # Drawbacks
 
@@ -24,9 +23,10 @@ None! Perfect RFC!
 
 # Alternatives
 
-`std::fmt::format` is the only bit that's not a facade of `core::fmt`. It could
-be a facade of `collections::fmt` instead, in which case the `format!` macro
-would use `$crate::fmt::format`.  This was acrichto's suggestion.
+Do nothing. In [#21912](https://github.com/rust-lang/rust/pull/21912) I made
+`std::fmt::format` a re-export of `collections::fmt::format`, which solved the
+problem with `format!` in `no_std` crates. So this RFC is not a high priority,
+but still seems like a clear improvement to the language.
 
 # Unresolved questions
 


### PR DESCRIPTION
[Rendered view](https://github.com/kmcallister/rfcs/blob/String-format/text/0000-String-format.md)