### PR TITLE
rfc 1291: Add libutil to scope of libc crate on Linux

### DIFF
--- a/text/1291-promote-libc.md
+++ b/text/1291-promote-libc.md
@@ -166,9 +166,9 @@ In order to have a well defined scope while satisfying these constraints, this
 RFC proposes that this crate will have a scope that is defined separately for
 each platform that it targets. The proposals are:
 
-* Linux (and other unix-like platforms) - the libc, libm, librt, libdl, and
-  libpthread libraries. Additional platforms can include libraries whose symbols
-  are found in these libraries on Linux as well.
+* Linux (and other unix-like platforms) - the libc, libm, librt, libdl,
+  libutil, and libpthread libraries. Additional platforms can include libraries
+  whose symbols are found in these libraries on Linux as well.
 * OSX - the common library to link to on this platform is libSystem, but this
   transitively brings in quite a few dependencies, so this crate will refine
   what it depends upon from libSystem a little further, specifically:


### PR DESCRIPTION
The initial motivation for adding this library is to get access to
`openpty(3)` and `forkpty(3)`. These simplify opening a pseudoterminal
master / slave pair. The functions are defined on Linux, OSX, FreeBSD,
NetBSD, and OpenBSD. On OS X, they are available without linking to any
additionaly libraries; on the other platforms they require linking with
`-lutil`.

On Linux, libutil is part of glibc, and defines 6 symbols:
- forkpty
- logwtmp
- login_tty
- openpty
- login
- logout

libutil is available in the base installs of Debian-, Fedora-, and
Arch-derived distributions, as well as openSUSE and Android, though on
Android the `pty.h` header that declares the functions seems not to be
available.  Together, these cover the DistroWatch [0] top 10
distributions.

In musl libc, `openpty(3)` and `forkpty(3)` are included in `libc.a`.

On NetBSD and OpenBSD, these functions are included in libutil, which
defines about 100 functions.

On FreeBSD, these functions are included in libutil, which defines about
200 functions.

[0]: http://distrowatch.com/