### PR TITLE
Make `std::io` iterators more convenient

### DIFF
--- a/text/0000-io-iterators.md
+++ b/text/0000-io-iterators.md
@@ -1,0 +1,103 @@
+- Feature Name: 
+- Start Date: Fri Mar 13 20:25:02 CET 2015
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+Make `std::io` iterators more convenient by moving error handling out of the
+loop.
+
+# Motivation
+
+`ReadExt` and `BufReadExt` provide several iterators:
+
+* `BufReadExt::split` -> `Result<Vec<u8>>`
+* `BufReadExt::lines` -> `Result<String>`
+* `ReadExt::bytes` -> `Result<u8>`
+* `ReadExt::chars` -> `Result<char, CharsError>`
+
+For example, `BufReadExt::lines` can be used like this:
+
+```rust
+let mut reader = // A reader that implements `BufReadExt`.
+for line in reader.lines() {
+    let line: String = match line {
+        Ok(l) => l,
+        Err(e) => {
+            // Handle the error here (or don't.)
+            break;
+        },
+    };
+    // Work with the line here
+}
+```
+
+Some might consider `lines` a convenience method and would thus expect it to
+simply stop the loop upon the first error. The current design, however, make the
+user explicitly handle the error inside the loop.
+
+Others want to handle every io error in their code and if `lines` just stopped
+the loop upon the first error, they could not distinguish between errors and
+end-of-file.
+
+We try to find a middle ground between those two positions below.
+
+# Detailed design
+
+Change the signatures of the methods mentioned above to accept an error
+parameter. For example for `lines`:
+
+```rust
+fn lines(self, err: Option<&mut Option<Error>>) -> Lines<Self> { /* ... */ }
+
+impl<B: BufRead> Iterator for Lines<B> {
+    type Item = String;
+
+    // ....
+}
+```
+
+The `err` argument will be stored in `Lines`. Upon the first error, lines checks
+whether `err.is_some()`. If so, it stores the error in the reference. Either
+way, it will stop the loop.
+
+This function can then be used like this:
+
+```rust
+// No error handling:
+
+let mut reader = // A reader that implements `BufReadExt`
+for line in reader.lines(None) {
+    // Work with the line here
+}
+
+// Error handling:
+
+let mut reader = // A reader that implements `BufReadExt`
+let mut err = None;
+for line in reader.lines(Some(&mut err)) {
+    // Work with the line here
+}
+if let Some(err) = err {
+    // Handle the error here
+}
+```
+
+# Drawbacks
+
+None
+
+# Alternatives
+
+## What other designs have been considered?
+
+None
+
+## What is the impact of not doing this?
+
+See the motivation.
+
+# Unresolved questions
+
+None

--- a/text/0000-io-iterators.md
+++ b/text/0000-io-iterators.md
@@ -43,6 +43,8 @@ end-of-file.
 
 We try to find a middle ground between those two positions below.
 
+(See also https://mail.mozilla.org/pipermail/rust-dev/2014-February/thread.html#8708)
+
 # Detailed design
 
 Change the signatures of the methods mentioned above to accept an error

--- a/text/0000-io-iterators.md
+++ b/text/0000-io-iterators.md
@@ -49,7 +49,7 @@ Change the signatures of the methods mentioned above to accept an error
 parameter. For example for `lines`:
 
 ```rust
-fn lines(self, err: Option<&mut Option<Error>>) -> Lines<Self> { /* ... */ }
+fn lines(self, err: Option<&mut Result<(), Error>>) -> Lines<Self> { /* ... */ }
 
 impl<B: BufRead> Iterator for Lines<B> {
     type Item = String;
@@ -75,18 +75,37 @@ for line in reader.lines(None) {
 // Error handling:
 
 let mut reader = // A reader that implements `BufReadExt`
-let mut err = None;
+let mut err = Ok(());
 for line in reader.lines(Some(&mut err)) {
     // Work with the line here
 }
-if let Some(err) = err {
+if let Err(e) = err {
     // Handle the error here
 }
 ```
 
 # Drawbacks
 
-None
+Consider the following use of the current `lines`:
+
+```rust
+let mut reader = // A reader that implements `BufReadExt`.
+for line in reader.lines() {
+    let line = try!(line);
+    // Work with the line here
+}
+```
+
+And with the new one:
+
+```rust
+let mut reader = // A reader that implements `BufReadExt`.
+let mut err = Ok(());
+for line in reader.lines(Some(&mut err)) {
+    // Work with the line here
+}
+try!(err);
+```
 
 # Alternatives
 

--- a/text/0000-io-iterators.md
+++ b/text/0000-io-iterators.md
@@ -12,10 +12,10 @@ loop.
 
 `ReadExt` and `BufReadExt` provide several iterators:
 
-* `BufReadExt::split` -> `Result<Vec<u8>>`
-* `BufReadExt::lines` -> `Result<String>`
-* `ReadExt::bytes` -> `Result<u8>`
-* `ReadExt::chars` -> `Result<char, CharsError>`
+* `BufReadExt::split` iterates over `Result<Vec<u8>>`
+* `BufReadExt::lines` iterates over `Result<String>`
+* `ReadExt::bytes` iterates over `Result<u8>`
+* `ReadExt::chars` iterates over `Result<char, CharsError>`
 
 For example, `BufReadExt::lines` can be used like this:
 


### PR DESCRIPTION
Make `std::io` iterators more convenient by moving error handling out of the loop.

[Rendered](https://github.com/mahkoh/rfcs/blob/ioiters/text/0000-io-iterators.md)