### PR TITLE
Add `[` to the FOLLOW(ty) in macro future-proofing rules.

### DIFF
--- a/text/0550-macro-future-proofing.md
+++ b/text/0550-macro-future-proofing.md
@@ -481,6 +481,9 @@ reasonable freedom and can be extended in the future.
 
 [RFC issue 1336]: https://github.com/rust-lang/rfcs/issues/1336
 
+- Updated by https://github.com/rust-lang/rfcs/pull/1462, which added
+  open square bracket into the follow set for types.
+
 # Appendices
 
 ## Appendix A: Algorithm for recognizing valid matchers.

--- a/text/0550-macro-future-proofing.md
+++ b/text/0550-macro-future-proofing.md
@@ -414,7 +414,7 @@ The current legal fragment specifiers are: `item`, `block`, `stmt`, `pat`,
 
 - `FOLLOW(pat)` = `{FatArrow, Comma, Eq, Or, Ident(if), Ident(in)}`
 - `FOLLOW(expr)` = `{FatArrow, Comma, Semicolon}`
-- `FOLLOW(ty)` = `{OpenDelim(Brace), Comma, FatArrow, Colon, Eq, Gt, Semi, Or, Ident(as), Ident(where)}`
+- `FOLLOW(ty)` = `{OpenDelim(Brace), Comma, FatArrow, Colon, Eq, Gt, Semi, Or, Ident(as), Ident(where), OpenDelim(Bracket)}`
 - `FOLLOW(stmt)` = `FOLLOW(expr)`
 - `FOLLOW(path)` = `FOLLOW(ty)`
 - `FOLLOW(block)` = any token


### PR DESCRIPTION
Add `[` to the FOLLOW(ty) in macro future-proofing rules (RFC #550 )

This is to address the regression https://github.com/rust-lang/rust/issues/30923