### PR TITLE
Remove keepalive methods from net2 RFC

### DIFF
--- a/text/1461-net2-mutators.md
+++ b/text/1461-net2-mutators.md
@@ -35,9 +35,6 @@ impl TcpStream {
     fn set_nodelay(&self, nodelay: bool) -> io::Result<()>;
     fn nodelay(&self) -> io::Result<bool>;
 
-    fn set_keepalive(&self, keepalive: Option<Duration>) -> io::Result<()>;
-    fn keepalive(&self) -> io::Result<Option<Duration>>;
-
     fn set_ttl(&self, ttl: u32) -> io::Result<()>;
     fn ttl(&self) -> io::Result<u32>;
 


### PR DESCRIPTION
Issues came up in the implementation of these methods that caused us to
back off from implementing keepalive functionality for now.

r? @alexcrichton 