### PR TITLE
i10n

### DIFF
--- a/text/000-i18n.md
+++ b/text/000-i18n.md
@@ -1,0 +1,46 @@
+Feature Name: i18n
+- Start Date: 2015-09-24
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+
+This RFC proposes to add i18n handling inse rust compiler.
+
+#Motivations
+
+With the growth of the number of rust's users, adding localization would be a big plus.
+
+#Proposal
+
+So the following error:
+
+```Shell
+test.rs:2:4: 2:6 error: expected one of `.`, `;`, `}`, or an operator, found `::`
+```
+
+Would become in rust-code:
+
+```Rust
+format_lang!("parser.expected", expected, found)
+```
+
+We would store all translations in localization files which would contain key value pairs. For example:
+
+```
+// in english file
+"expectedFound" = "expected one of {}, found {}"
+
+// in french file
+"expectedFound" = "l'un des symboles suivants était attendu: {}, symbole obtenu: {}"
+```
+
+If no translation is found, the english localization is used.
+
+The localization would be used like this:
+
+```Shell
+> rustc --lang fr some_file
+```
+
+For error codes / long diagnostics, we keep a different file format for convenience and instead of statically baking in the string, we do a file lookup.

--- a/text/000-i18n.md
+++ b/text/000-i18n.md
@@ -29,10 +29,10 @@ We would store all translations in localization files which would contain key va
 
 ```
 // in english file
-"parser.expected_operator" = "expected one of {}, found {}"
+"parser.expected_operator" = "expected one of {} or an operator, found {}"
 
 // in french file
-"parser.expected_operator" = "l'un des symboles suivants était attendu: {}, symbole obtenu: {}"
+"parser.expected_operator" = "un opérateur ou l'un des symboles suivants était attendu: {}, obtenu: {}"
 ```
 
 If no translation is found, the english localization is used.

--- a/text/000-i18n.md
+++ b/text/000-i18n.md
@@ -22,17 +22,17 @@ test.rs:2:4: 2:6 error: expected one of `.`, `;`, `}`, or an operator, found `::
 Would become in rust-code:
 
 ```Rust
-format_lang!("parser.expected", expected, found)
+format_lang!("parser.expected_operator", expected, found)
 ```
 
 We would store all translations in localization files which would contain key value pairs. For example:
 
 ```
 // in english file
-"expectedFound" = "expected one of {}, found {}"
+"parser.expected_operator" = "expected one of {}, found {}"
 
 // in french file
-"expectedFound" = "l'un des symboles suivants était attendu: {}, symbole obtenu: {}"
+"parser.expected_operator" = "l'un des symboles suivants était attendu: {}, symbole obtenu: {}"
 ```
 
 If no translation is found, the english localization is used.
@@ -44,3 +44,5 @@ The localization would be used like this:
 ```
 
 For error codes / long diagnostics, we keep a different file format for convenience and instead of statically baking in the string, we do a file lookup.
+
+The localization files should be stored in a folder called i10n. By default, the english files would be there, but if you put the french files there, the option `--lang fr` will work.

--- a/text/000-i18n.md
+++ b/text/000-i18n.md
@@ -19,7 +19,7 @@ So the following error:
 test.rs:2:4: 2:6 error: expected one of `.`, `;`, `}`, or an operator, found `::`
 ```
 
-Would become in rust-code:
+would become in rust-code:
 
 ```Rust
 format_lang!("parser.expected_operator", expected, found)
@@ -43,6 +43,32 @@ The localization would be used like this:
 > rustc --lang fr some_file
 ```
 
-For error codes / long diagnostics, we keep a different file format for convenience and instead of statically baking in the string, we do a file lookup.
+##Long diagnostics
 
-The localization files should be stored in a folder called i10n. By default, the english files would be there, but if you put the french files there, the option `--lang fr` will work.
+For error codes / long diagnostics, we keep a different file format for convenience and instead of statically baking in the string, we do a file lookup. The only difference will be that instead of calling:
+
+```Rust
+span_err!(E0123, "error description");
+```
+we will write:
+
+```Rust
+span_err!(diagnostics.E0123);
+```
+
+##Storage of localizations
+
+The localization files should be stored in a folder called i10n. By default, the english files will be there, but if you put the french files there, the option `--lang fr` will work. The folder will look like this:
+
+```
+i10n
+  |
+  |---en
+    |
+    |---diagnostics
+    |---parser
+```
+
+##Language pack
+
+The localization files will be exported as compressed files to allow user to download and handle them easily.

--- a/text/000-i18n.md
+++ b/text/000-i18n.md
@@ -71,4 +71,10 @@ i10n
 
 ##Language pack
 
-The localization files will be exported as compressed files to allow user to download and handle them easily.
+The localization files will be exported as compressed files to allow user to download and handle them easily. To install a new package, the following command will be run:
+
+```Shell
+rustc --install-lang fr
+#if not officially supported language:
+rustc --install-lang fr=pack.zip
+```

--- a/text/000-i18n.md
+++ b/text/000-i18n.md
@@ -5,21 +5,23 @@ Feature Name: i18n
 
 # Summary
 
-This RFC proposes to add i18n handling inse rust compiler.
+This RFC proposes to add an internationalization framework to the rust compiler.
 
 #Motivations
 
-With the growth of the number of rust's users, adding localization would be a big plus.
+With the growth of the number of users of Rust, localizing the compiler output would be a big plus.
 
 #Proposal
 
-So the following error:
+We make every user-facing string in the compiler into a key-value pair.
 
-```Shell
+For example, the following string output by the compiler:
+
+```text
 test.rs:2:4: 2:6 error: expected one of `.`, `;`, `}`, or an operator, found `::`
 ```
 
-would become in rust-code:
+would be created via:
 
 ```Rust
 format_lang!("parser.expected_operator", expected, found)
@@ -29,18 +31,18 @@ We would store all translations in localization files which would contain key va
 
 ```
 // in english file
-"parser.expected_operator" = "expected one of {} or an operator, found {}"
+parser.expected_operator = "expected one of {} or an operator, found {}"
 
 // in french file
-"parser.expected_operator" = "un opérateur ou l'un des symboles suivants était attendu: {}, obtenu: {}"
+parser.expected_operator = "un opérateur ou l'un des symboles suivants était attendu: {}, obtenu: {}"
 ```
 
 If no translation is found, the english localization is used.
 
-The localization would be used like this:
+To use a specific language, one can run rustc as follows:
 
 ```Shell
-> rustc --lang fr some_file
+> rustc --lang fr <other arguments>
 ```
 
 ##Long diagnostics
@@ -48,17 +50,27 @@ The localization would be used like this:
 For error codes / long diagnostics, we keep a different file format for convenience and instead of statically baking in the string, we do a file lookup. The only difference will be that instead of calling:
 
 ```Rust
-span_err!(E0123, "error description");
+span_err!(E0123, format!("error description {}", some_substitution));
 ```
 we will write:
 
 ```Rust
-span_err!(diagnostics.E0123);
+span_err!(diagnostics.E0123, some_substitution);
+```
+
+There will be two diagnostics keys for this, the short and long diagnostic.
+
+```
+diagnostics.E0123.short = "error description {}"
+diagnostics.E0123.long = """foo bar baz \
+quux \
+... \
+"""
 ```
 
 ##Storage of localizations
 
-The localization files should be stored in a folder called i10n. By default, the english files will be there, but if you put the french files there, the option `--lang fr` will work. The folder will look like this:
+The localization files should be stored in a folder called i10n, which is part of the rust installation folder. By default, the english files will be there, but if you put the french files there, the option `--lang fr` will work. The folder will look like this:
 
 ```
 i10n
@@ -69,12 +81,12 @@ i10n
     |---parser
 ```
 
+
 ##Language pack
 
 The localization files will be exported as compressed files to allow user to download and handle them easily. To install a new package, the following command will be run:
 
 ```Shell
-rustc --install-lang fr
-#if not officially supported language:
-rustc --install-lang fr=pack.zip
+rustc --install-lang fr # downloads an official language pack from the server
+rustc --install-lang fr=pack.zip # a custom pack can be installed this way
 ```


### PR DESCRIPTION
[rendered](https://github.com/GuillaumeGomez/rfcs/blob/master/text/000-i18n.md)

cc @Manishearth 