### PR TITLE
Specify that `bool` is compatible with the `_Bool` C type.

### DIFF
--- a/text/0000-cbool.md
+++ b/text/0000-cbool.md
@@ -9,15 +9,16 @@ Specify that `bool` is compatible with the `_Bool` C type.
 
 # Motivation
 
-You cannot safely call ffi functions with boolean arguments without a compatible type.
+You cannot safely call ffi functions with boolean arguments without a compatible
+type.
 
 # Detailed design
 
-Specify that `bool` is compatible with the `_Bool` C type and inform the compiler that `bool` is ffi safe.
+Specify that `bool` is compatible with the `_Bool` C type.
 
 # Drawbacks
 
-None right now. This should be a no-op on all supported platforms.
+None.
 
 # Alternatives
 

--- a/text/0000-cbool.md
+++ b/text/0000-cbool.md
@@ -1,0 +1,28 @@
+- Feature Name: cbool
+- Start Date: Mon Mar  9 00:16:53 CET 2015
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+Specify that `bool` is compatible with the `_Bool` C type.
+
+# Motivation
+
+You cannot safely call ffi functions with boolean arguments without a compatible type.
+
+# Detailed design
+
+Specify that `bool` is compatible with the `_Bool` C type and inform the compiler that `bool` is ffi safe.
+
+# Drawbacks
+
+None right now. This should be a no-op on all supported platforms.
+
+# Alternatives
+
+Define `_Bool` as a platform dependent integer type. This is unsafe because the behavior is supposedly undefined if you pass a value other than 0 or 1 to such a function.
+
+# Unresolved questions
+
+None.


### PR DESCRIPTION
Specify that `bool` is compatible with the `_Bool` C type.

[Rendered](https://github.com/mahkoh/rfcs/blob/cbool/text/0000-cbool.md)