### PR TITLE
change Seek API to be less enum-y

### DIFF
--- a/text/0517-io-os-reform.md
+++ b/text/0517-io-os-reform.md
@@ -955,23 +955,22 @@ directly if this is not desirable.
 [Seeking]: #seeking
 
 The seeking infrastructure is largely the same as today's, except that
-`tell` is removed and the `seek` signature is refactored with more precise
-types:
+`tell` is removed and the `seek` method is split up into three separate methods:
 
 ```rust
 pub trait Seek {
-    // returns the new position after seeking
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Error>;
-}
+    // returns the new position after seeking from the start
+    fn seek_from_start(&mut self, offset: u64) -> Result<u64, Error>;
 
-pub enum SeekFrom {
-    Start(u64),
-    End(i64),
-    Current(i64),
+    // returns the new position after seeking from the current position
+    fn seek_from_end(&mut self, offset: i64) -> Result<u64, Error>;
+
+    // returns the new position after seeking from the end
+    fn seek_from_current(&mut self, offset: i64) -> Result<u64, Error>;
 }
 ```
 
-The old `tell` function can be regained via `seek(SeekFrom::Current(0))`.
+The old `tell` function can be regained via `seek_from_current(0)`.
 
 #### Buffering
 [Buffering]: #buffering


### PR DESCRIPTION
The current `seek` API pretty closely mirrors the relevant OS APIs by having a single method with the seek-style specified as a runtime flag. However this just makes usage of the API more awkward. This API is logically 3 distinct methods that are being squashed into one by overloading on an enum variant. 

I consider this to be a popular "trap" in Rust API design; you see several similar methods and reason that they can in fact be unified be taking an enum, reducing the combinatorics and surface-area of the API. However this is simply shuffling the complexity from methods to variants. It requires the caller to pull the enum in scope, and since the prevailing style is to not pull in variants, leads to stuttery incantations like `reader.seek(SeekFrom::Start(offset))`. In addition it requires a newcomer to lookup what on earth SeekFrom even is.

Therefore this amendment proposes the following changes:

* `reader.seek(SeekFrom::Start(offset))` -> `reader.seek_from_start(offset)`
* `reader.seek(SeekFrom::Current(offset))` -> `reader.seek_from_current(offset)`
* `reader.seek(SeekFrom::End(offset))` -> `reader.seek_from_end(offset)`

Since the relevant OS APIs *are* a single method, this increases the implementation burden on library authors. However I believe that the Rust philosophy generally favours library *consumers* over *authors* (see e.g. where the burden of `unsafe` primarily lays). This particular API is one where implementation should be a rare one-off thing, while consumption is most certainly not.