### PR TITLE
Add a used attribute

### DIFF
--- a/text/0000-used.md
+++ b/text/0000-used.md
@@ -6,7 +6,8 @@
 # Summary
 [summary]: #summary
 
-Add a `preserve` attribute to prevent symbols from being discarded.
+Add a `preserve` attribute to prevent symbols from being discarded. This
+attribute is similar to GCC's `used` attribute.
 
 # Motivation
 [motivation]: #motivation
@@ -38,16 +39,12 @@ is compiled with optimization, it prints nothing.
 # Detailed design
 [design]: #detailed-design
 
-Two attributes are added:
+A `#[preserve]` attribute is added. This attribute can be applied to static
+variables and functions without type parameters.
 
-* `#[preserve(compiler)]`
-* `#[preserve]`
-
-These attributes can be applied to static variables and functions without type
-parameters.
-
-If an item is marked with any of these attributes, the compiler generates the
+If an item is marked with this attribute, the compiler generates the
 corresponding symbol and the symbol is not discarded by the compilation process.
+It may be discarded by the linking process.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-used.md
+++ b/text/0000-used.md
@@ -54,7 +54,7 @@ None.
 # Alternatives
 [alternatives]: #alternatives
 
-None.
+The name of the attribute could be changed.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-used.md
+++ b/text/0000-used.md
@@ -25,8 +25,6 @@ fail. For example:
 #[link_section = ".init_array"]
 static F: extern fn() = f;
 
-static mut X: usize = 0;
-
 extern fn f() {
     println!("test");
 }

--- a/text/0000-used.md
+++ b/text/0000-used.md
@@ -1,4 +1,4 @@
-- Feature Name: used
+- Feature Name: preserve
 - Start Date: 2016-01-11
 - RFC PR: (leave this empty)
 - Rust Issue: (leave this empty)
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Add a `used` attribute to prevent symbols from being discarded.
+Add a `preserve` attribute to prevent symbols from being discarded.
 
 # Motivation
 [motivation]: #motivation
@@ -38,12 +38,16 @@ is compiled with optimization, it prints nothing.
 # Detailed design
 [design]: #detailed-design
 
-A `#[used]` attribute is added. This attribute can be applied to static
-variables and functions without type parameters.
+Two attributes are added:
 
-If an items is marked with this attribute, the compiler generates the
-corresponding symbol and the symbol is not discarded by the compilation or
-linking process.
+* `#[preserve(compiler)]`
+* `#[preserve]`
+
+These attributes can be applied to static variables and functions without type
+parameters.
+
+If an item is marked with any of these attributes, the compiler generates the
+corresponding symbol and the symbol is not discarded by the compilation process.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-used.md
+++ b/text/0000-used.md
@@ -1,0 +1,63 @@
+- Feature Name: used
+- Start Date: 2016-01-11
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Add a `used` attribute to prevent symbols from being discarded.
+
+# Motivation
+[motivation]: #motivation
+
+The compiler cannot always see all references to a symbol. For example, if a
+symbol is only referenced from inline assembly, the compiler might think that
+the symbol is unused.
+
+If the compiler thinks that a symbol is unused, it might optimize the symbol
+away which might change the behavior of the program or cause the linking step to
+fail. For example:
+
+```rust
+#![allow(dead_code)]
+
+#[link_section = ".init_array"]
+static F: extern fn() = f;
+
+static mut X: usize = 0;
+
+extern fn f() {
+    println!("test");
+}
+
+fn main() { }
+```
+
+When this program is compiled without optimization, it prints "test". But if it
+is compiled with optimization, it prints nothing.
+
+# Detailed design
+[design]: #detailed-design
+
+A `#[used]` attribute is added. This attribute can be applied to static
+variables and functions without type parameters.
+
+If an items is marked with this attribute, the compiler generates the
+corresponding symbol and the symbol is not discarded by the compilation or
+linking process.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+None.
+
+# Alternatives
+[alternatives]: #alternatives
+
+None.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+None.


### PR DESCRIPTION
Add a `used` attribute to prevent symbols from being discarded.