### PR TITLE
add link definition for each of the anchored sections.

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -4,27 +4,33 @@
 - Rust Issue: (leave this empty)
 
 # Summary
+[summary]: #summary
 
 One para explanation of the feature.
 
 # Motivation
+[motivation]: #motivation
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
 # Detailed design
+[design]: #detailed-design
 
 This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
 with the language to understand, and for somebody familiar with the compiler to implement.
 This should get into specifics and corner-cases, and include examples of how the feature is used.
 
 # Drawbacks
+[drawbacks]: #drawbacks
 
 Why should we *not* do this?
 
 # Alternatives
+[alternatives]: #alternatives
 
 What other designs have been considered? What is the impact of not doing this?
 
 # Unresolved questions
+[unresolved]: #unresolved-questions
 
 What parts of the design are still TBD?


### PR DESCRIPTION
add link definition for each of the anchored sections.

I always find myself adding these anchors (or some variant thereof) while I'm drafting an RFC.

Lets put them into the template so that people will get them by default.  (Nothing should change about the presentation; it just gives a standard pattern for people to use to embed a link to another section in their markdown.)

(Hopefully we don't need an RFC to decide whether to change the RFC template in this manner.)