### PR TITLE
Amend RFC 517: Add material for stdio

### DIFF
--- a/text/0517-io-os-reform.md
+++ b/text/0517-io-os-reform.md
@@ -1165,14 +1165,16 @@ pub fn stderr() -> Stderr;
 ```
 
 * `stdin` - returns a handle to a **globally shared** standard input of
-  the process which is buffered as well. All operations on this handle will
-  first require acquiring a lock to ensure access to the shared buffer is
-  synchronized. The handle can be explicitly locked for a critical section so
-  relocking is not necessary.
+  the process which is buffered as well. Due to the globally shared nature of
+  this handle, all operations on `Stdin` directly will acquire a lock internally
+  to ensure access to the shared buffer is synchronized. This implementation
+  detail is also exposed through a `lock` method where the handle can be
+  explicitly locked for a period of time so relocking is not necessary.
 
   The `Read` trait will be implemented directly on the returned `Stdin` handle
   but the `BufRead` trait will not be (due to synchronization concerns). The
-  locked version of `Stdin` will provide an implementation of `BufRead`.
+  locked version of `Stdin` (`StdinLock`) will provide an implementation of
+  `BufRead`.
 
   The design will largely be the same as is today with the `old_io` module.
 

--- a/text/0517-io-os-reform.md
+++ b/text/0517-io-os-reform.md
@@ -1318,13 +1318,11 @@ interface.
 
 [gh22607]: https://github.com/rust-lang/rust/issues/22607
 
-The `set_stdout` and `set_stderr` functions will be moved to a new
-`std::fmt::output` module and renamed to `set_print` and `set_panic`,
-respectively. These new names reflect what they actually do, removing a
-longstanding confusion. The current `stdio::flush` function will also move to
-this module and be renamed to `flush_print`.
-
-The entire `std::fmt::output` module will remain `#[unstable]` for now, however.
+The `set_stdout` and `set_stderr` functions will be removed with no replacement
+for now. It's unclear whether these functions should indeed control a thread
+local handle instead of a global handle as whether they're justified in the
+first place. It is a backwards-compatible extension to allow this sort of output
+to be redirected and can be considered if the need arises.
 
 ### `std::env`
 [std::env]: #stdenv

--- a/text/0517-io-os-reform.md
+++ b/text/0517-io-os-reform.md
@@ -1244,6 +1244,10 @@ standard primitives listed above:
 #### Raw stdio
 [Raw stdio]: #raw-stdio
 
+> **Note**: This section is intended to be a sketch of possible raw stdio
+>           support, but it is not planned to implement or stabilize this
+>           implementation at this time.
+
 The above standard input/output handles all involve some form of locking or
 buffering (or both). This cost is not always wanted, and hence raw variants will
 be provided. Due to platform differences across unix/windows, the following


### PR DESCRIPTION
Expand the section on stdin, stdout, and stderr while also adding a new section
explaining the fate of the current print-related functions.

[Rendered](https://github.com/rust-lang/rfcs/pull/899/files?short_path=0372b19#diff-0372b196bcfe91383c810c2ec4a968c5)