### PR TITLE
Amend 1192 (RangeInclusive) to use an enum.

### DIFF
--- a/text/1192-inclusive-ranges.md
+++ b/text/1192-inclusive-ranges.md
@@ -27,7 +27,9 @@ more dots means more elements.
 
 ```rust
 pub enum RangeInclusive<T> {
-  Empty,
+  Empty {
+    at: T,
+  },
   NonEmpty {
     start: T,
     end: T,
@@ -85,7 +87,7 @@ The `Empty` variant could be omitted, leaving two options:
 - `RangeInclusive` could be a struct including a `finished` field.
 - `a...b` only implements `IntoIterator`, not `Iterator`, by
   converting to a different type that does have the field. However,
-  this means that `a...b` behaves differently to `a..b`, so
+  this means that `a.. .b` behaves differently to `a..b`, so
   `(a...b).map(|x| ...)` doesn't work (the `..` version of that is
   used reasonably often, in the author's experience)
 - `a...b` can implement `Iterator` for types that can be stepped

--- a/text/1192-inclusive-ranges.md
+++ b/text/1192-inclusive-ranges.md
@@ -108,3 +108,8 @@ The `Empty` variant could be omitted, leaving two options:
 # Unresolved questions
 
 None so far.
+
+# Amendments
+
+* In rust-lang/rfcs#1320, this RFC was amended to change the `RangeInclusive`
+  type from a struct with a `finished` field to an enum.

--- a/text/1192-inclusive-ranges.md
+++ b/text/1192-inclusive-ranges.md
@@ -26,10 +26,12 @@ more dots means more elements.
 `std::ops` defines
 
 ```rust
-pub struct RangeInclusive<T> {
-    pub start: T,
-    pub end: T,
-    pub finished: bool,
+pub enum RangeInclusive<T> {
+  Empty,
+  NonEmpty {
+    start: T,
+    end: T,
+  }
 }
 
 pub struct RangeToInclusive<T> {
@@ -37,12 +39,11 @@ pub struct RangeToInclusive<T> {
 }
 ```
 
-Writing `a...b` in an expression desugars to `std::ops::RangeInclusive
-{ start: a, end: b, finished: false }`. Writing `...b` in an
+Writing `a...b` in an expression desugars to `std::ops::RangeInclusive::NonEmpty { start: a, end: b }`. Writing `...b` in an
 expression desugars to `std::ops::RangeToInclusive { end: b }`.
 
 `RangeInclusive` implements the standard traits (`Clone`, `Debug`
-etc.), and implements `Iterator`. The `finished` field is to allow the
+etc.), and implements `Iterator`. The `Empty` variant is to allow the
 `Iterator` implementation to work without hacks (see Alternatives).
 
 The use of `...` in a pattern remains as testing for inclusion
@@ -79,8 +80,9 @@ winner.
 This RFC doesn't propose non-double-ended syntax, like `a...`, `...b`
 or `...` since it isn't clear that this is so useful. Maybe it is.
 
-The `finished` field could be omitted, leaving two options:
+The `Empty` variant could be omitted, leaving two options:
 
+- `RangeInclusive` could be a struct including a `finished` field.
 - `a...b` only implements `IntoIterator`, not `Iterator`, by
   converting to a different type that does have the field. However,
   this means that `a...b` behaves differently to `a..b`, so


### PR DESCRIPTION
This PR proposes that `RangeInclusive` be an enum with `Empty`/`NonEmpty` variants instead of a struct with a `finished` field:

```rust
pub enum RangeInclusive<T> {
    Empty {
        at: T,
    },
    NonEmpty {
        start: T,
        end: T,
    }
}
```

Rational:

1. `finished` is very iterator specific. Regardless of what happens, I think this field should be called `empty`.

2. `start`/`end` don't make sense if the range is empty. Using an enum prevents users from using the `start`/`end` of spent ranges. Basically, this makes it impossible for users to do something like `foo(my_range.take(10)); bar(my_range)` and forget to check `finished` in `bar`.

3. If we ever get more space optimizations (specifically, utf8 code point ones) `'a'...'z'` should be the same size as `'a'..'z'`.

4. Don't have to allocate the next start when the end of the range is reached (slight constant factor gain..., maybe). 