### PR TITLE
Disjoins (anonymous enums)

### DIFF
--- a/text/0000-disjoins.md
+++ b/text/0000-disjoins.md
@@ -5,6 +5,8 @@
 # Summary
 
 This is a resurrection/expansion of [an older RFC](https://github.com/rust-lang/rust/issues/8277).
+It also requires [the `!` RFC](https://github.com/rust-lang/rfcs/pull/1216) as
+a prerequisite.
 
 Rust supports both kinds of composite algebraic data type: product types
 (structs) and sum types (enums). Rust has anonymous structs (tuples) but no
@@ -52,7 +54,10 @@ signify OR instead of AND.
 
 # Motivation
 
-Disjoins fill an analogous role to tuples. They're useful where the programmer needs a single-use type who's usage will be localised to a small area of code.
+Disjoins are the natural extension of the anonymous empty enum type `!`.
+
+Disjoins fill an analogous role to tuples. They're useful where the programmer
+needs a single-use type who's usage will be localised to a small area of code.
 
 For example, consider this code:
 
@@ -87,126 +92,38 @@ one-hole-context type operator.
 
     ohc!(T, (i32, T, T)) ==> ((!, T, T) | (i32, (), T) | (i32, T, ()))
 
+Disjoins will become especially useful if Rust ever adds a way to define
+methods over generically-sized tuples. For example, it would also be possible
+to write a function that selects an item from a tuple.
+
+    match select((2i32, 'a', true)) {
+        (i|!|!) => println!("got an i32: {:?}", i),
+        (!|c|!) => println!("got a char: {:?}", c),
+        (!|!|b) => println!("got a bool: {:?}", b),
+    }
+
+Disjoins would also be necessary if we ever wanted a way to extract the
+representation of a type in the form of a type. Disjoins would be needed as the
+anonymous form of enums:
+
+    struct Foo { x: i32, y: char }
+    enum Bar { X(i32), Y(char) }
+
+    <Foo as Anonymous>::Anon == (i32, char)
+    <Bar as Anonumous>::Anon == (i32 | char)
+
 Like with tuples, disjoins should only be used where the meaning of the
 variants will be obvious. For things like argument/return types on public
 methods, named enums should be used instead.
 
-Another motivation for disjoins is that they require a syntax for the empty
-disjoin type. This makes them the perfect vehicle for bringing `!` into the
-type system.
-
-## The `!` type
-
-I've prosthelytised before that `!` should be treated as a type but have been met
-with skepticism. So I'll start with what I think is an accurate analogy. In
-C/C++, `void` is in essence a type like any other. It is the trivial type with
-one value, equivalent to a struct type with no members and can be trivially
-cast from any other type (by simply throwing away the value).  However it can't
-be used in all the normal positions where a type can be used. This breaks
-generic code (eg. `T foo(); T val = foo()` where `T == void`) and forces one to
-use workarounds such as defining `struct Void {}` and wrapping `void`-returning
-functions:
-  
-```c
-Void foo_wrap() {
-  foo();
-  return {};
-};
-```
-
-If in the 1960s, when PL theory was young, someone had suggested to Dennis
-Ritchie to allow `void` to be used a function argument, as a struct member and
-everywhere else a type could be used, he may well have said something like
-"That doesn't make sense. `void` isn't a type, it's just a special syntax for
-declaring functions with no return value, why would you want a `void` function
-argument anyway?". So instead, the `void` type gets treated as a second class
-citizen, adding extra hassle and complexity to the language for no benefit.
-  
-Fast-forward fifty years...
-
-Rust, building on decades of experience, decides to fix C's shortsightedness
-and bring `void` into the type system in the form of the empty tuple `()`.
-Rust also introduces a new composite data kind, dual to the notion of structs,
-in the form of enums. These are a somewhat innovative feature, most major
-languages don't have them (eg. C), and those that do often don't permit empty
-enums like Rust does (eg. Haskell). However Rust also introduces a syntax for
-declaring functions that never return: `fn() -> !`. Here, `!` is in essence a
-type like any other. It is the trivial type with no values, equivalent to an
-enum type with no variants, and can be trivially cast to any other type
-(because it has no values).  However it can't be used in all the normal
-positions where a type can be used. This breaks generic code (eg. `fn foo() ->
-T; let val: T = foo()` where `T == !`) and forces one to use workarounds such
-as defining `enum Void {}` and wrapping `!`-returning functions.
-
-```rust
-fn foo_wrap() -> Void {
-  foo()
-};
-```
-
-However when it's suggested to allow `!` to be used as a function argument, as
-a struct member and everywhere else a type can be used people often respond
-with something like "That doesn't make sense. `!` isn't a type, it's a special
-syntax for declaring functions that don't return, why would you want a `!`
-function argument anyway?". So instead, the `!` type gets treated as a second
-class citizen, adding extra hassle and complexity to the language for no
-benefit.
-
-`!` has a meaning in any situation that any other type does. A `!` function
-argument makes a function uncallable, a `Vec<!>` is a vector that can never
-contain an element, a `!` enum variant makes the variant guaranteed never to
-occur and so forth. It might seem pointless to use a `!` function argument or a
-`Vec<!>` (just as it would be pointless to use a `()` function argument or a
-`Vec<()>`), but that's no reason to disallow it. And generic code sometimes
-requires it. There's at least two cases of this:
-  * Functions of the type `fn() -> !` cannot satisfy the `Fn() -> T` trait. As
-    such diverging functions can't be passed to generic higher-order functions.
-  * There is no standard way to express types like `Result<T, !>` causing 
-    library authors to implement their own, incompatible implementations of
-    `enum Void {}`. (`Result<T, !>` is useful when implementing a trait method
-    of type `Result<T, E>` and you know the implementation will never return
-    `Err`)
-
-Promoting `!` to a type and allowing it to unify with all other types would
-give it the same behavior as the current `!` syntax, except generalized,
-allowing more kinds of correct code to exist.
-
-It's worth making clear the difference between `struct Void {}` (ie `void`, ie.
-`()`) and `enum Void {}` (ie. `!`). We can think of `struct` and `enum` as
-being dual type operators where `struct {A, B, C}` is `A AND B AND C` and `enum
-{A, B, C}` is `A OR B OR C`. `()` and `!` are then the identities of these
-operators in the sense that adding a `()` member to a struct does not change
-the overall structure of the type (because the member is always instantiated
-with `()` and thus does nothing) and adding a `!` variant to an enum does not
-change the overall structure of the type (because the member can never be
-instantiated and thus does nothing). The reason `()` and `!` have historically
-been neglected as types is that they're so trivial that it doesn't occur to
-people that they even *are* types. `()` only has one value and so it's not
-interesting. Something that can only be in one state cannot carry information
-and a type with that doesn't carry any information has no obvious use in a
-language. `!` has no values and so it's not interesting. A type with no values
-can never exist and a type that can never exist has no obvious use in a
-language.
-
-However they are types, they have their use cases and an algebraic type system
-is not complete without both of them.
-
 # Detailed design
 
 Disjoins have the exact same semantics as named enums and behave the same in
-terms of code generation, representation etc. Code that handles the empty
-disjoin type should be marked unreachable and eliminated where possible.
-Functions that return it should be marked with the llvm `NoReturn` attribute.
-The above should also apply to empty named enums.
-
-The typechecker should allow `!` to unify with all other types.
-
-The existing compiler support for diverging functions (eg. `FnDiverging`)
-should be removed/replaced.
+terms of code generation, representation etc.
 
 # Drawbacks
 
-Adds it's own complexity to the type system and compiler.
+Adds complexity to the type system and compiler.
 
 # Alternatives
 
@@ -218,12 +135,7 @@ Adds it's own complexity to the type system and compiler.
 * Change the syntax? This might be necessary if the suggested syntax turns out
   to be ambiguous (see: Unresolved Questions). The `!` in disjoin expressions
   and patterns could be changed to another character although `!` already
-  has connotations of "no value".
-* Just promote `!` to a type. Although `!` fits naturally into a scheme
-  of anonymous enums this would still be a worthwhile change if done
-  independently. This would be a smaller change in the sense that it would
-  involve removing restrictions on an existing feature rather than adding a
-  whole new feature.
+  has connotations of "no value". Also the suggested syntax seems unpopular.
 
 # Unresolved questions
 
@@ -231,9 +143,4 @@ Is the suggested syntax unambiguous? The '|' character is already used for
 closures, bitwise OR and disjunctive match patterns. The '!' character is used
 for the not-operator and negative trait bounds. I can't see any of these being
 a problem but I'm not sure.
-
-Could `!` be treated as a subtype of all other types? Theoretically, yes, but
-the implementation might be a headache. Allowing `!` to unify with all other
-types would be simpler and good enough for most cases. And we don't treat `()`
-as a supertype of all other types either.
 

--- a/text/0000-disjoins.md
+++ b/text/0000-disjoins.md
@@ -1,0 +1,200 @@
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+This is a resurrection/expansion of [an older RFC](https://github.com/rust-lang/rust/issues/8277).
+
+Rust supports both kinds of composite algebraic data type: product types
+(structs) and sum types (enums). Rust has anonymous structs (tuples) but no
+anonymous enums, leaving a gap in it's type system.
+
+                    named      anonymous
+                 ------------------------
+                 |           |          |
+        products |  structs  |  tuples  |
+                 |           |          |
+                 ------------------------
+                 |           |          |
+            sums |   enums   |    ??    |
+                 |           |          |
+                 ------------------------
+                 |           |          |
+    exponentials | functions | closures |
+                 |           |          |
+                 ------------------------
+
+This RFC proposes to add anonymous enums to Rust and suggests naming them
+disjoins (as in disjoint unions).
+
+```rust
+let foo: (char | i32 | i32) = (!|!|123);
+match foo {
+  (c|!|!) => println!("char in position zero: {:?}", c),
+  (!|i|!) => println!("i32 in position one: {}", i),
+  (!|!|i) => println!("i32 in position two: {}", i),
+};
+
+let foo: (char|) = ('a'|);
+match foo {
+  (c|)  => println!("char in position zero: {:?}", c),
+};
+
+let foo: ! = panic!("no value");
+match foo {
+};
+
+```
+
+# Motivation
+
+Disjoins fill an analogous role to tuples. They're useful where the programmer needs a single-use type who's usage will be localised to a small area of code.
+
+For example, consider this code:
+
+```
+fn some_function() -> Result<i32, io::Error> {
+  ...
+
+  fn inner_helper_function() -> Result<char, (io::Error | Utf8Error)> {
+    ...
+  }
+
+  match inner_helper_function() {
+    Ok(c)  => ...,
+    Err(e) => match e {
+      (io_err|!)  => return Err(io_err),
+      (!|u8_err)  => ...,
+    },
+  };
+  ...
+}
+```
+
+Here, defining a type `enum IoOrUtf8Error { ... }` would have been possible,
+but would have been overkill because it would only have been used in one place.
+The type would also had to have been defined somewhere outside of
+`some_function` which would have spread out the relevant code and made it less
+readable.
+
+Disjoins are also useful in situations where having unnamed variants is the
+natural choice. For example, with disjoins it would be possible to define a
+one-hole-context type operator.
+
+    ohc!(T, (i32, T, T)) ==> ((!, T, T) | (i32, (), T) | (i32, T, ()))
+
+Like with tuples, disjoins should only be used where the meaning of the
+variants will be obvious. For things like argument/return types on public
+methods, named enums should be used instead.
+
+Another motivation for disjoins is that they require a syntax for the empty
+disjoin type. This makes them the perfect vehicle for bringing `!` into the
+type system.
+
+## The `!` type
+
+I've prosthelytised before that `!` should be treated as a type but have been met
+with skepticism. So I'll start with what I think is an accurate analogy. In
+C/C++, `void` is in essence a type like any other. It is the trivial type with
+one value, equivalent to a struct type with no members and can be trivially
+cast from any other type (by simply throwing away the value).  However it can't
+be used in all the normal positions where a type can be used. This breaks
+generic code (eg. `T foo(); T val = foo()` where `T == void`) and forces one to
+use workarounds such as defining `struct Void {}` and wrapping `void`-returning
+functions:
+  
+```c
+Void foo_wrap() {
+  foo();
+  return {};
+};
+```
+
+If in the 1960s, when PL theory was young, someone had suggested to Dennis
+Ritchie to allow `void` to be used a function argument, as a struct member and
+everywhere else a type could be used, he may well have said something like
+"That doesn't make sense. `void` isn't a type, it's just a special syntax for
+declaring functions with no return value, why would you want a `void` function
+argument anyway?". So instead, the `void` type gets treated as a second class
+citizen, adding extra hassle and complexity to the language for no benefit.
+  
+Fast-forward fifty years...
+
+Rust, building on decades of experience, decides to fix C's shortsightedness
+and bring `void` into the type system in the form of the empty tuple `()`.
+Rust also introduces a new composite data kind, dual to the notion of structs,
+in the form of enums. These are a somewhat innovative feature, most major
+languages don't have them (eg. C), and those that do often don't permit empty
+enums like Rust does (eg. Haskell). However Rust also introduces a syntax for
+declaring functions that never return: `fn() -> !`. Here, `!` is in essence a
+type like any other. It is the trivial type with no values, equivalent to an
+enum type with no variants, and can be trivially cast to any other type
+(because it has no values).  However it can't be used in all the normal
+positions where a type can be used. This breaks generic code (eg. `fn foo() ->
+T; let val: T = foo()` where `T == !`) and forces one to use workarounds such
+as defining `enum Void {}` and wrapping `!`-returning functions.
+
+```rust
+fn foo_wrap() -> Void {
+  foo()
+};
+```
+
+However when it's suggested to allow `!` to be used as a function argument, as
+a struct member and everywhere else a type can be used people often respond
+with something like "That doesn't make sense. `!` isn't a type, it's a special
+syntax for declaring functions that don't return, why would you want a `!`
+function argument anyway?". So instead, the `!` type gets treated as a second
+class citizen, adding extra hassle and complexity to the language for no
+benefit.
+
+`!` has a meaning in any situation that any other type does. A `!` function
+argument makes a function uncallable, a `Vec<!>` is a vector that can never
+contain an element, a `!` enum variant makes the variant guaranteed never to
+occur and so forth. It might seem pointless to use a `!` function argument or a
+`Vec<!>` (just as it would be pointless to use a `()` function argument or a
+`Vec<()>`), but that's no reason to disallow it. And generic code sometimes
+requires it. There's at least two cases of this:
+  * Functions of the type `fn() -> !` cannot satisfy the `Fn() -> T` trait. As
+    such diverging functions can't be passed to generic higher-order functions.
+  * There is no standard way to express types like `Result<T, !>` causing 
+    library authors to implement their own, incompatible implementations of
+    `enum Void {}`. (`Result<T, !>` is useful when implementing a trait method
+    of type `Result<T, E>` and you know the implementation will never return
+    `Err`)
+
+Promoting `!` to a type and allowing it to unify with all other types would
+give it the same behavior as the current `!` syntax, except generalized,
+allowing more kinds of correct code to exist.
+
+# Detailed design
+
+Disjoins have the exact same semantics as named enums and behave the same in
+terms of code generation, representation etc. Code that handles the empty
+disjoin type should be marked unreachable and eliminated where possible.
+Functions that return it should be marked with the llvm `NoReturn` attribute.
+The above should also apply to empty named enums.
+
+The typechecker should treat `!` as a subtype of, and allow it to unify with,
+all other types.
+
+The existing compiler support for diverging functions (eg. `FnDiverging`)
+should be removed/replaced.
+
+# Drawbacks
+
+Adds it's own complexity to the type system and compiler.
+
+# Alternatives
+
+* Do Nothing.
+* Some have suggested non-positional disjoint union types (ie. where (T | T) is
+  isomorphic to T). However these aren't enums, aren't algebraic, and would add
+  enormous complexity to Rust's type system compared to positional disjoint
+  unions.
+
+# Unresolved questions
+
+None AFAICS.
+


### PR DESCRIPTION
[Rendered view](https://github.com/canndrew/rfcs/blob/master/text/0000-disjoins.md)

**Edit 2:** I have split off a separate RFC for the `!` type [here](https://github.com/rust-lang/rfcs/pull/1216). This RFC now assumes that RFC as a prerequisite.

**Edit:** A lot of people are getting stuck on this point so it bears further clarification. `()` and `!` are not the same type. They are related, but different. `()` is the type with **one** value, `!` is the type with ***zero*** values. What this means:
  * A function with return type `()` can only return `()`. This why you don't need a return statement in such a function, because there's only one thing it can possibly return. A function with return type `!` can *never return at all* - because there's nothing that it could return.
  * A variable of type `()` can only be assigned one value (ie. the value `()`). A variable of type `!` can *never be assigned a value at all*. This doesn't mean you can't use them, for example it's totally okay to write `let x: ! = panic!()` because `panic!()` never returns. You could also write a function that takes a `!` argument - but that function could never be called.
  * Likewise, an enum variant of type `!` can never exist. For example, a value of type `Result<T, !>` is guaranteed to be `Ok` because there's nothing the `Err` variant could hold. Contrast this with `Result<T, ()>` which has a value `Err(())`.
  * Code that handles a variable of type `!` never executes. This is enforced at compile time by the type-checker. Rust doesn't allow uninitialized variables and it's impossible to write (safe) code that initializes a `!`.
  * `!` can be mapped to any other type. To see why this is so consider the definition of a (pure) function: A function assigns to every value in it's domain a value in it's codomain. For example, to specify a function `fn foo(x: bool) -> i32` we need to specify the values of `foo(true)` and `foo(false)`. For this we can use something like `match x { true => 23, false => 34}`. Likewise, to specify a function `fn bar(x: !) -> i32` we need to specify a value for each possible `x` - of which there are none. We could write the function body as `match x {}`. This works because there is one match branch for each possible `x` and every branch returns an `i32`. If you find yourself asking "but what value does that return?", ask yourself "for what x?" and then look at the match statement again. Also, remember that that match statement can never execute.
  * `!` can be thought of as a subtype of every other type. Every `!` is also a `String`, and an `i32`, and a `char` etc. This is true for the same reason that `Iterator::all` returns `true` on an empty iterator - there are no counterexamples. By contrast, the same is not true of `()`. The value `()` is not a `String`, or an `i32`, or a `char` etc. This RFC proposed to allow `!` to unify with any other type (as it already does) meaning that a variable of type `!` can be treated as any type.
  * `()` can be thought of as being an empty *value* (the value `()` has no bits of information). `!` is an empty *type* (the type `!` has not inhabitants). They both mean "nothing", but it's a different "nothing".

Note that `!` is not new or in any way special. We already have all these behaviours with empty enums. Given `enum Empty {}` and `e: Empty` we know:
  * A function that returns `Empty` diverges.
  * A function that takes an `Empty` can never be called
  * `e` can never be assigned a value
  * The code that handles `e` will never execute.
  * a `Result<T, Empty>` can only be `Ok`, never `Err`
  * `e` can be mapped into any type with `match e {}`
