### PR TITLE
RFC: #[deprecated] for Everyone

### DIFF
--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -40,13 +40,14 @@ strongly advised to make use of it to convey the reason for the deprecation to
 users of their library. The string is interpreted as plain unformatted text 
 (for now) so that rustdoc can include it in the item's documentation without 
 messing up the formatting.
-* `use`, if included, must be the import path (or a comma-separated list of 
+* `use`, if included, must be the import path (or a semicolon-delimited list of 
 paths) to a set of API items that will replace the functionality of the 
 deprecated item. All crates in scope can be reached by this path. E.g. let's 
 say my `foo()` item was superceded by either the `bar()` or `baz()` functions
-in the `bar` crate, I can `#[deprecate(use="bar::{bar,baz}")] foo()`, as long 
-as I have the `bar` crate in the library path. Rustc checks if the item is 
-actually available, otherwise returning an error.
+in the `bar` crate, in conjunction with the `bruzz(_)` function in the `baz`
+crate, I can `#[deprecate(use="bar::{bar,baz};baz::bruzz")] foo()`, as long 
+as I have the `bar` and `baz` crates in the library path. Rustc checks if the 
+item is actually available, otherwise returning an error.
 
 On use of a *deprecated* item, `rustc` will `warn` of the deprecation. Note 
 that during Cargo builds, warnings on dependencies get silenced. Note that 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -9,7 +9,7 @@ This RFC proposes to allow library authors to use a `#[deprecated]` attribute,
 with optional `since = "`*version*`"`, `reason = "`*free text*`"` and 
 `use = "`*substitute declaration*`"` fields. The compiler can then
 warn on deprecated items, while `rustdoc` can document their deprecation
-accordingly. 
+accordingly.
 
 # Motivation
 
@@ -29,29 +29,26 @@ Public API items (both plain `fn`s, methods, trait- and inherent
 fields and enum variants) can be given a `#[deprecated]` attribute. All
 possible fields are optional:
 
-* `since` is defined to contain the exact version of the crate that
-deprecated the item, as defined by Cargo.toml (thus following the semver
-scheme). It makes no sense to put a version number higher than the current
-newest version here, and this is not checked (but could be by external
-lints, e.g. [rust-clippy](https://github.com/Manishearth/rust-clippy).
-To maximize usefulness, the version should be fully specified (e.g. no
-wildcards or ranges).
+* `since` is defined to contain the version of the crate at the time of
+deprecating the item, following the semver scheme. It makes no sense to put a 
+version number higher than the current newest version here, and this is not 
+checked (but could be by external lints, e.g. 
+[rust-clippy](https://github.com/Manishearth/rust-clippy).
 * `reason` should contain a human-readable string outlining the reason for
 deprecating the item. While this field is not required, library authors are
-strongly advised to make use of it to convey the reason to users of their
-library. The string is required to be plain unformatted text (for now) so that
-rustdoc can include it in the item's documentation without messing up the 
-formatting.
-* `use` should be the full path to an API item that will replace the 
-functionality of the deprecated item, optionally (if the replacement is in a 
-different crate) followed by `@` and either a crate name (so that 
-`https://crates.io/crates/` followed by the name is a live link) or the URL to 
-a repository or other location where a surrogate can be obtained. Links must be 
-plain FTP, FTPS, HTTP or HTTPS links. The intention is to allow rustdoc (and
-possibly other tools in the future, e.g. IDEs) to act on the included 
-information. The `use` field can have multiple values.
+strongly advised to make use of it to convey the reason for the deprecation to 
+users of their library. The string is interpreted as plain unformatted text 
+(for now) so that rustdoc can include it in the item's documentation without 
+messing up the formatting.
+* `use`, if included, must be the import path (or a comma-separated list of 
+paths) to a set of API items that will replace the functionality of the 
+deprecated item. All crates in scope can be reached by this path. E.g. let's 
+say my `foo()` item was superceded by either the `bar()` or `baz()` functions
+in the `bar` crate, I can `#[deprecate(use="bar::{bar,baz}")] foo()`, as long 
+as I have the `bar` crate in the library path. Rustc checks if the item is 
+actually available, otherwise returning an error.
 
-On use of a *deprecated* item, `rustc` should `warn` of the deprecation. Note 
+On use of a *deprecated* item, `rustc` will `warn` of the deprecation. Note 
 that during Cargo builds, warnings on dependencies get silenced. Note that 
 while this has the upside of keeping things tidy, it has a downside when it 
 comes to deprecation:
@@ -62,11 +59,11 @@ try to build `foobar` directly. We may want to create a service like `crater`
 to warn on use of deprecated items in library crates, however this is outside
 the scope of this RFC.
 
-`rustdoc` should show deprecation on items, with a `[deprecated since x.y.z]`
-box that may optionally show the reason and/or link to the replacement if
-available.
+`rustdoc` will show deprecation on items, with a `[deprecated]`
+box that may optionally show the version, reason and/or link to the replacement 
+if available.
 
-The language reference should be extended to describe this feature as outlined
+The language reference will be extended to describe this feature as outlined
 in this RFC. Authors shall be advised to leave their users enough time to react
 before *removing* a deprecated item.
 
@@ -83,7 +80,7 @@ quite complex.
 
 * Do nothing
 * make the `since` field required and check that it's a single version
-* Optionally the deprecation lint chould check the current version as set by
+* Optionally the deprecation lint could check the current version as set by
 cargo in the CARGO_CRATE_VERSION environment variable (the rust build process 
 should set this environment variable, too). This would allow future 
 deprecations to be shown in the docs early, but not warned against by the
@@ -93,13 +90,12 @@ be `Allow` by default)
 * `reason` could include markdown formatting
 * The `use` could simply be plain text, which would remove much of the
 complexity here
-* The `use` field contents could make use of the context in finding
-replacements, e.g. extern crates, so that `time::precise_time_ns` would resolve
-to the `time::precise_time_ns` API in the `time` crate, provided an
-`extern crate time;` declaration is present
 * The `use` field could be left out and added later. However, this would
 lead people to describe a replacement in the `reason` field, as is already
 happening in the case of rustc-private deprecation
+* Optionally, `cargo` could offer a new dependency category: "doc-dependencies"
+which are used to pull in other crates' documentations to link them (this is
+obviously not only relevant to deprecation).
 
 # Unresolved questions
 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -6,10 +6,9 @@
 # Summary
 
 This RFC proposes to allow library authors to use a `#[deprecated]` attribute,
-with optional `since = "`*version*`"`, `reason = "`*free text*`"` and 
-`use = "`*substitute declaration*`"` fields. The compiler can then
-warn on deprecated items, while `rustdoc` can document their deprecation
-accordingly.
+with optional `since = "`*version*`"` and `reason = "`*free text*`"`fields. The 
+compiler can then warn on deprecated items, while `rustdoc` can document their 
+deprecation accordingly.
 
 # Motivation
 
@@ -30,29 +29,20 @@ fields and enum variants) can be given a `#[deprecated]` attribute. All
 possible fields are optional:
 
 * `since` is defined to contain the version of the crate at the time of
-deprecating the item, following the semver scheme. It makes no sense to put a 
-version number higher than the current newest version here, and this is not 
-checked (but could be by external lints, e.g. 
-[rust-clippy](https://github.com/Manishearth/rust-clippy).
+deprecating the item, following the semver scheme. Rustc does not know about
+versions, thus the content of this field is not checked (but will be by external
+lints, e.g. [rust-clippy](https://github.com/Manishearth/rust-clippy).
 * `reason` should contain a human-readable string outlining the reason for
 deprecating the item. While this field is not required, library authors are
 strongly advised to make use of it to convey the reason for the deprecation to 
 users of their library. The string is interpreted as plain unformatted text 
 (for now) so that rustdoc can include it in the item's documentation without 
 messing up the formatting.
-* `use`, if included, must be the import path (or a semicolon-delimited list of 
-paths) to a set of API items that will replace the functionality of the 
-deprecated item. All crates in scope can be reached by this path. E.g. let's 
-say my `foo()` item was superceded by either the `bar()` or `baz()` functions
-in the `bar` crate, in conjunction with the `bruzz(_)` function in the `baz`
-crate, I can `#[deprecate(use="bar::{bar,baz};baz::bruzz")] foo()`, as long 
-as I have the `bar` and `baz` crates in the library path. Rustc checks if the 
-item is actually available, otherwise returning an error.
 
 On use of a *deprecated* item, `rustc` will `warn` of the deprecation. Note 
-that during Cargo builds, warnings on dependencies get silenced. Note that 
-while this has the upside of keeping things tidy, it has a downside when it 
-comes to deprecation:
+that during Cargo builds, warnings on dependencies get silenced. While this has 
+the upside of keeping things tidy, it has a downside when it comes to 
+deprecation:
 
 Let's say I have my `llogiq` crate that depends on `foobar` which uses a
 deprecated item of `serde`. I will never get the warning about this unless I
@@ -60,9 +50,8 @@ try to build `foobar` directly. We may want to create a service like `crater`
 to warn on use of deprecated items in library crates, however this is outside
 the scope of this RFC.
 
-`rustdoc` will show deprecation on items, with a `[deprecated]`
-box that may optionally show the version, reason and/or link to the replacement 
-if available.
+`rustdoc` will show deprecation on items, with a `[deprecated]` box that may 
+optionally show the version and reason where available.
 
 The language reference will be extended to describe this feature as outlined
 in this RFC. Authors shall be advised to leave their users enough time to react
@@ -71,38 +60,69 @@ before *removing* a deprecated item.
 The internally used feature can either be subsumed by this or possibly renamed
 to avoid a name clash.
 
+# Intended Use
+
+Crate author Anna wants to evolve her crate's API. She has found that one
+type, `Foo`, has a better implementation in the `rust-foo` crate. Also she has
+written a `frob(Foo)` function to replace the earlier `Foo::frobnicate(self)`
+method. 
+
+So Anna first bumps the version of her crate (because deprecation is always
+done on a version change) from `0.1.1` to `0.2.1`. She also adds the following 
+prefix to the `Foo` type:
+
+```
+extern crate rust_foo;
+
+#[deprecated(since = "0.2.1", use="rust_foo::Foo", 
+    reason="The rust_foo version is more advanced, and this crates' will likely be discontinued")]
+struct Foo { .. }
+```
+
+Users of her crate will see the following once they `cargo update` and `build`:
+
+```
+src/foo_use.rs:27:5: 27:8 warning: Foo is marked deprecated as of version 0.2.1
+src/foo_use.rs:27:5: 27:8 note: The rust_foo version is more advanced, and this crates' will likely be discontinued
+```
+
+Rust-clippy will likely gain more sophisticated checks for deprecation:
+
+* `future_deprecation` will warn on items marked as deprecated, but with a
+version lower than their crates', while `current_deprecation` will warn only on
+those items marked as deprecated where the version is equal or lower to the
+crates' one.
+* `deprecation_syntax` will check that the `since` field really contains a
+semver number and not some random string.
+
+Clippy users can then activate the clippy checks and deactivate the standard
+deprecation checks.
+
 # Drawbacks
 
-* The required checks for the `since` and `use` fields are potentially
-quite complex.
 * Once the feature is public, we can no longer change its design
 
 # Alternatives
 
 * Do nothing
 * make the `since` field required and check that it's a single version
-* Optionally the deprecation lint could check the current version as set by
-cargo in the CARGO_CRATE_VERSION environment variable (the rust build process 
-should set this environment variable, too). This would allow future 
-deprecations to be shown in the docs early, but not warned against by the
-stability lint (there could however be a `future-deprecation` lint that should
-be `Allow` by default)
 * require either `reason` or `use` be present
 * `reason` could include markdown formatting
-* The `use` could simply be plain text, which would remove much of the
-complexity here
-* The `use` field could be left out and added later. However, this would
-lead people to describe a replacement in the `reason` field, as is already
-happening in the case of rustc-private deprecation
+* rename the `reason` field to `note` to clarify it's broader usage.
+* add a `note` field and make `reason` a field with specific meaning, perhaps
+even predefine a number of valid reason strings, as JEP277 currently does
+* Add a `use` field containing a plain text of what to use instead
+* Add a `use` field containing a path to some function, type, etc. to replace
+the current feature. Currently with the rustc-private feature, people are 
+describing a replacement in the `reason` field, which is clearly not the 
+original intention of the field
 * Optionally, `cargo` could offer a new dependency category: "doc-dependencies"
 which are used to pull in other crates' documentations to link them (this is
-obviously not only relevant to deprecation).
+obviously not only relevant to deprecation)
 
 # Unresolved questions
 
 * What other restrictions should we introduce now to avoid being bound to a 
 possibly flawed design?
-* How should the multiple values in the `use` field work? Just split by
-comma or some other delimiter?
 * Can / Should the `std` library make use of the `#[deprecated]` extensions?
 * Bikeshedding: Are the names good enough?

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -21,7 +21,7 @@ We want to:
 1. evolve the `std` API, including making items unavailable with new 
 versions
 2. with minimal -- next to no -- breakage
-3. be able to plug security/safety holes 
+3. be able to plug security/safety holes
 4. avoid confusing users
 5. stay backwards-compatible so people can continue to use dependencies 
 written for older versions (except where point 3. forbids this)
@@ -33,18 +33,20 @@ successful, and since the 1.0.0 release, there is an expectation of
 stability. Therefore the first order of business when evolving the
 `std` API is: **Don't break people's code**. 
 
-In practice there will be some qualification, e.g. if an API is
-*inherently* unsafe, it should be acceptable to remove it completely,
-as any code using it was in fact broken to begin with. Therefore it is
-acceptable to make this code stop working altogether.
+In practice there will be some qualification, e.g. if an API is 
+*inherently* unsafe, it should be acceptable make it completely 
+unavailable, as any code using it was in fact broken to begin with. 
+Therefore it is acceptable to make this code stop working altogether, 
+as long as the resulting error is not too confusing (which again means 
+we should make the item inaccessible instead of removing it).
 
-On the other hand, if an API permits unsafe uses, and a safer 
-alternative is available, we may want to *retroactively deprecate* it, 
-so that people will get warnings even if they specified an older target 
-version. We may want to have a different kind of warning than the 
+If an API permits unsafe uses, and a safer alternative is available, we 
+may want to mark it as insecure in addition to deprecating it, so that 
+people will get warnings even if they specified an older target 
+version. We want to have a different kind of warning than the 
 standard deprecation warning, as there are already some crates (e.g. 
 compiletest.rs) on crates.io that declare `#![deny(deprecate)]`, so 
-those warnings would turn to errors. 
+those warnings would turn to errors.
 
 We also really want to make features inaccessible in a newer version, 
 not just mark them as deprecated. Otherwise we would bloat our APIs 
@@ -126,18 +128,35 @@ not declare a version to give the target version requirement more
 weight to library authors. 
 
 `rustc` should use this target version definition to check for 
-deprecated items. If no target version is defined, deprecation checking 
-is deactivated (as we cannot assume a specific rust version), however a 
-warning stating the same should be issued (as with cargo – we should 
-probably make cargo not warn on build to get rid of duplicate 
-warnings). Otherwise, use of API items whose `since` attribute is less 
-or equal to the target version of the crate should trigger a warning, 
-while API items whose `removed_at` attribute is less or equal to the 
-target version should trigger an error. 
+deprecated items. If the target version is specified, use of API items 
+whose `since` attribute is less or equal to the target version of the 
+crate should trigger a warning, while API items whose `removed_at` 
+attribute is less or equal to the target version should trigger an 
+error.
 
-Also if the target definition has a higher version than `rustc`, it
-should warn that it probably has to be updated in order to build the
-crate.
+We can also define a `future deprecation` lint set to `Allow` by 
+default to allow people being proactive about items that are going to
+be deprecated. 
+
+Also if the target definition has a higher version than `rustc`, it 
+should briefly warn that it probably has to be updated in order to 
+build the crate. However, `rustc` should try to build the code anyway; 
+further errors may give the user additional information.
+
+If *no* target version is defined, deprecation checking is deactivated 
+(as we cannot assume a specific rust version), however a note 
+stating the same should be printed (as with cargo – we should probably 
+make cargo not warn on build to get rid of duplicate warnings). Since
+all current code comes without a target version, we have to assume
+a minimal version 1.0.0.
+
+In addition to the note, the `std` authors could opt to create a new 
+`#[since="1.2.0"]` attribute, which would allow rustc to infer the 
+minimal target version of some code from the API features it uses in 
+absence of a specified version. Deprecation warnings/errors should then 
+refer to the inferred target versions as well as the APIs that led to 
+the inference of the latest version (at least perhaps on calling 
+`rustc` with `-v`).
 
 `rustdoc` should mark deprecated APIs as such (e.g. make them in a 
 lighter gray font) and relegate removed APIs to a section below all 
@@ -145,6 +164,24 @@ others (and that may be hidden via a checkbox). We should not
 completely remove the documentation, as users of libraries that target 
 old versions may still have a use for them, but neither should we let 
 them clutter the docs. 
+
+## Dealing with insecure items
+
+Since just removing insecure items, though tempting, would lead to user 
+confusion, a new `#[insecure(reason = "...")]` attribute should be 
+added to all insecure API items. An `insecure_api` lint that by default 
+raises `Error` can catch all uses of those items. To distinguish 
+between items *some uses of which* may be insecure and *inherently* 
+insecure items, either a second entry `inherent = true` could be added 
+or a `#[maybe_insecure(reason = "...")]` annotation could take the 
+latter part.
+
+The rationale for defining a separate attribute is that it avoids 
+mixing separate concerns (versioning and security), and that we want to
+allow warnings/errors on dependencies regardless of specified target
+versions. It also allows us to show the reason (from the attr) in the
+lint message, which will be specific to the insecurity at hand and 
+hopefully be helpful to the user.
 
 ## Policy
 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -33,16 +33,24 @@ successful, and since the 1.0.0 release, there is an expectation of
 stability. Therefore the first order of business when evolving the
 `std` API is: **Don't break people's code**. 
 
-In practice there will be some qualification, e.g. if fixing a security 
-hole requires breaking an API, it is nonetheless acceptable, because 
-the API was broken to begin with, as is code using it. So breaking this
-code is acceptable.  
+In practice there will be some qualification, e.g. if an API is
+*inherently* unsafe, it should be acceptable to remove it completely,
+as any code using it was in fact broken to begin with. Therefore it is
+acceptable to make this code stop working altogether.
 
-On the other hand, we really want to make features inaccessible in a
-newer version, not just mark them as deprecated. Otherwise we would
-bloat our APIs with deprecated features that no one uses (see Java). To
-do this, it's not enough to hide the feature from the docs, as that
-would be confusing (see point 4.) to those who encounter a hidden API.
+On the other hand, if an API permits unsafe uses, and a safer 
+alternative is available, we may want to *retroactively deprecate* it, 
+so that people will get warnings even if they specified an older target 
+version. We may want to have a different kind of warning than the 
+standard deprecation warning, as there are already some crates (e.g. 
+compiletest.rs) on crates.io that declare `#![deny(deprecate)]`, so 
+those warnings would turn to errors. 
+
+We also really want to make features inaccessible in a newer version, 
+not just mark them as deprecated. Otherwise we would bloat our APIs 
+with deprecated features that no one uses (see Java). To do this, it's 
+not enough to hide the feature from the docs, as that would be 
+confusing (see point 4.) to those who encounter a hidden API.
 
 Not breaking code also mean we do not want to have the deprecation 
 feature interfere with a project's dependencies, which would teach 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -1,0 +1,42 @@
+- Feature Name: A plan for deprecating APIs within Rust
+- Start Date: 2015-06-03
+- RFC PR: 
+- Rust Issue: 
+
+# Summary
+
+There has been an ongoing [discussion on internals](https://internals.rust-lang.org/t/thoughts-on-aggressive-deprecation-in-libstd/2176/55) about how we are going to evolve the standard library. This RFC tries to condense the consensus
+
+# Motivation
+
+We want to guide the deprecation efforts to allow std to evolve freely to get the best possible API while ensuring minimum-breakage backwards compatibility for users and allow std authors to remove API items for a given version of Rust. Basically have our cake and eat it. Yum, cake.
+
+Of course we cannot really keep and remove a feature at the same time. To square this circle, we can follow the process outlined herein.
+
+# Detailed design
+
+We already declare deprecation in terms of Rust versions (like "1.0", "1.2"). The current attribute looks like `#[deprecated(since = "1.0.0", reason="foo")]`. This should be extended to add an optional `removed_at` key, to state that the item should be made inaccessible at that version. Note that while this allows for marking items as deprecated, there is absolutely no provision to actually *remove* items. In fact this proposal bans removing an API type outright, unless security concerns are deemed more important than the resulting breakage from removing it or the API item has some fault that means it cannot be used correctly at all (thus leaving the API in place would result in the same level of breakage than removing it).
+
+Currently every rustc version implements only its own version, having multiple versions is possible using something like multirust, though this does not work within a build. Also currently rustc versions do not guarantee interoperability. This RFC aims to change this situation.
+
+First, crates should state their target version using a `#![version = "1.0.0"]` attribute. Cargo should insert the current rust version by default on `cargo new` and *warn* if no version is defined on all other commands. It may optionally *note* that the specified target version is outdated on `cargo package`. [crates.io](https://crates.io) may deny packages that do not declare a version to give the target version requirement more weight to library authors. Cargo should also be able to hold back a new library version if its declared target version is newer than the rust version installed on the system. In those cases, cargo should emit a warning urging the user to upgrade their rust installation.
+
+`rustc` should use this target version definition to check for deprecated items. If no target version is defined, deprecation checking is deactivated (as we cannot assume a specific rust version), however a warning stating the same should be issued (as with cargo – we should probably make cargo not warn on build to get rid of duplicate warnings). Otherwise, use of API items whose `since` attribute is less or equal to the target version of the crate should trigger a warning, while API items whose `removed_at` attribute is less or equal to the target version should trigger an error.
+
+`rustdoc` should mark deprecated APIs as such (e.g. make them in a lighter gray font) and relegate removed APIs to a section below all others (and that may be hidden via a checkbox). We should not completely remove the documentation, as users of libraries that target old versions may still have a use for them, but neither should we let them clutter the docs. 
+
+# Drawbacks
+
+By requiring full backwards-compatibility, we will never be able to actually remove stuff from the APIs, which will probably lead to some bloat. 
+
+# Alternatives
+
+* Follow a more agressive strategy that actually removes stuff from the API. This would make it easier for the libstd creators at some cost for library and application writers, as they are required to keep up to date or face breakage
+* Hide deprecated items in the docs: This could be done either by putting them into a linked extra page or by adding a "show deprecated" checkbox that may be default be checked or not, depending on who you ask. This will however confuse people, who see the deprecated APIs in some code, but cannot find them in the docs anymore
+* Allow to distinguish "soft" and "hard" deprecation, so that an API can be marked as "soft" deprecated to dissuade new uses before hard deprecation is decided. Allowing people to specify deprecation in future version appears to have much of the same benefits without needing a new attribute key.
+* Decide deprecation on a per-case basis. This is what we do now. The proposal just adds a well-defined process to it
+* Never deprecate anything. Evolve the API by adding stuff only. Rust would be crushed by the weight of its own cruft before 2.0 even has a chance to land. Users will be uncertain which APIs to use
+
+# Unresolved questions
+
+Should we allow library writers to use the same features for deprecating their API items?

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -12,14 +12,15 @@ anyones code.
 
 Namely the following items:
 
-1. Add a `--target=`*<version string> command line argument to rustc.
+1. Add a `--target-version=`*<version string> command line argument to rustc.
 This will be used for deprecation checking and for selecting code paths
 in the compiler.
 2. Add an (optional for now) `rust = "..."` dependency to Cargo.toml,
 which `cargo new` pre-fills with the current rust version
-3. Allow `std` APIs to declare an `#[insecure(level="Warn", reason="...")]` 
-attribute that will produce a warning or error, depending on level,
-that cannot be switched off (even with `-Awarning`)
+3. Allow `std` APIs to declare an 
+`#[insecure(level="Warn", reason="...")]`  attribute that will produce 
+a warning or error, depending on level, that cannot be switched off 
+(even with `-Awarning`)
 4. Add a `removed_at="..."` item to `#[deprecated]` attributes that 
 allows making API items unavailable starting from certain target 
 versions. 
@@ -126,12 +127,12 @@ make no provisions for it. Thus proposal item 3.
 
 Cargo parses the additional `rust = "..."` dependency as if it was a 
 library. The usual rules for version parsing apply. If no `rust` 
-dependency is supplied, it can either default to `*`.
+dependency is supplied, it defaults to `*`.
 
 Cargo should also supply the current Rust version (which can be either
 supplied by calling `rustc -V` or by linking to a rust library defining
 a version object) on `cargo new`. Cargo supplies the given target 
-version to `rustc` via the `--target` command line argument.
+version to `rustc` via the `--target-version` command line argument.
 
 Cargo *may* also warn on `cargo package` if no `rust` version was 
 supplied. [crates.io](https://crates.io) *could* require a version
@@ -140,9 +141,9 @@ attribute on upload and display the required rust version on the site.
 One nice aspect of this is that `rust` looks just like yet another
 dependency and effectively follows the same rules.
 
-`rustc` needs to accept the `--target <version>` command line argument.
-If no argument is supplied, `rustc` defaults to its own version. The
-same version syntax as Cargo applies:
+`rustc` needs to accept the `--target-version <version>` command line 
+argument. If no argument is supplied, `rustc` defaults to its own 
+version. The same version syntax as Cargo applies:
 
 * `*` effectively means *any version*. For API items, it means
 deprecation checking is disabled. For language changes, it means using

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -206,11 +206,19 @@ decades, so it appears the tradeoff has seen some confirmation already.
 
 # Alternatives
 
-* Opt-in and / or opt-out "feature-flags" (e.g. `#[legacy(..)]` for 
-opting out of a change) was suggested. The big problem is that this 
-relies on the user being able to change their dependencies, which may 
-not be possible for legal, organizational or other reasons. In 
-contrast, a defined target version doesn't ever need to change. 
+* Have a flag in `Cargo.toml` instead of the crate root. This however 
+requires an argument to `rustc`, because Cargo (in addition to those 
+not using it) somehow has to pass it to `rustc`. Requiring such an 
+argument on every non-cargoized build would increase room for error and 
+thus pessimize usability. Also apart from availability of dependencies, 
+which arguably is Cargo's main raison d'être, we currently do not have 
+a precedent where Cargo.toml has direct effect on the working of a 
+crate's code.
+* Opt-in and / or opt-out "feature-flags" (e.g. `#[legacy(..)]`) was 
+suggested. The big problem is that this relies on the user being able 
+to change their dependencies, which may not be possible for legal, 
+organizational or other reasons. In contrast, a defined target version 
+doesn't ever need to change. 
 Depending on the specific case, it may be useful to allow a combination 
 of `#![legacy(..)]`, `#![future(..)]` and `#![target(..)]` where each 
 API version can declare the currently active feature and permit or

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -15,19 +15,21 @@ Namely the following items:
 1. Add a `--target-version=`*<version string>* command line argument to 
 rustc. This will be used for deprecation checking and for selecting 
 code paths in the compiler.
-2. Add an (optional for now) `rust = "..."` dependency to Cargo.toml,
-which `cargo new` pre-fills with the current rust version 
-(alternatively this could be a package attribute)
+2. Add an optional `rust = "..."` package attribute to Cargo.toml, 
+which `cargo new` pre-fills with the current rust version.
 3. Allow `std` APIs to declare an 
 `#[insecure(level="Warn", reason="...")]`  attribute that will produce 
 a warning or error, depending on level, that cannot be switched off 
 (even with `-Awarning`)
 4. Add a `removed_at="..."` item to `#[deprecated]` attributes that 
 allows making API items unavailable starting from certain target 
-versions. 
+versions.
 5. Add a number of warnings to steer users in the direction of using 
 the most recent Rust version that makes sense to them, while making it 
 easy for library writers to support a wide range of Rust versions
+6. (optional) add a `legacy="..."` item to `#[deprecated]` attributes
+that allows grouping API items under a legacy flag that is already 
+defined in RFC #1122 (see below)
 
 ## Background
 
@@ -129,9 +131,9 @@ make no provisions for it. Thus proposal item 3.
 
 # Detailed design
 
-Cargo parses the additional `rust = "..."` dependency as if it was a 
-library. The usual rules for version parsing apply. If no `rust` 
-dependency is supplied, it defaults to `*`.
+Cargo parses the additional `rust = "..."` package attribute. The usual 
+rules for version parsing apply. If no `rust` attribute is supplied, it 
+defaults to `*`.
 
 Cargo should also supply the current Rust version (which can be either
 supplied by calling `rustc -V` or by linking to a rust library defining
@@ -139,11 +141,12 @@ a version object) on `cargo new`. Cargo supplies the given target
 version to `rustc` via the `--target-version` command line argument.
 
 Cargo *may* also warn on `cargo package` if no `rust` version was 
-supplied. [crates.io](https://crates.io) *could* require a version
-attribute on upload and display the required rust version on the site.
+supplied. A few versions in the future, Cargo could also warn of 
+missing version attributes on build or other actions, at least if the 
+crate is a library.
 
-One nice aspect of this is that `rust` looks just like yet another
-dependency and effectively follows the same rules.
+[crates.io](https://crates.io) *could* require a version attribute on 
+upload and display the required rust version on the site.
 
 `rustc` needs to accept the `--target-version <version>` command line 
 argument. If no argument is supplied, `rustc` defaults to its own 
@@ -202,7 +205,9 @@ to specifically allow usage of the grouped APIs, thus selectively
 removing the deprecation warning.
 
 This would create a nice feature parity between language code paths and
-`std` API deprecation checking.
+`std` API deprecation checking. Also it would lessen the pain for users
+who want to upgrade their systems one feature at a time and can use the
+legacy flags to effectively manage their usage of deprecated items.
 
 # Drawbacks
 
@@ -250,4 +255,4 @@ needing a new attribute key.
 
 # Unresolved questions
 
-Should the rust = "<version>" be a *dependency* or a package attribute?
+None

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -130,6 +130,15 @@ decades, so it appears the tradeoff has seen some confirmation already.
 
 # Alternatives
 
+* Opt-in and / or opt-out "feature-flags" (e.g. `#[legacy(..)]` for 
+opting out of a change) was suggested. The big problem is that this 
+relies on the user being able to change their dependencies, which may 
+not be possible for legal, organizational or other reasons. In 
+contrast, a defined target version doesn't ever need to change. 
+Depending on the specific case, it may be useful to allow a combination 
+of `#![legacy(..)]`, `#![future(..)]` and `#![target(..)]` where each 
+API version can declare the currently active feature and permit or
+forbid use of the opt-in/out flags.
 * Follow a more agressive strategy that actually removes stuff from the 
 API. This would make it easier for the libstd creators at some cost for 
 library and application writers, as they are required to keep up to 
@@ -155,4 +164,5 @@ authors to join the process
 # Unresolved questions
 
 Should we allow library writers to use the same features for 
-deprecating their API items?
+deprecating their API items? I think we should at least make sure that
+our design and implementation allow this in the future.

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -12,11 +12,12 @@ anyones code.
 
 Namely the following items:
 
-1. Add a `--target-version=`*<version string> command line argument to rustc.
-This will be used for deprecation checking and for selecting code paths
-in the compiler.
+1. Add a `--target-version=`*<version string>* command line argument to 
+rustc. This will be used for deprecation checking and for selecting 
+code paths in the compiler.
 2. Add an (optional for now) `rust = "..."` dependency to Cargo.toml,
-which `cargo new` pre-fills with the current rust version
+which `cargo new` pre-fills with the current rust version 
+(alternatively this could be a package attribute)
 3. Allow `std` APIs to declare an 
 `#[insecure(level="Warn", reason="...")]`  attribute that will produce 
 a warning or error, depending on level, that cannot be switched off 
@@ -24,8 +25,8 @@ a warning or error, depending on level, that cannot be switched off
 4. Add a `removed_at="..."` item to `#[deprecated]` attributes that 
 allows making API items unavailable starting from certain target 
 versions. 
-5. Add a number of warnings to steer users in the direction of using the
-most recent Rust version that makes sense to them, while making it 
+5. Add a number of warnings to steer users in the direction of using 
+the most recent Rust version that makes sense to them, while making it 
 easy for library writers to support a wide range of Rust versions
 
 ## Background
@@ -39,8 +40,8 @@ As a background, in no particular order:
 * [#1122 Language SemVer](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md)
 * [#1150 Rename Attribute](https://github.com/rust-lang/pull/1150)
 
-In addition, there has been an ongoing [discussion on 
-internals](https://internals.rust-lang.org/t/thoughts-on-aggressive-deprecation-in-libstd/2176/55) 
+In addition, there has been an ongoing 
+[discussion on internals](https://internals.rust-lang.org/t/thoughts-on-aggressive-deprecation-in-libstd/2176/55) 
 about how we are going to evolve the standard library, which this
 proposal is mostly based on.
 
@@ -90,10 +91,13 @@ The following motivates items 2, 4 and 5.
 
 Currently, there is no way to make an API item unavailable via 
 deprecation. This means the API will only ever expand, with a lot of
-churn (case in point, the Java language has about 20% deprecated API
-surface [citation needed]). To better lead users to the right APIs and
-to allow for more effective language/API evolution, this proposal adds
-the `removed_at="<version>"` item to the `#[deprecated]` attribute.
+churn (case in point, the Java language as of Version 8 lists 462
+deprecated constructs, including methods, constants and complete 
+classes, in relation to 4241 classes, this makes for about 10% of
+deprecated API surface. Note that this is but a rough estimate). To 
+better lead users to the right APIs and to allow for more effective 
+language/API evolution, this proposal adds the `removed_at="<version>"`
+item to the `#[deprecated]` attribute.
 
 This allows us to effectively remove an API item from a certain target
 version while avoiding breaking code written for older target versions.
@@ -104,7 +108,7 @@ the user to a working replacement.
 
 We want to avoid users setting `#[allow(deprecate)]` on their code to
 get rid of the warnings. On the other hand, there have been instances
-of failing builds because code was marked with `#![deny(deprecate)]`,
+of failing builds because code was marked with `#![deny(warnings)]`,
 namely `compiletest.rs` and all crates using it. This shows that the
 current system has room for improvement.
 
@@ -147,7 +151,7 @@ version. The same version syntax as Cargo applies:
 
 * `*` effectively means *any version*. For API items, it means
 deprecation checking is disabled. For language changes, it means using
-the 1.0.0 code paths (for now, we may opt to change this in the 
+the `1.0.0` code paths (for now, we may opt to change this in the 
 future), because anything else would break all current code.
 * `1.x` or e.g. `>=1.2.0` sets the target version to the minor version.
 Deprecation checking and language code path selection occur relative
@@ -165,6 +169,11 @@ best-effort basis.
 Optionally, we can define a `future deprecation` lint set to `Allow` by 
 default to allow people being proactive about items that are going to
 be deprecated.
+
+`rustc` should resolve the `#[feature]` flags against the upper bound 
+of the specified target version instead the current version, but 
+default to the current version if no target version is specified or the 
+specified version has no upper bound.
 
 `rustc` should also show a warning or error, depending on level, on
 encountering usage of API items marked as `#[insecure]`. The attribute
@@ -185,7 +194,7 @@ including displaying the `reason` prominently.
 
 # Optional Extension: Legacy flags
 
-The `#[deprecated]` attribute could get an optional `legacy="xy`
+The `#[deprecated]` attribute could get an optional `legacy="xy"`
 entry, which could effectively group a set of APIs under the given 
 name. Users can then declare the `#[legacy]` flag as defined in 
 [RFC #1122](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md)
@@ -241,4 +250,4 @@ needing a new attribute key.
 
 # Unresolved questions
 
-I no longer have any. Please join the discussion to add yours.
+Should the rust = "<version>" be a *dependency* or a package attribute?

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -13,23 +13,23 @@ anyones code.
 Namely the following items:
 
 1. Add a `--target-version=`*<version string>* command line argument to 
-rustc. This will be used for deprecation checking and for selecting 
-code paths in the compiler.
+   rustc. This will be used for deprecation checking and for selecting 
+   code paths in the compiler.
 2. Add an optional `rust = "..."` package attribute to Cargo.toml, 
-which `cargo new` pre-fills with the current rust version.
+   which `cargo new` pre-fills with the current rust version.
 3. Allow `std` APIs to declare an 
-`#[insecure(level="Warn", reason="...")]`  attribute that will produce 
-a warning or error, depending on level, that cannot be switched off 
-(even with `-Awarning`)
+   `#[insecure(level="Warn", reason="...")]`  attribute that will 
+   produce a warning or error, depending on level, that cannot be 
+   switched off (even with `-Awarning`)
 4. Add a `removed_at="..."` item to `#[deprecated]` attributes that 
-allows making API items unavailable starting from certain target 
-versions.
+   allows making API items unavailable starting from certain target 
+   versions.
 5. Add a number of warnings to steer users in the direction of using 
-the most recent Rust version that makes sense to them, while making it 
-easy for library writers to support a wide range of Rust versions
+   the most recent Rust version that makes sense to them, while making 
+   it easy for library writers to support a wide range of Rust versions
 6. (optional) add a `legacy="..."` item to `#[deprecated]` attributes
-that allows grouping API items under a legacy flag that is already 
-defined in RFC #1122 (see below)
+   that allows grouping API items under a legacy flag that is already 
+   defined in RFC #1122 (see below)
 
 ## Background
 
@@ -153,16 +153,16 @@ argument. If no argument is supplied, `rustc` defaults to its own
 version. The same version syntax as Cargo applies:
 
 * `*` effectively means *any version*. For API items, it means
-deprecation checking is disabled. For language changes, it means using
-the `1.0.0` code paths (for now, we may opt to change this in the 
-future), because anything else would break all current code.
-* `1.x` or e.g. `>=1.2.0` sets the target version to the minor version.
-Deprecation checking and language code path selection occur relative
-to the lowest given version. This might also affect stability handling,
-though this RFC doesn't specify this as of yet.
+  deprecation checking is disabled. For language changes, it means 
+  using the `1.0.0` code paths (for now, we may opt to change this in 
+  the future), because anything else would break all current code.
+* `1.x` or e.g. `>=1.2.0` sets the target version to the minor version. 
+  Deprecation checking and language code path selection occur relative 
+  to the lowest given version. This might also affect stability 
+  handling, though this RFC doesn't specify this as of yet.
 * `1.0 - <2.0` as above, the *lowest* supplied version has to be
-assumed for code path selection. However, deprecation checking should
-assume the *highest* supplied version, if any.
+  assumed for code path selection. However, deprecation checking should
+  assume the *highest* supplied version, if any.
 
 If the target version is *higher* than the current `rustc` version, 
 `rustc` should show a warning to suggest that it may need to be updated 
@@ -224,34 +224,35 @@ estimate the effort to be reasonably low.
 # Alternatives
 
 * It was suggested that opt-in and opt-out (e.g. by `#[legacy(..)]`)
-could be sufficient to work around any breaking code on API or language
-changes. The big problem here is that this relies on the user being able 
-to change their dependencies, which may not be possible for legal, 
-organizational or other reasons. In contrast, a defined target version 
-doesn't ever need to change
+  could be sufficient to work around any breaking code on API or 
+  language changes. The big problem here is that this relies on the 
+  user being able to change their dependencies, which may not be 
+  possible for legal, organizational or other reasons. In contrast, a 
+  defined target version doesn't ever need to change
 
-Depending on the specific case, it may be useful to allow a combination 
-of `#![legacy(..)]`, `#![feature(..)]` and the target version where 
-each Rust version can declare the currently active feature set and 
-permit or forbid use of the opt-in/out flags
+  Depending on the specific case, it may be useful to allow a 
+  combination of `#![legacy(..)]`, `#![feature(..)]` and the target 
+  version where each Rust version can declare the currently active 
+  feature set and permit or forbid use of the opt-in/out flags
 
 * Follow a more agressive strategy that actually removes stuff from the 
-API. This would make it easier for the libstd creators at some cost for 
-library and application writers, as they are required to keep up to 
-date or face breakage. The risk of breaking existing code makes this
-strategy very unattractive
+  API. This would make it easier for the libstd creators at some cost 
+  for library and application writers, as they are required to keep up 
+  to date or face breakage. The risk of breaking existing code makes 
+  this strategy very unattractive
 
 * Hide deprecated items in the docs: This could be done either by 
-putting them into a linked extra page or by adding a "show deprecated" 
-checkbox that may be default be checked or not, depending on who you 
-ask. This will however confuse people, who see the deprecated APIs in 
-some code, but cannot find them in the docs anymore 
+  putting them into a linked extra page or by adding a "show 
+  deprecated" checkbox that may be default be checked or not, depending 
+  on who you ask. This will however confuse people, who see the 
+  deprecated APIs in some code, but cannot find them in the docs 
+  anymore 
 
 * Allow to distinguish "soft" and "hard" deprecation, so that an API 
-can be marked as "soft" deprecated to dissuade new uses before hard 
-deprecation is decided. Allowing people to specify deprecation in 
-future version appears to have much of the same benefits without 
-needing a new attribute key. 
+  can be marked as "soft" deprecated to dissuade new uses before hard 
+  deprecation is decided. Allowing people to specify deprecation in 
+  future version appears to have much of the same benefits without 
+  needing a new attribute key. 
 
 # Unresolved questions
 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -5,38 +5,95 @@
 
 # Summary
 
-There has been an ongoing [discussion on internals](https://internals.rust-lang.org/t/thoughts-on-aggressive-deprecation-in-libstd/2176/55) about how we are going to evolve the standard library. This RFC tries to condense the consensus
+There has been an ongoing [discussion on internals](https://internals.rust-lang.org/t/thoughts-on-aggressive-deprecation-in-libstd/2176/55) about how we are going to evolve the standard library. This RFC tries to condense the consensus.
 
 # Motivation
 
 We want to guide the deprecation efforts to allow std to evolve freely to get the best possible API while ensuring minimum-breakage backwards compatibility for users and allow std authors to remove API items for a given version of Rust. Basically have our cake and eat it. Yum, cake.
 
-Of course we cannot really keep and remove a feature at the same time. To square this circle, we can follow the process outlined herein.
+Of course we cannot really keep and remove a feature at the same time. 
+To square this circle, we can follow the process outlined herein.
 
 # Detailed design
 
-We already declare deprecation in terms of Rust versions (like "1.0", "1.2"). The current attribute looks like `#[deprecated(since = "1.0.0", reason="foo")]`. This should be extended to add an optional `removed_at` key, to state that the item should be made inaccessible at that version. Note that while this allows for marking items as deprecated, there is absolutely no provision to actually *remove* items. In fact this proposal bans removing an API type outright, unless security concerns are deemed more important than the resulting breakage from removing it or the API item has some fault that means it cannot be used correctly at all (thus leaving the API in place would result in the same level of breakage than removing it).
+We already declare deprecation in terms of Rust versions (like "1.0", 
+"1.2"). The current attribute looks like `#[deprecated(since = "1.0.0", 
+reason="foo")]`. This should be extended to add an optional 
+`removed_at` key, to state that the item should be made inaccessible at 
+that version. Note that while this allows for marking items as 
+deprecated, there is purposely no provision to actually *remove* items. 
+In fact this proposal bans removing an API type outright, unless 
+security concerns are deemed more important than the resulting breakage 
+from removing it or the API item has some fault that means it cannot be 
+used correctly at all (thus leaving the API in place would result in 
+the same level of breakage than removing it).
 
-Currently every rustc version implements only its own version, having multiple versions is possible using something like multirust, though this does not work within a build. Also currently rustc versions do not guarantee interoperability. This RFC aims to change this situation.
+Currently every rustc version implements only its own version, having 
+multiple versions is possible using something like multirust, though 
+this does not work within a build. Also currently rustc versions do not 
+guarantee interoperability. This RFC aims to change this situation.
 
-First, crates should state their target version using a `#![version = "1.0.0"]` attribute. Cargo should insert the current rust version by default on `cargo new` and *warn* if no version is defined on all other commands. It may optionally *note* that the specified target version is outdated on `cargo package`. [crates.io](https://crates.io) may deny packages that do not declare a version to give the target version requirement more weight to library authors. Cargo should also be able to hold back a new library version if its declared target version is newer than the rust version installed on the system. In those cases, cargo should emit a warning urging the user to upgrade their rust installation.
+First, crates should state their target version using a `#![version = 
+"1.0.0"]` attribute. Cargo should insert the current rust version by 
+default on `cargo new` and *warn* if no version is defined on all other 
+commands. It may optionally *note* that the specified target version is 
+outdated on `cargo package`. [crates.io](https://crates.io) may deny 
+packages that do not declare a version to give the target version 
+requirement more weight to library authors. Cargo should also be able 
+to hold back a new library version if its declared target version is 
+newer than the rust version installed on the system. In those cases, 
+cargo should emit a warning urging the user to upgrade their rust 
+installation.
 
-`rustc` should use this target version definition to check for deprecated items. If no target version is defined, deprecation checking is deactivated (as we cannot assume a specific rust version), however a warning stating the same should be issued (as with cargo – we should probably make cargo not warn on build to get rid of duplicate warnings). Otherwise, use of API items whose `since` attribute is less or equal to the target version of the crate should trigger a warning, while API items whose `removed_at` attribute is less or equal to the target version should trigger an error.
+`rustc` should use this target version definition to check for 
+deprecated items. If no target version is defined, deprecation checking 
+is deactivated (as we cannot assume a specific rust version), however a 
+warning stating the same should be issued (as with cargo – we should 
+probably make cargo not warn on build to get rid of duplicate 
+warnings). Otherwise, use of API items whose `since` attribute is less 
+or equal to the target version of the crate should trigger a warning, 
+while API items whose `removed_at` attribute is less or equal to the 
+target version should trigger an error.
 
-`rustdoc` should mark deprecated APIs as such (e.g. make them in a lighter gray font) and relegate removed APIs to a section below all others (and that may be hidden via a checkbox). We should not completely remove the documentation, as users of libraries that target old versions may still have a use for them, but neither should we let them clutter the docs. 
+`rustdoc` should mark deprecated APIs as such (e.g. make them in a 
+lighter gray font) and relegate removed APIs to a section below all 
+others (and that may be hidden via a checkbox). We should not 
+completely remove the documentation, as users of libraries that target 
+old versions may still have a use for them, but neither should we let 
+them clutter the docs. 
 
 # Drawbacks
 
-By requiring full backwards-compatibility, we will never be able to actually remove stuff from the APIs, which will probably lead to some bloat. 
+By requiring full backwards-compatibility, we will never be able to 
+actually remove stuff from the APIs, which will probably lead to some 
+bloat. Other successful languages have lived with this for multiple 
+decades, so it appears the tradeoff has seen some confirmation already. 
 
 # Alternatives
 
-* Follow a more agressive strategy that actually removes stuff from the API. This would make it easier for the libstd creators at some cost for library and application writers, as they are required to keep up to date or face breakage
-* Hide deprecated items in the docs: This could be done either by putting them into a linked extra page or by adding a "show deprecated" checkbox that may be default be checked or not, depending on who you ask. This will however confuse people, who see the deprecated APIs in some code, but cannot find them in the docs anymore
-* Allow to distinguish "soft" and "hard" deprecation, so that an API can be marked as "soft" deprecated to dissuade new uses before hard deprecation is decided. Allowing people to specify deprecation in future version appears to have much of the same benefits without needing a new attribute key.
-* Decide deprecation on a per-case basis. This is what we do now. The proposal just adds a well-defined process to it
-* Never deprecate anything. Evolve the API by adding stuff only. Rust would be crushed by the weight of its own cruft before 2.0 even has a chance to land. Users will be uncertain which APIs to use
+* Follow a more agressive strategy that actually removes stuff from the 
+API. This would make it easier for the libstd creators at some cost for 
+library and application writers, as they are required to keep up to 
+date or face breakage * Hide deprecated items in the docs: This could 
+be done either by putting them into a linked extra page or by adding a 
+"show deprecated" checkbox that may be default be checked or not, 
+depending on who you ask. This will however confuse people, who see the 
+deprecated APIs in some code, but cannot find them in the docs anymore 
+* Allow to distinguish "soft" and "hard" deprecation, so that an API 
+can be marked as "soft" deprecated to dissuade new uses before hard 
+deprecation is decided. Allowing people to specify deprecation in 
+future version appears to have much of the same benefits without 
+needing a new attribute key. * Decide deprecation on a per-case basis. 
+This is what we do now. The proposal just adds a well-defined process 
+to it * Never deprecate anything. Evolve the API by adding stuff only. 
+Rust would be crushed by the weight of its own cruft before 2.0 even 
+has a chance to land. Users will be uncertain which APIs to use * We 
+could extend the deprecation feature to cover libraries. As Cargo.toml 
+already defines the target versions of dependencies (unless declared as 
+`"*"`), we could use much of the same machinery to allow library 
+authors to join the process
 
 # Unresolved questions
 
-Should we allow library writers to use the same features for deprecating their API items?
+Should we allow library writers to use the same features for 
+deprecating their API items?

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -57,7 +57,11 @@ probably make cargo not warn on build to get rid of duplicate
 warnings). Otherwise, use of API items whose `since` attribute is less 
 or equal to the target version of the crate should trigger a warning, 
 while API items whose `removed_at` attribute is less or equal to the 
-target version should trigger an error.
+target version should trigger an error. 
+
+Also if the target definition has a higher version than `rustc`, it
+should warn that it probably has to be updated in order to build the
+crate.
 
 `rustdoc` should mark deprecated APIs as such (e.g. make them in a 
 lighter gray font) and relegate removed APIs to a section below all 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -223,6 +223,14 @@ estimate the effort to be reasonably low.
 
 # Alternatives
 
+* An earlier version of this proposal suggested using a crate attribute
+  instead of a cargo package attribute and a compiler option, to also 
+  allow cargo-less use cases without manual interaction. However it was 
+  determined that those cases usually target the current Rust version 
+  anyway, and the current proposal allows us to default to the current 
+  version for rustc, while the earlier proposal would have defaulted to 
+  1.0.0 by necessity of not breaking existing code
+
 * It was suggested that opt-in and opt-out (e.g. by `#[legacy(..)]`)
   could be sufficient to work around any breaking code on API or 
   language changes. The big problem here is that this relies on the 
@@ -252,8 +260,10 @@ estimate the effort to be reasonably low.
   can be marked as "soft" deprecated to dissuade new uses before hard 
   deprecation is decided. Allowing people to specify deprecation in 
   future version appears to have much of the same benefits without 
-  needing a new attribute key. 
+  requiring a new attribute key
 
 # Unresolved questions
 
-None
+The names for the cargo package attribute and the rustc compiler option
+are still subject to bikeshedding (however, discussion has stalled,
+suggesting the current names are good enough).

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -37,7 +37,11 @@ First, crates should state their target version using a `#![version =
 "1.0.0"]` attribute. Cargo should insert the current rust version by 
 default on `cargo new` and *warn* if no version is defined on all other 
 commands. It may optionally *note* that the specified target version is 
-outdated on `cargo package`. [crates.io](https://crates.io) may deny 
+outdated on `cargo package`. To get the current rust version, cargo
+could query rustc -V (with some postprocessing) or use some as yet
+undefined symbol exported by the rust libraries.
+
+[crates.io](https://crates.io) may deny 
 packages that do not declare a version to give the target version 
 requirement more weight to library authors. Cargo should also be able 
 to hold back a new library version if its declared target version is 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -74,6 +74,9 @@ The language reference should be extended to describe this feature as outlined
 in this RFC. Authors shall be advised to leave their users enough time to react
 before *removing* a deprecated item.
 
+The internally used feature can either be subsumed by this or possibly renamed
+to avoid a name clash.
+
 # Drawbacks
 
 * The required checks for the `since` and `surrogate` fields are potentially
@@ -94,6 +97,8 @@ be `Allow` by default)
 * `reason` could include markdown formatting
 * The `surrogate` could simply be plain text, which would remove much of the
 complexity here
+* The `surrogate` field could be left out and added later. However, this would
+lead people to describe it in the `reason` field
 
 # Unresolved questions
 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -1,266 +1,92 @@
-- Feature Name: Target Version
-- Start Date: 2015-06-03
+- Feature Name: Public Stability
+- Start Date: 2015-09-03
 - RFC PR: 
 - Rust Issue: 
 
 # Summary
 
-This RFC proposes a small number of extensions to improve the user
-experience around different rust versions, while at the same time
-giving Rust developers more freedom to make changes without breaking
-anyones code.
-
-Namely the following items:
-
-1. Add a `--target-version=`*<version string>* command line argument to 
-   rustc. This will be used for deprecation checking and for selecting 
-   code paths in the compiler.
-2. Add an optional `rust = "..."` package attribute to Cargo.toml, 
-   which `cargo new` pre-fills with the current rust version.
-3. Add a `removed_at="..."` item to `#[deprecated]` attributes that 
-   allows making API items unavailable starting from certain target 
-   versions.
-4. Add a number of warnings to steer users in the direction of using 
-   the most recent Rust version that makes sense to them, while making 
-   it easy for library writers to support a wide range of Rust versions
-5. (optional) add a `legacy="..."` item to `#[deprecated]` attributes
-   that allows grouping API items under a legacy flag that is already 
-   defined in RFC #1122 (see below)
-
-## Background
-
-A good number of policies and mechanisms around versioning regarding
-the Rust language and APIs have already been submitted, some accepted.
-As a background, in no particular order:
-
-* [#0572 Feature gates](https://github.com/rust-lang/rfcs/blob/master/text/0572-rustc-attribute.md)
-* [#1105 API Evolution](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
-* [#1122 Language SemVer](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md)
-* [#1150 Rename Attribute](https://github.com/rust-lang/pull/1150)
-
-In addition, there has been an ongoing 
-[discussion on internals](https://internals.rust-lang.org/t/thoughts-on-aggressive-deprecation-in-libstd/2176/55) 
-about how we are going to evolve the standard library, which this
-proposal is somewhat based on.
-
-Finally, the recent discussion on the first breaking change 
-([RFC PR #1156 Adjust default object bounds](https://github.com/rust-lang/rfcs/pull/1156))
-has made it clear that we need a more flexible way of dealing with
-(breaking) changes.
-
-The current setup allows the `std` API to declare `#[unstable]` and
-`#[deprecated]` flags, whereas users can opt-in to unstable features
-with `#![feature]` flags that are customarily added to the crate root.
-On usage of deprecated APIs, a warning is shown unless suppressed.
-`cargo` does this for dependencies by default by calling `rustc` with
-the `-Awarnings` argument.
+This RFC proposes to make the stability attributes `#[deprecate]`, `#[stable]`
+and `#[unstable]` publicly available, removing some and adding other 
+restrictions while keeping everything mostly the same for APIs shipped with 
+Rust.
 
 # Motivation
 
-## 1. Language / `std` Evolution
+Library authors want a way to evolve their APIs without too much breakage. To 
+this end, Rust has long employed the aforementioned attributes. Now that Rust
+is somewhat stable, it's time to open them up so that others can use them.
 
-The following motivates items 1 and 2 (and to a lesser extent 4)
-
-With the current setup, we can already evolve the language and APIs,
-albeit in a very limited way. For example, it is virtually impossible
-to actually remove an API, because that would break code. Even minor
-breaking changes (as [RFC PR #1156](https://github.com/rust-lang/rfcs/pull/1156) 
-cited above) generate huge discussion, because they call the general
-stability of the language and environment into question.
-
-The problem with opt-out, as defined by 
-[RFC #1122](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md)
-is that code which previously compiled without problems stops working
-on a Rust upgrade, and requires manual intervention to get working 
-again.
-
-This has the long-term potential of fragmenting the Rust ecosystem into
-crates/projects using certain Rust versions and thus should be avoided
-at some (but not all) cost.
-
-Note that a similar problem exists with deprecation as defined: People
-may get used to deprecation warnings or just turn them off until their
-build breaks. Worse, the current setup creates a mirror world for
-libraries, in which deprecation doesn't exist!
-
-## 2. User Experience
-
-The following motivates items 2, 3 and 4.
-
-Currently, there is no way to make an API item unavailable via 
-deprecation. This means the API will only ever expand, with a lot of
-churn (case in point, the Java language as of Version 8 lists 462
-deprecated constructs, including methods, constants and complete 
-classes, in relation to 4241 classes, this makes for about 10% of
-deprecated API surface. Note that this is but a rough estimate). To 
-better lead users to the right APIs and to allow for more effective 
-language/API evolution, this proposal adds the `removed_at="<version>"`
-item to the `#[deprecated]` attribute.
-
-This allows us to effectively remove an API item from a certain target
-version while avoiding breaking code written for older target versions.
-
-Also rustc can emit better error messages than it could were the API
-items actually removed. In the best case, the error messages can steer
-the user to a working replacement.
-
-We want to avoid users setting `#[allow(deprecate)]` on their code to
-get rid of the warnings. On the other hand, there have been instances
-of failing builds because code was marked with `#![deny(warnings)]`,
-namely `compiletest.rs` and all crates using it. This shows that the
-current system has room for improvement.
-
-We want to avoid failing builds because of wrong or missing target
-version definition. Therefor supplying useful defaults is of the 
-essence.
-
-The documentation can be optionally reduced to items relating to the
-current target version (e.g. by a switch), or deprecated items 
-relegated to a separate space, to reduce clutter and possible user
-confusion.
+A pre-RFC on rust-users has seen a good number of supportive voices, which
+suggests that the feature will improve the life of rust library authors
+considerably.
 
 # Detailed design
 
-Cargo parses the additional `rust = "..."` package attribute. The usual 
-rules for version parsing apply. If no `rust` attribute is supplied, it 
-defaults to `*`.
+Add another stability level variant `Undefined`, to be used whenever a
+`#[deprecate]` attribute is without a `#[stable]` or `#[unstable]`. This lifts
+the restriction to have the latter attributes whenever the former is used. To
+keep the restriction for ASWRs, we add an `undefined_stability` lint that is 
+`Allow` by default, but set to `Warn` in the Rust build process, that catches 
+`Undefined` stability attributes (can be done within the Stability lint pass).
 
-Cargo should also supply the current Rust version (which can be either
-supplied by calling `rustc -V` or by linking to a rust library defining
-a version object) on `cargo new`. Cargo supplies the given target 
-version to `rustc` via the `--target-version` command line argument.
+Remove the rust API restriction on `#[deprecate]`, `#[stable]` and 
+`#[unstable]`.
 
-Cargo *may* also warn on `cargo package` if no `rust` version was 
-supplied. A few versions in the future, Cargo could also warn of 
-missing version attributes on build or other actions, at least if the 
-crate is a library.
+On all attributes the `version` field of the attribute should be checked to be 
+valid semver as per [RFC 
+#1122](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md). 
+It is per this RFC redefined to mean the version of the crate (or rust 
+distribution, for `std`) as declared in `Cargo.toml`.
 
-[crates.io](https://crates.io) *could* require a version attribute on 
-upload and display the required rust version on the site.
+The `issue` field of the `#[`(`un`)`stable]` attributes is defined per this RFC
+to mean the suffix to a URL to the issue tracker (it may also be the complete
+URL). Optionally rustdoc may link the issue from the documentation; a new 
+`--issue-tracker-url-prefix=...` option will be prefixed to all links.
 
-`rustc` needs to accept the `--target-version <version>` command line 
-argument. If no argument is supplied, `rustc` defaults to its own 
-version. The same version syntax as Cargo applies:
+The `feature` field is defined to contain a feature name to be used with 
+`cfg(feature = "...")`. To check this, Cargo could put the list of *available*
+features in a space-separated `CRATE_FEATURES_AVAILABLE` environment variable.
+Alternative build processes can also set this. To simplify things, putting a
+`"*"` in the environment variable should disable the check. Otherwise the
+stability lint can check if the feature has been declared.
 
-* `*` effectively means *any version*. For API items, it means
-  deprecation checking is disabled. For language changes, it means 
-  using the `1.0.0` code paths (for now, we may opt to change this in 
-  the future), because anything else would break all current code.
-* `1.x` or e.g. `>=1.2.0` sets the target version to the minor version. 
-  Deprecation checking and language code path selection occur relative 
-  to the lowest given version. This might also affect stability 
-  handling, though this RFC doesn't specify this as of yet.
-* `1.0 - <2.0` as above, the *lowest* supplied version has to be
-  assumed for code path selection. However, deprecation checking should
-  assume the *highest* supplied version, if any.
+The `reason` field is defined to contain a human-readable text with a 
+suggestion what to use instead and a rationale. This is how the field is used
+currently. See the Alternatives section for a less conservative (but more 
+work-intensive) proposal.
 
-If the target version is *higher* than the current `rustc` version, 
-`rustc` should show a warning to suggest that it may need to be updated 
-in order to compile the crate and then try to compile the crate on a
-best-effort basis.
-
-Optionally, we can define a `future deprecation` lint set to `Allow` by 
-default to allow people being proactive about items that are going to
-be deprecated.
-
-`rustc` should resolve the `#[feature]` flags against the upper bound 
-of the specified target version instead the current version, but 
-default to the current version if no target version is specified or the 
-specified version has no upper bound.
-
-While `rustdoc` already parses the deprecation flags, it should in 
-addition relegate items removed in the current version to a separate 
-area below the other documentation and optically mark them as removed. 
-We should not completely remove them, because that would confuse users 
-who see the API items in code written for older target versions.
-
-# Optional Extension: Legacy flags
-
-The `#[deprecated]` attribute could get an optional `legacy="xy"`
-entry, which could effectively group a set of APIs under the given 
-name. Users can then declare the `#[legacy]` flag as defined in 
-[RFC #1122](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md)
-to specifically allow usage of the grouped APIs, thus selectively
-removing the deprecation warning.
-
-This would create a nice feature parity between language code paths and
-`std` API deprecation checking. Also it would lessen the pain for users
-who want to upgrade their systems one feature at a time and can use the
-legacy flags to effectively manage their usage of deprecated items.
+The language reference should be extended to describe this feature.
 
 # Drawbacks
 
-By requiring full backwards-compatibility, we will never be able to 
-actually remove stuff from the APIs, which will probably lead to some 
-bloat. However, the cost of maintaining the outdated APIs is far 
-outweighted by the benefits. Case in point: Other successful languages 
-have lived with this for multiple decades, so it appears the tradeoff 
-has seen some confirmation already. 
-
-Cargo and `rustc` need some code to manage the additional rules. I
-estimate the effort to be reasonably low. For *compiler changes* 
-however, unless it's a genuine bug and unless there could be programs 
-relying on the old behaviours, both the old and new code paths have to
-be maintained in the compiler, which is the biggest cost of 
-implementing this RFC.
+* Work to be done will take time not to invest in other improvements
+* There could be attribute definitions in the codebase that do not adhere to
+the outlined design, and would have to be changed to fit. It is unclear whether
+this is a real drawback
+* Once the feature is public, we can no longer change its design
+* Someone could misuse the API to e.g. add malicious links into their rustdoc.
+However this is possible via plain links even now
 
 # Alternatives
 
-* An earlier version of this proposal suggested using a crate attribute
-  instead of a cargo package attribute and a compiler option, to also 
-  allow cargo-less use cases without manual interaction. However it was 
-  determined that those cases usually target the current Rust version 
-  anyway, and the current proposal allows us to default to the current 
-  version for rustc, while the earlier proposal would have defaulted to 
-  1.0.0 by necessity of not breaking existing code
-
-* It was suggested that opt-in and opt-out (e.g. by `#[legacy(..)]`)
-  could be sufficient to work around any breaking code on API or 
-  language changes. The big problem here is that this relies on the 
-  user being able to change their dependencies, which may not be 
-  possible for legal, organizational or other reasons. In contrast, a 
-  defined target version doesn't ever need to change
-
-  Depending on the specific case, it may be useful to allow a 
-  combination of `#![legacy(..)]`, `#![feature(..)]` and the target 
-  version where each Rust version can declare the currently active 
-  feature set and permit or forbid use of the opt-in/out flags
-
-* Follow a more agressive strategy that actually removes stuff from the 
-  API. This would make it easier for the libstd creators at some cost 
-  for library and application writers, as they are required to keep up 
-  to date or face breakage. The risk of breaking existing code makes 
-  this strategy very unattractive
-
-* Hide deprecated items in the docs: This could be done either by 
-  putting them into a linked extra page or by adding a "show 
-  deprecated" checkbox that may be default be checked or not, depending 
-  on who you ask. This will however confuse people, who see the 
-  deprecated APIs in some code, but cannot find them in the docs 
-  anymore 
-
-* Allow to distinguish "soft" and "hard" deprecation, so that an API 
-  can be marked as "soft" deprecated to dissuade new uses before hard 
-  deprecation is decided. Allowing people to specify deprecation in 
-  future version appears to have much of the same benefits without 
-  requiring a new attribute key
+* Do nothing
+* Optionally the deprecation lint chould check the current version as set by
+cargo in the CARGO_CRATE_VERSION environment variable (the rust build process 
+should set this environment variable, too). This would allow future 
+deprecations to be shown in the docs early, but not warned against by the
+stability lint (there could however be a `future-deprecation` lint that should
+be `Allow` by default).
+* The `reason` field definition could be reduced to stating the *rationale* for 
+deprecating the API item. A new `instead` field then contains the full path to 
+a replacement item (trait, method, function, etc.). Since this path is well 
+defined, it can be checked against. However, some provision needs to be made to 
+allow those paths to be extended with a crate (e.g. for items that have been 
+moved to different crates). The upside is that this would open up the 
+possibility for rustdoc to link to the replacement, the downside is that the
+check could potentially be costly.
 
 # Unresolved questions
 
-* The names for the cargo package attribute and the rustc compiler 
-  option are still subject to bikeshedding (however, discussion has 
-  stalled, suggesting the current names are good enough).
-
-* How do we determine if something is a genuine bug (and should be 
-  changed retroactively)?
-
-* If we agree that something needs to be changed retroactively (i.e. in 
-  older versions), do we also release the old versions anew? Which 
-  ones? Should we nominate LTS versions? Who would maintain them?
-
-* Is *forward-compatibility* sufficiently handled? Seeing that e.g. 
-  adding an item to a trait could break code using that trait, changing 
-  a trait would require both versions being interoperable, which could 
-  be impossible in the general case. This would needed to be handled by 
-  finding a new name for the trait or supplying a default 
-  implementation.
+* Is the current design (as outlined herein) good enough to be made public? 
+* What other restrictions should we introduce now to avoid being bound to a 
+possibly flawed design?

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -6,8 +6,8 @@
 # Summary
 
 This RFC proposes to allow library authors to use a `#[deprecated]` attribute,
-with `since="`(version)`"`, `reason="`(free text)`"` and 
-`surrogate="`(text or surrogate declaration)`"` fields. The compiler can then
+with `since = "`*version*`"`, `reason = "`*free text*`"` and 
+`surrogate = "`*text or surrogate declaration*`"` fields. The compiler can then
 warn on deprecated items, while `rustdoc` can document their deprecation
 accordingly. 
 

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-This RFC proposes to allow library authors to use a `#[deprecate]` attribute,
+This RFC proposes to allow library authors to use a `#[deprecated]` attribute,
 with `since="`(version)`"`, `reason="`(free text)`"` and 
 `surrogate="`(text or surrogate declaration)`"` fields. The compiler can then
 warn on deprecated items, while `rustdoc` can document their deprecation
@@ -26,18 +26,17 @@ interface to use while maximizing usefulness of the metadata introduced.
 
 Public API items (both plain `fn`s, methods, trait- and inherent 
 `impl`ementations as well as `const` definitions, type definitions, struct
-fields and enum variants) can be given a `#[deprecate]` attribute.
+fields and enum variants) can be given a `#[deprecated]` attribute.
 
-This attribute *must* have the `since` field, which contains at least the 
+This attribute *must* have the `since` field, which contains the exact
 version of the crate that deprecated the item, as defined by Cargo.toml 
 (thus following the semver scheme). It makes no sense to put a version number 
 higher than the current newest version here, and this is not checked (but 
 could be by external lints, e.g. 
 [rust-clippy](https://github.com/Manishearth/rust-clippy).
 
-Following semantic versioning would mean that the supplied value could
-actually be a version *range*, which could imply an end-of-life for the
-feature.
+It is required that the version be fully specified (e.g. no wildcards or
+ranges).
 
 Other optional fields are:
 
@@ -54,7 +53,7 @@ different crate) followed by `@` and either a crate name (so that
 a repository or other location where a surrogate can be obtained. Links must be 
 plain FTP, FTPS, HTTP or HTTPS links. The intention is to allow rustdoc (and
 possibly other tools in the future, e.g. IDEs) to act on the included 
-information.
+information. The `surrogate` field can have multiple values.
 
 On use of a *deprecated* item, `rustc` should `warn` of the deprecation. Note 
 that during Cargo builds, warnings on dependencies get silenced. Note that 
@@ -100,5 +99,7 @@ complexity here
 
 * What other restrictions should we introduce now to avoid being bound to a 
 possibly flawed design?
-* Can / Should the `std` library make use of the `#[deprecate]` extensions?
+* How should the multiple values in the `surrogate` field work? Just split by
+some delimiter?
+* Can / Should the `std` library make use of the `#[deprecated]` extensions?
 * Bikeshedding: Are the names good enough?

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -25,14 +25,19 @@ interface to use while maximizing usefulness of the metadata introduced.
 # Detailed design
 
 Public API items (both plain `fn`s, methods, trait- and inherent 
-`impl`ementations as well as `const` definitions) can be given a `#[deprecate]`
-attribute.
+`impl`ementations as well as `const` definitions, type definitions, struct
+fields and enum variants) can be given a `#[deprecate]` attribute.
 
-This attribute *must* have the `since` field, which contains the version of the 
-crate that deprecated the item, as defined by Cargo.toml (thus following the 
-semver scheme). It makes no sense to put a version number higher than the 
-current newest version here, and this is not checked (but could be by external
-lints, e.g. [rust-clippy](https://github.com/Manishearth/rust-clippy).
+This attribute *must* have the `since` field, which contains at least the 
+version of the crate that deprecated the item, as defined by Cargo.toml 
+(thus following the semver scheme). It makes no sense to put a version number 
+higher than the current newest version here, and this is not checked (but 
+could be by external lints, e.g. 
+[rust-clippy](https://github.com/Manishearth/rust-clippy).
+
+Following semantic versioning would mean that the supplied value could
+actually be a version *range*, which could imply an end-of-life for the
+feature.
 
 Other optional fields are:
 
@@ -79,12 +84,14 @@ quite complex.
 # Alternatives
 
 * Do nothing
+* make the `since` field optional
 * Optionally the deprecation lint chould check the current version as set by
 cargo in the CARGO_CRATE_VERSION environment variable (the rust build process 
 should set this environment variable, too). This would allow future 
 deprecations to be shown in the docs early, but not warned against by the
 stability lint (there could however be a `future-deprecation` lint that should
 be `Allow` by default)
+* require either `reason` or `surrogate` be present
 * `reason` could include markdown formatting
 * The `surrogate` could simply be plain text, which would remove much of the
 complexity here
@@ -94,3 +101,4 @@ complexity here
 * What other restrictions should we introduce now to avoid being bound to a 
 possibly flawed design?
 * Can / Should the `std` library make use of the `#[deprecate]` extensions?
+* Bikeshedding: Are the names good enough?

--- a/text/0000-deprecation.md
+++ b/text/0000-deprecation.md
@@ -6,8 +6,8 @@
 # Summary
 
 This RFC proposes to allow library authors to use a `#[deprecated]` attribute,
-with `since = "`*version*`"`, `reason = "`*free text*`"` and 
-`surrogate = "`*text or surrogate declaration*`"` fields. The compiler can then
+with optional `since = "`*version*`"`, `reason = "`*free text*`"` and 
+`use = "`*substitute declaration*`"` fields. The compiler can then
 warn on deprecated items, while `rustdoc` can document their deprecation
 accordingly. 
 
@@ -26,34 +26,30 @@ interface to use while maximizing usefulness of the metadata introduced.
 
 Public API items (both plain `fn`s, methods, trait- and inherent 
 `impl`ementations as well as `const` definitions, type definitions, struct
-fields and enum variants) can be given a `#[deprecated]` attribute.
+fields and enum variants) can be given a `#[deprecated]` attribute. All
+possible fields are optional:
 
-This attribute *must* have the `since` field, which contains the exact
-version of the crate that deprecated the item, as defined by Cargo.toml 
-(thus following the semver scheme). It makes no sense to put a version number 
-higher than the current newest version here, and this is not checked (but 
-could be by external lints, e.g. 
-[rust-clippy](https://github.com/Manishearth/rust-clippy).
-
-It is required that the version be fully specified (e.g. no wildcards or
-ranges).
-
-Other optional fields are:
-
+* `since` is defined to contain the exact version of the crate that
+deprecated the item, as defined by Cargo.toml (thus following the semver
+scheme). It makes no sense to put a version number higher than the current
+newest version here, and this is not checked (but could be by external
+lints, e.g. [rust-clippy](https://github.com/Manishearth/rust-clippy).
+To maximize usefulness, the version should be fully specified (e.g. no
+wildcards or ranges).
 * `reason` should contain a human-readable string outlining the reason for
 deprecating the item. While this field is not required, library authors are
 strongly advised to make use of it to convey the reason to users of their
 library. The string is required to be plain unformatted text (for now) so that
 rustdoc can include it in the item's documentation without messing up the 
 formatting.
-* `surrogate` should be the full path to an API item that will replace the 
-functionality of the deprecated item, optionally (if the surrogate is in a 
+* `use` should be the full path to an API item that will replace the 
+functionality of the deprecated item, optionally (if the replacement is in a 
 different crate) followed by `@` and either a crate name (so that 
 `https://crates.io/crates/` followed by the name is a live link) or the URL to 
 a repository or other location where a surrogate can be obtained. Links must be 
 plain FTP, FTPS, HTTP or HTTPS links. The intention is to allow rustdoc (and
 possibly other tools in the future, e.g. IDEs) to act on the included 
-information. The `surrogate` field can have multiple values.
+information. The `use` field can have multiple values.
 
 On use of a *deprecated* item, `rustc` should `warn` of the deprecation. Note 
 that during Cargo builds, warnings on dependencies get silenced. Note that 
@@ -67,7 +63,7 @@ to warn on use of deprecated items in library crates, however this is outside
 the scope of this RFC.
 
 `rustdoc` should show deprecation on items, with a `[deprecated since x.y.z]`
-box that may optionally show the reason and/or link to the surrogate if
+box that may optionally show the reason and/or link to the replacement if
 available.
 
 The language reference should be extended to describe this feature as outlined
@@ -79,32 +75,37 @@ to avoid a name clash.
 
 # Drawbacks
 
-* The required checks for the `since` and `surrogate` fields are potentially
+* The required checks for the `since` and `use` fields are potentially
 quite complex.
 * Once the feature is public, we can no longer change its design
 
 # Alternatives
 
 * Do nothing
-* make the `since` field optional
+* make the `since` field required and check that it's a single version
 * Optionally the deprecation lint chould check the current version as set by
 cargo in the CARGO_CRATE_VERSION environment variable (the rust build process 
 should set this environment variable, too). This would allow future 
 deprecations to be shown in the docs early, but not warned against by the
 stability lint (there could however be a `future-deprecation` lint that should
 be `Allow` by default)
-* require either `reason` or `surrogate` be present
+* require either `reason` or `use` be present
 * `reason` could include markdown formatting
-* The `surrogate` could simply be plain text, which would remove much of the
+* The `use` could simply be plain text, which would remove much of the
 complexity here
-* The `surrogate` field could be left out and added later. However, this would
-lead people to describe it in the `reason` field
+* The `use` field contents could make use of the context in finding
+replacements, e.g. extern crates, so that `time::precise_time_ns` would resolve
+to the `time::precise_time_ns` API in the `time` crate, provided an
+`extern crate time;` declaration is present
+* The `use` field could be left out and added later. However, this would
+lead people to describe a replacement in the `reason` field, as is already
+happening in the case of rustc-private deprecation
 
 # Unresolved questions
 
 * What other restrictions should we introduce now to avoid being bound to a 
 possibly flawed design?
-* How should the multiple values in the `surrogate` field work? Just split by
-some delimiter?
+* How should the multiple values in the `use` field work? Just split by
+comma or some other delimiter?
 * Can / Should the `std` library make use of the `#[deprecated]` extensions?
 * Bikeshedding: Are the names good enough?


### PR DESCRIPTION
Library authors need a way of evolving their API painlessly. This is it.

[Rendered](https://github.com/llogiq/rfcs/blob/deprecate/text/0000-deprecation.md)