### PR TITLE
RFC: Function pointers reform

### DIFF
--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -42,13 +42,14 @@ The following rules will apply:
 9. The `fn{f} -> fn` coercions between compatible `fn{f}`s and `fn`s are no longer valid.
 10. The `&fn{f} -> &fn` coercions between compatible `fn{f}`s and `fn`s are valid as unsizing coercions.
 
-An optional change that can be applied now or after Rust's final stabilization:
+Optional changes that can be applied now or after Rust's final stabilization:
 
-Make `fn{f}`s zero-sized statically to save space and better align with the fact that `fn`s are zero-sized dynamically.
+1. Make `fn{f}`s zero-sized statically to save space and better align with the fact that `fn`s are zero-sized dynamically.
+2. Make `&fn{f}`s implement closure traits for better symmetry between `fn{f}`s and `fn`s. 
 
 Notes:
 
-1. Currently, both `&fn{f}`s and `&fn`s are coercible to closure trait objects, but are not closures themselves. After the changes, they will be closures (`&fn`s) or coercible to closures (`&fn{f}`s).
+1. Currently, both `&fn{f}`s and `&fn`s are coercible to closure trait objects, but are not closures themselves. After the changes, they will be closures (`&fn`s) or coercible to closures (`&fn{f}`s). If the second optional change happens, then `&fn{f}`s will also be closures, without coercions.
 2. Source codes using `fn`s will have to use `&fn`s or `*const fn`s instead.
 3. In previous revisions of this RFC, `fn`s were going to be interpreted as types representing "function bodies", not "incomplete function items". But then it was pointed out that every type in Rust must have dynamically determinable sizes. This means, for `fn`s, the sizes must all be the same, because `&fn`s cannot actually carry any auxiliary data, or they will not be thin pointers. The obvious special size value here is zero. It would be weird for function bodies to be considered zero-sized, so `fn`s are reinterpreted as "incomplete function items".
 4. In previous revisions of this RFC, there were another optional change: implementing `Deref<Target=fn>`s on `fn{f}`s. This were intended to stress the fact that `fn{f}`s were themselves pointer-like constructs "pointing to" function bodies. But now that `fn`s will not be interpreted as "function bodies", this optional change will make no sense. Therefore it is dropped.

--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-Make Rust's current function pointer types unsized, and introduce function reference types and new function pointer types, in order to make function references/pointers work more like value references/pointers.
+Repurpose Rust's current function pointer types to denote "incomplete function items", and introduce function reference types and new function pointer types, so that function references/pointers work more like value references/pointers.
 
 This is based on [RFC 883](https://github.com/rust-lang/rfcs/pull/883) and related discussions, where the following design is already largely agreed upon, but the author of RFC 883 doesn't have time to revise it. Therefore, this RFC is created to push for the changes.
 
@@ -25,16 +25,16 @@ Thus, this RFC proposes the following solution.
 
 # Detailed design
 
-Make the current function pointer types unsized, and introduce function reference types of the form `&fn(arg_list) -> ret_type` and new (const) function pointer types of the form `*const fn(arg_list) -> ret_type`.
+Repurpose current function pointer types to denote "incomplete function items". Introduce function reference types of the form `&fn(arg_list) -> ret_type` and new function pointer types of the form `*const fn(arg_list) -> ret_type`.
 
 In the following section, `fn{f}`s, `fn`s, `&fn`s and `*const fn`s denote function item types, current function pointer types, function reference types and new function pointer types, respectively. Those types are considered "compatible" if their `(arg_list) -> ret_type` parts match.
 
 The following rules will apply:
 
-1. `fn{f}`s are still the function item types, or "function handles/proxies/values".
+1. `fn{f}`s are still function item types, or "function handles/proxies/values", whose representations and semantics remain unchanged.
 2. `fn`s are no longer function pointer types, but types representing "incomplete function items", which are unsized statically and zero-sized dynamically.
-3. `&fn`s are function reference types, DST pointers with "auxiliary data" of type `()`.
-4. `&fn`s and `*const fn`s work like normal references/pointers and casting between compatible `&fn`s and `*const fn`s is valid.
+3. `&fn`s are function reference types, DST pointers with auxiliary data of type `()`, and work like other references.
+4. `*const fn`s are raw function pointer types that work as normally expected, and casting between compatible `&fn`s and `*const fn`s is valid.
 5. There are no `&mut fn`s, also no `*mut fn`s.
 6. `fn{f}`s still implement the closure traits (`Fn`/`FnMut`/`FnOnce`).
 7. `fn`s still implement the closure traits, for keeping `&fn`s coercible to closure trait objects.

--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-Repurpose current function pointer types to mean "function bodies" or "incomplete function items". Introduce function reference types and new function pointer types, so that function references/pointers work more like value references/pointers.
+Repurpose current function pointer types to mean "function bodies". Introduce function reference types and new function pointer types, so that function references/pointers work more like value references/pointers.
 
 This is based on [RFC 883](https://github.com/rust-lang/rfcs/pull/883) and related discussions, where the following design is already largely agreed upon, but the author of RFC 883 doesn't have time to revise it. Therefore, this RFC is created to push for the changes.
 
@@ -88,11 +88,17 @@ let nullable_fn_ptr: *const fn() = ...; // consistent with nullable value pointe
 
 And stick with function pointers that aren't quite function pointers.
 
-## B. Allow `fn{f} -> &'static fn`, not `&fn{f} -> &fn`.
+## B. Make "`fn`s are dynamically zero sized" externally visible.
 
-It is a bit strange that a value type can be coerced to a reference type, though `fn{f}`s are indeed pointer-like in a way.
+And interpret `fn`s as "incomplete function items".
 
-## B. Make function item types truly donate functions.
+However, given that there are other "truly unsized" types, it is better to keep the implementation detail hidden, instead of coming up with an explanation for a special cased type that is "unsized statically but zero sized dynamically".
+
+## C. Allow `fn{f} -> &'static fn`, not `&fn{f} -> &fn`.
+
+It is a bit strange that a value type can be coerced to a reference type and the symmetry will be lost, though `fn{f}`s are indeed pointer-like in a way.
+
+## D. Make function item types truly denote functions.
 
 This alternative makes values of the type `fn{f}`s not copyable, and only `&fn{f}`s (and variations) can be passed around.
 
@@ -100,9 +106,9 @@ This has the advantage of having dedicated types for representing functions (new
 
 However, unlike function handles, function references/pointers cannot be zero-sized. Also, if `fn{f}`s are no longer `Copy`, more code will have to be changed to use `&fn{f}`, making this alternative a much larger-scale breaking change.
 
-## C. Make function item types `&'static fn{f}`s.
+## E. Make function item types `&'static fn{f}`s.
 
-Like Alternative B, this also rules out the possibility of zero-sized function handle types.
+Like Alternative D, this also rules out the possibility of zero-sized function handle types.
 
 # Unresolved questions
 

--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -71,7 +71,7 @@ boxed_hof(&foo); // still valid, `&foo` coerced to `&Fn()`, a closure trait obje
 let nullable_ptr_to_value: *const ValueType = ...; // for comparison
 let old_nullable_ptr_to_fn: Option<fn()> = ...; // currently valid, but a workaround, will be invalid
 let nullable_ref_to_fn: Option<&fn()> = ...; // directly replaces the above after the changes
-let nullable_ptr_to_fn: baz: *const fn() = ...; // consistent with nullable value pointers after the changes
+let nullable_ptr_to_fn: *const fn() = ...; // consistent with nullable value pointers after the changes
                                                 // (currently a nullable pointer to a non-null function pointer, not to a function)
 ```
 

--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -1,0 +1,90 @@
+- Feature Name: reformed_fn_pointers
+- Start Date: 2015-03-21
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+Make Rust's current function pointer types unsized, and introduce function reference types and new function pointer types, in order to make function references/pointers work more like value references/pointers.
+
+This is based on [RFC 883](https://github.com/rust-lang/rfcs/pull/883) and related discussions, where the following design is already largely agreed upon, but the author of RFC 883 doesn't have time to revise it. Therefore, this RFC is created to push for the changes.
+
+# Motivation
+
+Currently in Rust, there are two kinds of types that represent functions:
+
+1. Function item types: the types of function items, `fn(arg_list) -> ret_type {foo}`s.
+2. Function pointer types: the types of pointers to functions, `fn(arg_list) -> ret_type`s.
+
+Though called "function pointers", the function pointer types are considered *value* types (not reference/pointer types) by the language, which has the following problems:
+
+1. Inconsistencies in the language, especially when it comes to FFI codes that deal with nullable foreign function pointers. 
+2. There is currently no easy way to express the lifetime constraint on a function pointer to a non-`'static` function, which in particular makes it harder to implement type-safe JIT-ed functions/hot-loaded plugins in the future.
+
+Thus, this RFC proposes the following solution.
+
+# Detailed design
+
+Make the current function pointer types unsized, and introduce function reference types of the form `&fn(arg_list) -> ret_type` and new (const) function pointer types of the form `&const fn(arg_list) -> ret_type`.
+
+In the following section, `F`s denote function item types, `fn()`s, `&fn()`s and `*const fn()`s denote current function pointer types, function reference types and new function pointer types, respectively. Those types are considered "compatible" if their `arg_list -> ret_type` parts match.
+
+The following rules will apply:
+
+1. `F`s are still the function item types.
+2. `fn()`s are no longer function pointer types, but unsized types representing the bodies of functions.
+3. `&fn()`s are function reference types, DST pointers with "auxiliary data" of type `()`.
+4. `&fn()`s and `*const fn()`s work like normal references/pointers and casting between compatible `&fn()`s and `*const fn()`s is valid.
+5. There are no `&mut fn()`s, also no `*mut fn()`s.
+6. `F`s still implement the closure traits (`Fn`/`FnMut`/`FnOnce`).
+7. `fn()`s still implement the closure traits, for keeping `&fn()`s coercible to closure trait objects.
+8. `&fn()`s will implement the closure traits.
+9. The `F -> fn()` coercions between compatible `F`s and `fn()`s are no longer valid.
+10. The `&F -> &fn()` coercions between compatible `F`s and `fn()`s are valid as unsizing coercions.
+
+Notes:
+
+1. Currently, both `&F`s and `&fn()`s are coercible to closure trait objects, but are not closures themselves. After the changes, they will be closures (`&fn()`s) or coercible to closures (`&F`s).
+2. Source codes using `fn()`s will have to use `&fn()`s or `*const fn()`s instead.
+
+Optional changes that can be applied now or after Rust's final stabilization:
+
+1. Make `F`s zero-sized.
+2. Implement `Deref<Target=fn()>` on `F`s. This enables the `*` operator on `F` values, which doesn't seem to have practical uses. However, depending on how one interprets the nature of `F`s and `F -> fn()` coercions, this can be a desirable change. This change can stress the fact that `F`s are pointer-like (they are copyable handles to function bodies, not the function bodies themselves) and they see `&F -> &fn()`s as deref coercions.
+
+Examples:
+
+```rust
+fn foo() { ... }
+fn unboxed_hof<F: Fn()>(f: F) { ... }
+fn boxed_hof(f: &Fn()) { ... }
+
+let bar = foo; // still valid
+let old_ptr_to_foo: fn() = foo; // currently valid, but will be invalid
+let ref_to_foo: &fn() = &foo;
+let ptr_to_foo = ref_to_foo as *const fn();
+
+unboxed_hof(foo); // still valid
+unboxed_hof(&foo); // currently invalid, but will be valid, `&foo` coerced to `&fn()`, a closure
+boxed_hof(&foo); // still valid, `&foo` coerced to `&Fn()`, a closure trait object
+
+let nullable_ptr_to_value: *const ForeignType = ...; // for comparison
+let old_nullable_ptr_to_fn: Option<fn()> = ...; // currently valid, but a workaround, will be invalid
+let nullable_ref_to_fn: Option<&fn()> = ...; // directly replaces the above after the changes
+let nullable_ptr_to_fn: baz: *const fn() = ...; // consistent with nullable value pointers after the changes
+                                                // (currently a nullable pointer to a non-null function pointer, not to a function)
+```
+
+# Drawbacks
+
+This involves breaking changes.
+
+However, currently function pointers are not used much. (See [this comment](https://github.com/rust-lang/rfcs/pull/883#issuecomment-76291284) for some statistics.)
+
+# Alternatives
+
+Please see [RFC 883](https://github.com/rust-lang/rfcs/pull/883) and related discussions for the various alternatives.
+
+# Unresolved questions
+
+None.

--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -27,30 +27,30 @@ Thus, this RFC proposes the following solution.
 
 Make the current function pointer types unsized, and introduce function reference types of the form `&fn(arg_list) -> ret_type` and new (const) function pointer types of the form `&const fn(arg_list) -> ret_type`.
 
-In the following section, `F`s denote function item types, `fn()`s, `&fn()`s and `*const fn()`s denote current function pointer types, function reference types and new function pointer types, respectively. Those types are considered "compatible" if their `arg_list -> ret_type` parts match.
+In the following section, `fn{f}`s denote function item types, `fn`s, `&fn`s and `*const fn`s denote current function pointer types, function reference types and new function pointer types, respectively. Those types are considered "compatible" if their `arg_list -> ret_type` parts match.
 
 The following rules will apply:
 
-1. `F`s are still the function item types.
-2. `fn()`s are no longer function pointer types, but unsized types representing the bodies of functions.
-3. `&fn()`s are function reference types, DST pointers with "auxiliary data" of type `()`.
-4. `&fn()`s and `*const fn()`s work like normal references/pointers and casting between compatible `&fn()`s and `*const fn()`s is valid.
-5. There are no `&mut fn()`s, also no `*mut fn()`s.
-6. `F`s still implement the closure traits (`Fn`/`FnMut`/`FnOnce`).
-7. `fn()`s still implement the closure traits, for keeping `&fn()`s coercible to closure trait objects.
-8. `&fn()`s will implement the closure traits.
-9. The `F -> fn()` coercions between compatible `F`s and `fn()`s are no longer valid.
-10. The `&F -> &fn()` coercions between compatible `F`s and `fn()`s are valid as unsizing coercions.
+1. `fn{f}`s are still the function item types.
+2. `fn`s are no longer function pointer types, but unsized types representing the bodies of functions.
+3. `&fn`s are function reference types, DST pointers with "auxiliary data" of type `()`.
+4. `&fn`s and `*const fn`s work like normal references/pointers and casting between compatible `&fn`s and `*const fn`s is valid.
+5. There are no `&mut fn`s, also no `*mut fn`s.
+6. `fn{f}`s still implement the closure traits (`Fn`/`FnMut`/`FnOnce`).
+7. `fn`s still implement the closure traits, for keeping `&fn`s coercible to closure trait objects.
+8. `&fn`s will implement the closure traits.
+9. The `fn{f} -> fn` coercions between compatible `fn{f}`s and `fn`s are no longer valid.
+10. The `&fn{f} -> &fn` coercions between compatible `fn{f}`s and `fn`s are valid as unsizing coercions.
 
 Notes:
 
-1. Currently, both `&F`s and `&fn()`s are coercible to closure trait objects, but are not closures themselves. After the changes, they will be closures (`&fn()`s) or coercible to closures (`&F`s).
-2. Source codes using `fn()`s will have to use `&fn()`s or `*const fn()`s instead.
+1. Currently, both `&fn{f}`s and `&fn`s are coercible to closure trait objects, but are not closures themselves. After the changes, they will be closures (`&fn`s) or coercible to closures (`&fn{f}`s).
+2. Source codes using `fn`s will have to use `&fn`s or `*const fn`s instead.
 
 Optional changes that can be applied now or after Rust's final stabilization:
 
-1. Make `F`s zero-sized.
-2. Implement `Deref<Target=fn()>` on `F`s. This enables the `*` operator on `F` values, which doesn't seem to have practical uses. However, depending on how one interprets the nature of `F`s and `F -> fn()` coercions, this can be a desirable change. This change can stress the fact that `F`s are pointer-like (they are copyable handles to function bodies, not the function bodies themselves) and they see `&F -> &fn()`s as deref coercions.
+1. Make `fn{f}`s zero-sized.
+2. Implement `Deref<Target=fn()>` on `fn{f}`s. This enables the `*` operator on `fn{f}` values, which doesn't seem to have practical uses. However, depending on how one interprets the nature of `fn{f}`s and `fn{f} -> fn` coercions, this can be a desirable change. For some, this change can stress the fact that `fn{f}`s are pointer-like (they are copyable handles to function bodies, not the function bodies themselves) and they see `&fn{f} -> &fn`s as deref coercions.
 
 Examples:
 
@@ -68,7 +68,7 @@ unboxed_hof(foo); // still valid
 unboxed_hof(&foo); // currently invalid, but will be valid, `&foo` coerced to `&fn()`, a closure
 boxed_hof(&foo); // still valid, `&foo` coerced to `&Fn()`, a closure trait object
 
-let nullable_ptr_to_value: *const ForeignType = ...; // for comparison
+let nullable_ptr_to_value: *const ValueType = ...; // for comparison
 let old_nullable_ptr_to_fn: Option<fn()> = ...; // currently valid, but a workaround, will be invalid
 let nullable_ref_to_fn: Option<&fn()> = ...; // directly replaces the above after the changes
 let nullable_ptr_to_fn: baz: *const fn() = ...; // consistent with nullable value pointers after the changes

--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -58,7 +58,7 @@ fn boxed_hof(f: &Fn()) { ... }
 
 let bar = foo; // valid and unchanged
 let old_fn_ptr: fn() = foo; // currently valid, but will be invalid
-let fn_ref: &fn() = &foo; // the new `&fn{f} -> &fn` coercion
+let fn_ref: &'static fn() = &foo; // the new `&fn{f} -> &fn` coercion
 let fn_ptr = fn_ref as *const fn(); // the new `&fn -> *const fn` cast
 
 unboxed_hof(foo); // valid and unchanged

--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -31,8 +31,8 @@ In the following section, `fn{f}`s, `fn`s, `&fn`s and `*const fn`s denote functi
 
 The following rules will apply:
 
-1. `fn{f}`s are still the function item types.
-2. `fn`s are no longer function pointer types, but unsized types representing the bodies of functions.
+1. `fn{f}`s are still the function item types, or "function handles/proxies/values".
+2. `fn`s are no longer function pointer types, but types representing "incomplete function items", which are unsized statically and zero-sized dynamically.
 3. `&fn`s are function reference types, DST pointers with "auxiliary data" of type `()`.
 4. `&fn`s and `*const fn`s work like normal references/pointers and casting between compatible `&fn`s and `*const fn`s is valid.
 5. There are no `&mut fn`s, also no `*mut fn`s.
@@ -42,15 +42,16 @@ The following rules will apply:
 9. The `fn{f} -> fn` coercions between compatible `fn{f}`s and `fn`s are no longer valid.
 10. The `&fn{f} -> &fn` coercions between compatible `fn{f}`s and `fn`s are valid as unsizing coercions.
 
+An optional change that can be applied now or after Rust's final stabilization:
+
+Make `fn{f}`s zero-sized statically to save space and better align with the fact that `fn`s are zero-sized dynamically.
+
 Notes:
 
 1. Currently, both `&fn{f}`s and `&fn`s are coercible to closure trait objects, but are not closures themselves. After the changes, they will be closures (`&fn`s) or coercible to closures (`&fn{f}`s).
 2. Source codes using `fn`s will have to use `&fn`s or `*const fn`s instead.
-
-Optional changes that can be applied now or after Rust's final stabilization:
-
-1. Make `fn{f}`s zero-sized.
-2. Implement `Deref<Target=fn()>` on `fn{f}`s. This enables the `*` operator on `fn{f}` values, which doesn't seem to have practical uses. However, depending on how one interprets the nature of `fn{f}`s and `&fn{f} -> &fn` coercions, this can be a desirable change. For some, this change can stress the fact that `fn{f}`s are pointer-like (they are copyable handles to function bodies, not the function bodies themselves) and they see `&fn{f} -> &fn`s as deref coercions.
+3. In previous revisions of this RFC, `fn`s were going to be interpreted as types representing "function bodies", not "incomplete function items". But then it was pointed out that every type in Rust must have dynamically determinable sizes. This means, for `fn`s, the sizes must all be the same, because `&fn`s cannot actually carry any auxiliary data, or they will not be thin pointers. The obvious special size value here is zero. It would be weird for function bodies to be considered zero-sized, so `fn`s are reinterpreted as "incomplete function items".
+4. In previous revisions of this RFC, there were another optional change: implementing `Deref<Target=fn>`s on `fn{f}`s. This were intended to stress the fact that `fn{f}`s were themselves pointer-like constructs "pointing to" function bodies. But now that `fn`s will not be interpreted as "function bodies", this optional change will make no sense. Therefore it is dropped.
 
 Examples:
 

--- a/text/0000-reformed-fn-pointers.md
+++ b/text/0000-reformed-fn-pointers.md
@@ -84,21 +84,21 @@ let nullable_fn_ptr: *const fn() = ...; // consistent with nullable value pointe
 
 # Alternatives
 
-## A. Keep the status quo.
+#### A. Keep the status quo.
 
 And stick with function pointers that aren't quite function pointers.
 
-## B. Make "`fn`s are dynamically zero sized" externally visible.
+#### B. Make "`fn`s are dynamically zero sized" externally visible.
 
 And interpret `fn`s as "incomplete function items".
 
 However, given that there are other "truly unsized" types, it is better to keep the implementation detail hidden, instead of coming up with an explanation for a special cased type that is "unsized statically but zero sized dynamically".
 
-## C. Allow `fn{f} -> &'static fn`, not `&fn{f} -> &fn`.
+#### C. Allow `fn{f} -> &'static fn`, not `&fn{f} -> &fn`.
 
 It is a bit strange that a value type can be coerced to a reference type and the symmetry will be lost, though `fn{f}`s are indeed pointer-like in a way.
 
-## D. Make function item types truly denote functions.
+#### D. Make function item types truly denote functions.
 
 This alternative makes values of the type `fn{f}`s not copyable, and only `&fn{f}`s (and variations) can be passed around.
 
@@ -106,7 +106,7 @@ This has the advantage of having dedicated types for representing functions (new
 
 However, unlike function handles, function references/pointers cannot be zero-sized. Also, if `fn{f}`s are no longer `Copy`, more code will have to be changed to use `&fn{f}`, making this alternative a much larger-scale breaking change.
 
-## E. Make function item types `&'static fn{f}`s.
+#### E. Make function item types `&'static fn{f}`s.
 
 Like Alternative D, this also rules out the possibility of zero-sized function handle types.
 


### PR DESCRIPTION
Repurpose Rust's current function pointer types to denote "incomplete function items", and introduce function reference types and new function pointer types, so that function references/pointers work more like value references/pointers.

This is based on #883 and related discussions, where the design is already largely agreed upon. The author of #883, @Ericson2314 is too busy to update that RFC, so this RFC is created.

[Rendered](https://github.com/CloudiDust/rfcs/blob/reformed-fn-pointers/text/0000-reformed-fn-pointers.md)