### PR TITLE
Fix gap in the text defining the Drop-Check rule.

### DIFF
--- a/text/0769-sound-generic-drop.md
+++ b/text/0769-sound-generic-drop.md
@@ -247,9 +247,12 @@ of type `&'a`/`&'a mut`. This is the "Drop-Check" (aka `dropck`) rule.
 The Motivation section alluded to the compiler enforcing a new rule.
 Here is a more formal statement of that rule:
 
-Let `v` be some value (either temporary or named); if the type of `v` owns data of type `D`,
-where `D` has a lifetime- or type-parametric `Drop` implementation and
-either:
+Let `v` be some value (either temporary or named)
+and `'a` be some lifetime (scope);
+if the type of `v` owns data of type `D`, where
+(1.) `D` has a lifetime- or type-parametric `Drop` implementation, and
+(2.) the structure of `D` can reach a reference of type `&'a _`, and
+(3.) either:
 
   * (A.) the `Drop impl` for `D` instantiates `D` at `'a`
          directly, i.e. `D<'a>`, or,


### PR DESCRIPTION
I was re-reading the text last night and realized that `'a` was
referenced only from Condition (A.) and from the final consequence
"`'a` must strictly outlive ..."; i.e. the definition was not
well-formed, since `'a` was never defined for Condition B.

This is an attempt to fill the gap to describe the semantics that I am
aiming for in the implementation.