### PR TITLE
Edit #911 - The order `const unsafe fn` was chosen (rust-lang/rust#29107)

### DIFF
--- a/text/0911-const-fn.md
+++ b/text/0911-const-fn.md
@@ -178,7 +178,7 @@ invariants to be maintained (e.g. `std::ptr::Unique` requires a non-null pointer
 struct OptionalInt(u32);
 impl OptionalInt {
     /// Value must be non-zero
-    unsafe const fn new(val: u32) -> OptionalInt {
+    const unsafe fn new(val: u32) -> OptionalInt {
         OptionalInt(val)
     }
 }
@@ -241,4 +241,4 @@ cannot be taken for granted, at least `if`/`else` should eventually work.
 
 Since it was accepted, the RFC has been updated as follows:
 
-1. Allowed `unsafe const fn`
+1. Allowed `const unsafe fn`


### PR DESCRIPTION
This commit just reverses the order of `unsafe const` to `const unsafe` to correctly reflect the lang team's decision. See http://github.com/rust-lang/rfcs/issues/1245#issuecomment-146999181