### PR TITLE
Expand `try!` macro with additional case

### DIFF
--- a/text/0000-expand-try-macro.md
+++ b/text/0000-expand-try-macro.md
@@ -1,0 +1,51 @@
+- Feature Name: expand-try-macro
+- Start Date: 2015-12-05
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Add additional `try!(expr => return)` that will return without value.
+
+# Motivation
+[motivation]: #motivation
+
+After I have created [Soma][soma] crate there was [suggestion in Reddit
+post][reddit] to do so.
+
+[reddit]: https://www.reddit.com/r/rust/comments/3vblc5/soma_simple_solution_to_rfc_1303/cxnhbfs
+[soma]: https://github.com/hauleth/soma
+
+# Detailed design
+[design]: #detailed-design
+
+It would be simple as:
+
+```rust
+macro_rules! try {
+    // existing definition
+
+    ($expr:expr => return) => (match $expr {
+        $crate::result::Result::Ok(val) => val,
+        $crate::result::Result::Err(..) => return,
+    });
+}
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+I am not so sure if it has raison d'etre in Rust `libcore` but I think that we
+should at least discuss it's usability.
+
+# Alternatives
+[alternatives]: #alternatives
+
+Left as is. We can use `if let …` syntax in the same manner.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+Would it be usable and would be seen as a good practise to implicitly reject
+`Err(…)` value?

--- a/text/0000-expand-try-macro.md
+++ b/text/0000-expand-try-macro.md
@@ -11,11 +11,10 @@ Add additional `try!(expr => return)` that will return without value.
 # Motivation
 [motivation]: #motivation
 
-After I have created [Soma][soma] crate there was [suggestion in Reddit
-post][reddit] to do so.
+Sometimes there is need to early escape function on `Result::Err(..)`. This
+proposal provide simpler (nicer?) way to deal with that cases.
 
 [reddit]: https://www.reddit.com/r/rust/comments/3vblc5/soma_simple_solution_to_rfc_1303/cxnhbfs
-[soma]: https://github.com/hauleth/soma
 
 # Detailed design
 [design]: #detailed-design
@@ -47,5 +46,6 @@ Left as is. We can use `if let …` syntax in the same manner.
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-Would it be usable and would be seen as a good practise to implicitly reject
-`Err(…)` value?
+- Would it be usable and would be seen as a good practise to implicitly reject
+  `Err(…)` value?
+- Should it be `try!($expr => $expr)` to allow custom return block?


### PR DESCRIPTION
As it is suggested in [Reddit post][reddit] I suggests `try!($expr => return)`
macro to return earlier from function returning `()` and discard `Err(…)` value.

As honestly I am not sure about this feature, but I think that community should
decide about it.

[Rendered][rendered]

[reddit]: https://www.reddit.com/r/rust/comments/3vblc5/soma_simple_solution_to_rfc_1303/cxnhbfs
[rendered]: https://github.com/hauleth/rfcs/blob/expand-try-macro/text/0000-expand-try-macro.md