### PR TITLE
Tweaks to the object-safety rules

### DIFF
--- a/text/0255-object-safety.md
+++ b/text/0255-object-safety.md
@@ -195,6 +195,12 @@ the actual type parameter satisfies the formal bounds.  We could
 probably give a different error message if the bounds are met, but the
 trait is not object-safe.
 
+We might in the future use finer-grained reasoning to permit more
+non-object-safe methods from appearing in the trait. For example, we
+might permit `fn foo() -> Self` because it (implicitly) requires that
+`Self` be sized. Similarly, we might permit other tests beyond just
+sized-ness. Any such extension would be backwards compatible.
+
 # Unresolved questions
 
 N/A

--- a/text/0255-object-safety.md
+++ b/text/0255-object-safety.md
@@ -84,7 +84,10 @@ of the following conditions:
 * require `Self : Sized`; or,
 * meet all of the following conditions:
   * must not have any type parameters; and,
-  * must not take `self` by value; and,
+  * must have a receiver that dereferences to the `Self` type;
+    - for now, this means `&self`, `&mut self`, or `self: Box<Self>`,
+      but eventually this should be extended to custom types like
+      `self: Rc<Self>` and so forth.
   * must not use `Self` (in the future, where we allow arbitrary types
     for the receiver, `Self` may only be used for the type of the
     receiver and only where we allow `Sized?` types).

--- a/text/0255-object-safety.md
+++ b/text/0255-object-safety.md
@@ -158,7 +158,7 @@ trait SomeTrait {
 The reason that this makes sense is that if one were writing a generic
 function with a type parameter `T` that may range over the trait
 object, that type parameter would have to be declared `?Sized`, and
-hence would not have access to the `bar` method:
+hence would not have access to the `new` method:
 
 ```rust
 fn baz<T:?Sized+SomeTrait>(t: &T) {
@@ -167,7 +167,7 @@ fn baz<T:?Sized+SomeTrait>(t: &T) {
 ```
 
 However, if one writes a function with sized type parameter, which
-could never be a trait object, then the `bar()` functions becomes
+could never be a trait object, then the `new` function becomes
 available.
 
 ```rust


### PR DESCRIPTION
Amend object safety RFC to include the complete set of rules, along with an exemption that permits individual methods to require that `Self:Sized`. 

Implemented on the following branch:

https://github.com/nikomatsakis/rust/tree/object-safe-sized-methods