### PR TITLE
pretty print `Debug` of tuples, tuple structs and enum variants in a single line

### DIFF
--- a/text/0640-debug-improvements.md
+++ b/text/0640-debug-improvements.md
@@ -134,8 +134,8 @@ HashMap {
     "c": 3
 }
 ```
-* Struct and tuple struct output is printed with one field per line, indented
-    four spaces, and fields printed with the `#` modifier as well: e.g.
+* Struct and struct variant output is printed with one field per line,
+indented four spaces, and fields printed with the `#` modifier as well: e.g.
 ```rust
 Foo {
     field1: "hi",
@@ -143,12 +143,16 @@ Foo {
     field3: false
 }
 ```
+* Tuple, tuple struct and enum variant output is printed in a single line,
+without adding newlines after any field: e.g.
 ```rust
-Foo(
-    "hi",
-    10,
-    false
-)
+("hi", 10, false)
+```
+```rust
+Foo("hi", 10, false)
+```
+```rust
+Some(1)
 ```
 
 In all cases, pretty printed and non-pretty printed output should differ *only*


### PR DESCRIPTION
Currently, `println!("{:#?}", Some(1));` *pretty* print output as, with newlines and indent:

```
Some(
    1
)
```

But I don't think it is **pretty** print: it's weird and ugly, no one write code like this. It is not a preferred code style also.

`Some(1)` itself, without adding newlines and indent, is pretty well.

Tuples were already implemented, in 1.0 stable, to pretty print in a single line, without adding newlines and indents. So we should do the same for tuple structs and enum variants, for consistency.