### PR TITLE
specify that CoerceUnsized should ignore PhantomData fields

### DIFF
--- a/text/0982-dst-coercion.md
+++ b/text/0982-dst-coercion.md
@@ -176,3 +176,9 @@ indicate the field type which is coerced, for example).
 # Unresolved questions
 
 None
+
+# Updates since being accepted
+
+Since it was accepted, the RFC has been updated as follows:
+
+1. `CoerceUnsized` was specified to ingore PhantomData fields.

--- a/text/0982-dst-coercion.md
+++ b/text/0982-dst-coercion.md
@@ -113,7 +113,7 @@ in the `Target` type. Assuming `Fs` is the type of a field in `Self` and `Ft` is
 the type of the corresponding field in `Target`, then either `Ft <: Fs` or
 `Fs: CoerceUnsized<Ft>` (note that this includes some built-in coercions, coercions
 unrelated to unsizing are excluded, these could probably be added later, if needed).
-* There must be only one field that is coerced.
+* There must be only one non-PhantomData field that is coerced.
 * We record for each impl, the index of the field in the `Self` type which is
 coerced.
 
@@ -135,7 +135,7 @@ is auto-deref'ed, but not autoref'ed.
 ### On encountering an adjustment (translation phase)
 
 * In trans (which is post-monomorphisation) we should always be able to find an
-impl for any `CoerceUnsized` bound. 
+impl for any `CoerceUnsized` bound.
 * If the impl is for a built-in pointer type, then we use the current coercion
 code for the various pointer kinds (`Box<T>` has different behaviour than `&` and
 `*` pointers).

--- a/text/0982-dst-coercion.md
+++ b/text/0982-dst-coercion.md
@@ -175,7 +175,11 @@ indicate the field type which is coerced, for example).
 
 # Unresolved questions
 
-None
+It is unclear to what extent DST coercions should support multiple fields that
+refer to the same type parameter. `PhantomData<T>` should definitely be
+supported as an "extra" field that's skipped, but can all zero-sized fields
+be skipped? Are there cases where this would enable by-passing the abstractions
+that make some API safe?
 
 # Updates since being accepted
 


### PR DESCRIPTION
Otherwise you can't have a `Smaht<T>(*const T, PhantomData<T>)`, which is problematic for drop check, which requires this annotation if Smaht owns the referrent (Box, Rc, Vec, etc..).

See https://github.com/rust-lang/rust/issues/26905 for some discussion.

You could arguably ignore all zero-sized fields, but it's currently hard for the compiler to do so (size is largely a trans notion, to my knowledge). Also maybe you actually want a generic ZST field that has some meaning beyond PhantomData?

A potential workaround to this problem would be `Smaht(*const u8, PhantomData<T>)` but this is entering a fairly degenerate state for the semantics of raw pointers. Although we're already in a bit of a degenerate state in that all Smaht pointers desire some level of mutable access, but are forced to use `*const` to acquire the correct variance. We paper over that mess via Unique -- we could consider just embracing that and making Unique the only proper way to build Smaht pointers. 

Of course Unique is incorrect for Rc, but I plan on adding a Shared equivalent for Rc anyway which could have similar magicks.