### PR TITLE
Retire RFC 8 (intrinsics) without implementing it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ the direction the language is evolving in.
 ## Active RFC List
 [Active RFC List]: #active-rfc-list
 
-* [0008-new-intrinsics.md](text/0008-new-intrinsics.md)
 * [0016-more-attributes.md](text/0016-more-attributes.md)
 * [0019-opt-in-builtin-traits.md](text/0019-opt-in-builtin-traits.md)
 * [0066-better-temporary-lifetimes.md](text/0066-better-temporary-lifetimes.md)

--- a/text/0008-new-intrinsics.md
+++ b/text/0008-new-intrinsics.md
@@ -2,6 +2,8 @@
 - RFC PR: [rust-lang/rfcs#8](https://github.com/rust-lang/rfcs/pull/8)
 - Rust Issue: 
 
+** Note: this RFC was never implemented. **
+
 # Summary
 
 The way our intrinsics work forces them to be wrapped in order to


### PR DESCRIPTION
This RFC changed the design of intrinsics with the goal of eliminating
the need for creating inlined wrappers around them. In the meantime,
the critical intrinsics for which this have been a problem have all
had their wrappers removed (afaik without solving the problem this
RFC set out to solve).

In the meantime, I decided I do not like the design here that unifies
intrinsics and lang items - they are sufficiently different to warrant
different names.

The ideas here have bitrotted and when we need to solve this for real
we should start over.