### PR TITLE
Update RFC 195 to account for RFC 246.

### DIFF
--- a/text/0195-associated-items.md
+++ b/text/0195-associated-items.md
@@ -21,6 +21,11 @@ This RFC also provides a mechanism for *multidispatch* traits, where the `impl`
 is selected based on multiple types. The connection to associated items will
 become clear in the detailed text below.
 
+*Note: This RFC was originally accepted before RFC 246 added consts and changed
+the definition of statics. The text has been updated to clarify that both consts
+and statics can be associated with a trait. Other than that modification, the
+proposal has not been changed to reflect newer Rust features or syntax.*
+
 # Motivation
 
 A typical example where associated items are helpful is data structures like


### PR DESCRIPTION
**Edit:** While the goal of this RFC is the same, namely to provide further interpretation of the design of associated constants, the current proposal differs radically from the original PR. This PR now clarifies that associated statics are *not* added, only constants, and mentions some limitations on associated constants that require more design work to deal with.

[Rendered.](https://github.com/rust-lang/rfcs/pull/865/files?short_path=e0686e7#diff-e0686e7af71a6699c8dc01e510e51e1c)

**Original text of this post follows**

Currently, the associated items RFC only provides for associated functions, lifetimes, statics, and types. However, it was never updated to account for the const/static split. This PR makes minimal changes to address this by adding associated consts as well.

The original motivating example for statics really applies to consts now, and I have updated it accordingly. I have not added a motivating example for statics; I'm sure that there is a use case, but I have not come up with one that could be easily explained.

I have also not bothered to update the examples to account for other RFCs (e.g. `uint` is now `usize`, `[T, ..N]` is now `[T; N]`). Maybe that would be worth doing for major RFCs that are going to be used as references into the future, but for now I left the RFC as it was historically accepted, since those other cases are not likely to cause confusion about what was intended.