### PR TITLE
Add feature name header to RFC template

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,3 +1,4 @@
+- Feature Name: (fill me in with a unique ident, my_awesome_feature)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: (leave this empty)
 - Rust Issue: (leave this empty)


### PR DESCRIPTION
Every new feature that enters the language or libs should have an associated feature name, and that should be specified in the RFC to increase traceability.