### PR TITLE
RFC - Allow Drop types in statics/const functions

### DIFF
--- a/text/0000-drop-types-in-const.md
+++ b/text/0000-drop-types-in-const.md
@@ -32,7 +32,10 @@ Destructors do not run on `static` items (by design), so this can lead to unexpe
 # Alternatives
 [alternatives]: #alternatives
 
-Existing workarounds are based on storing `Option<T>`, and initialising it to `Some` upon first access. These solutions work, but require runtime intialisation and incur a checking overhead on subsequent accesses.
+- Runtime initialisation of a raw pointer can be used instead (as the `lazy_static` crate currently does on stable)
+- On nightly, a bug related to `static` and `UnsafeCell<Option<T>>` can be used to remove the dynamic allocation.
+
+Both of these alternatives require runtime initialisation, and incur a checking overhead on subsequent accesses.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-drop-types-in-const.md
+++ b/text/0000-drop-types-in-const.md
@@ -1,0 +1,40 @@
+- Feature Name: `drop_types_in_const`
+- Start Date: 2016-01-01
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Allow types with destructors to be used in `const`/`static` items, as long as the destructor is never run during `const` evaluation.
+
+# Motivation
+[motivation]: #motivation
+
+Most collection types do not allocate any memory when constructed empty. With the change to make leaking safe, the restriction on `static` items with destructors
+is no longer trequired to be a hard error.
+
+Allowing types with destructors to be directly used in `const` functions and stored in `static`s will remove the need to have
+runtime-initialisation for global variables.
+
+# Detailed design
+[design]: #detailed-design
+
+- Remove the check for `Drop` types in constant expressions.
+- Add an error lint ensuring that `Drop` types are not dropped in a constant expression
+ - This includes when another field is moved out of a struct/tuple, and unused arguments in constant functions.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Destructors do not run on `static` items (by design), so this can lead to unexpected behavior when a side-effecting type is stored in a `static` (e.g. a RAII temporary folder handle). However, this can already happen using the `lazy_static` crate, or with `Option<DropType>` (which bypasses the existing checks).
+
+# Alternatives
+[alternatives]: #alternatives
+
+Existing workarounds are based on storing `Option<T>`, and initialising it to `Some` upon first access. These solutions work, but require runtime intialisation and incur a checking overhead on subsequent accesses.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+- TBD

--- a/text/0000-drop-types-in-const.md
+++ b/text/0000-drop-types-in-const.md
@@ -20,14 +20,17 @@ runtime-initialisation for global variables.
 # Detailed design
 [design]: #detailed-design
 
-- Remove the check for `Drop` types in constant expressions.
-- Add an error lint ensuring that `Drop` types are not dropped in a constant expression
- - This includes when another field is moved out of a struct/tuple, and unused arguments in constant functions.
+
+- allow destructors in statics
+ - optionally warn about the "potential leak"
+- allow instantiating structures that impl Drop in constant expressions
+- prevent const items from holding values with destructors, but allow const fn to return them
+- disallow constant expressions which would result in the Drop impl getting called, where they not in a constant context
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Destructors do not run on `static` items (by design), so this can lead to unexpected behavior when a side-effecting type is stored in a `static` (e.g. a RAII temporary folder handle). However, this can already happen using the `lazy_static` crate, or with `Option<DropType>` (which bypasses the existing checks).
+Destructors do not run on `static` items (by design), so this can lead to unexpected behavior when a side-effecting type is stored in a `static` (e.g. a RAII temporary folder handle). However, this can already happen using the `lazy_static` crate.
 
 # Alternatives
 [alternatives]: #alternatives

--- a/text/0000-drop-types-in-const.md
+++ b/text/0000-drop-types-in-const.md
@@ -27,6 +27,28 @@ runtime-initialisation for global variables.
 - Allow `const fn` to return types wth destructors.
 - Disallow constant expressions which would result in the destructor being called (if the code were run at runtime).
 
+## Examples
+Assuming that `RwLock` and `Vec` have `const fn new` methods, the following example is possible and avoids runtime validity checks.
+
+```rust
+/// Logging output handler
+trait LogHandler: Send + Sync {
+    // ...
+}
+/// List of registered logging handlers
+static S_LOGGERS: RwLock<Vec< Box<LogHandler> >> = RwLock::new( Vec::new() );
+```
+
+Disallowed code
+```rust
+static VAL: usize = (Vec::<u8>::new(), 0).1;	// The `Vec` would be dropped
+const EMPTY_BYTE_VEC: Vec<u8> = Vec::new();	// `const` items can't have destructors
+
+const fn sample(_v: Vec<u8>) -> usize {
+	0	// Discards the input vector, dropping it
+}
+```
+
 # Drawbacks
 [drawbacks]: #drawbacks
 

--- a/text/0000-drop-types-in-const.md
+++ b/text/0000-drop-types-in-const.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Allow types with destructors to be used in `const`/`static` items, as long as the destructor is never run during `const` evaluation.
+Allow types with destructors to be used in `static` items and in `cosnt` functions, as long as the destructor never needs to run in const context.
 
 # Motivation
 [motivation]: #motivation
@@ -20,17 +20,17 @@ runtime-initialisation for global variables.
 # Detailed design
 [design]: #detailed-design
 
-
-- allow destructors in statics
- - optionally warn about the "potential leak"
-- allow instantiating structures that impl Drop in constant expressions
-- prevent const items from holding values with destructors, but allow const fn to return them
-- disallow constant expressions which would result in the Drop impl getting called, where they not in a constant context
+- Lift the restriction on types with destructors being used in statics.
+ - (Optionally adding a lint that warn about the possibility of resource leak)
+- Alloc instantiating structures with destructors in constant expressions,
+- Continue to prevent `const` items from holding types with destructors.
+- Allow `const fn` to return types wth destructors.
+- Disallow constant expressions which would result in the destructor being called (if the code were run at runtime).
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Destructors do not run on `static` items (by design), so this can lead to unexpected behavior when a side-effecting type is stored in a `static` (e.g. a RAII temporary folder handle). However, this can already happen using the `lazy_static` crate.
+Destructors do not run on `static` items (by design), so this can lead to unexpected behavior when a type's destructor has effects outside the program (e.g. a RAII temporary folder handle, which deletes the folder on drop). However, this can already happen using the `lazy_static` crate.
 
 # Alternatives
 [alternatives]: #alternatives

--- a/text/0000-drop-types-in-const.md
+++ b/text/0000-drop-types-in-const.md
@@ -6,13 +6,13 @@
 # Summary
 [summary]: #summary
 
-Allow types with destructors to be used in `static` items and in `cosnt` functions, as long as the destructor never needs to run in const context.
+Allow types with destructors to be used in `static` items and in `const` functions, as long as the destructor never needs to run in const context.
 
 # Motivation
 [motivation]: #motivation
 
 Most collection types do not allocate any memory when constructed empty. With the change to make leaking safe, the restriction on `static` items with destructors
-is no longer trequired to be a hard error.
+is no longer required to be a hard error.
 
 Allowing types with destructors to be directly used in `const` functions and stored in `static`s will remove the need to have
 runtime-initialisation for global variables.
@@ -24,7 +24,7 @@ runtime-initialisation for global variables.
  - (Optionally adding a lint that warn about the possibility of resource leak)
 - Alloc instantiating structures with destructors in constant expressions,
 - Continue to prevent `const` items from holding types with destructors.
-- Allow `const fn` to return types wth destructors.
+- Allow `const fn` to return types with destructors.
 - Disallow constant expressions which would result in the destructor being called (if the code were run at runtime).
 
 ## Examples

--- a/text/0000-drop-types-in-const.md
+++ b/text/0000-drop-types-in-const.md
@@ -11,8 +11,8 @@ Allow types with destructors to be used in `static` items and in `const` functio
 # Motivation
 [motivation]: #motivation
 
-Most collection types do not allocate any memory when constructed empty. With the change to make leaking safe, the restriction on `static` items with destructors
-is no longer required to be a hard error.
+Some of the collection types do not allocate any memory when constructed empty (most notably `Vec`). With the change to make leaking safe, the restriction on `static` items with destructors
+is no longer required to be a hard error (as it is safe and accepted that these destructors may never run).
 
 Allowing types with destructors to be directly used in `const` functions and stored in `static`s will remove the need to have
 runtime-initialisation for global variables.
@@ -21,6 +21,7 @@ runtime-initialisation for global variables.
 [design]: #detailed-design
 
 - Lift the restriction on types with destructors being used in statics.
+ - `static`s containing Drop-types will not run the destructor upon program/thread exit.
  - (Optionally adding a lint that warn about the possibility of resource leak)
 - Alloc instantiating structures with destructors in constant expressions,
 - Continue to prevent `const` items from holding types with destructors.
@@ -59,8 +60,9 @@ Destructors do not run on `static` items (by design), so this can lead to unexpe
 
 - Runtime initialisation of a raw pointer can be used instead (as the `lazy_static` crate currently does on stable)
 - On nightly, a bug related to `static` and `UnsafeCell<Option<T>>` can be used to remove the dynamic allocation.
-
-Both of these alternatives require runtime initialisation, and incur a checking overhead on subsequent accesses.
+ - Both of these alternatives require runtime initialisation, and incur a checking overhead on subsequent accesses.
+- Leaking of objects could be addressed by using C++-style `.dtors` support
+ - This is undesirable, as it introduces confusion around destructor execution order.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions


### PR DESCRIPTION
This addresses #913 and rust-lang/rust#30667

[rendered](https://github.com/thepowersgang/rust-lang_rfcs/blob/drop-types-in-const/text/0000-drop-types-in-const.md)