### PR TITLE
rfc 1291: Add errno() and set_errno() to libc scope

### DIFF
--- a/text/1291-promote-libc.md
+++ b/text/1291-promote-libc.md
@@ -179,6 +179,10 @@ each platform that it targets. The proposals are:
   what the CRT contains. This notably means that a large amount of the current
   contents will be removed on Windows.
 
+Additionally, this crate will provide `errno()` and `set_errno()` functions to
+read and set `errno`. This is necessary to allow Rust programs using `libc`
+functions to properly detect and handle error conditions.
+
 New platforms added to `libc` can decide the set of libraries `libc` will link
 to and bind at that time.
 


### PR DESCRIPTION
Without these functions, Rust programs cannot inspect errors returned by
functions defined in `libc`. From POSIX [0]:

> An application that needs to examine the value of errno to determine
> the error should set it to 0 before a function call, then inspect it
> before a subsequent function call.

From the C standard [1]:

> Thus, a program that uses errno for error checking should set it to
> zero before a library function call, then inspect it before a
> subsequent library function call.

While most `libc` functions return a sentinel value to indicate an
error, not all do. For example, POSIC `strtol` has an error condition
that can only be discovered by setting and reading `errno` [2]:

>  If the value of base is not supported, 0 shall be returned and errno
>  shall be set to [EINVAL].

Refs https://github.com/rust-lang/libc/issues/47

[0] http://pubs.opengroup.org/onlinepubs/9699919799/functions/errno.html#tag_16_110_07
[1] §7.5, footnote 202 of ISO/IEC 9899:2011, WG14 draft version N1570
    (http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)
[2] http://pubs.opengroup.org/onlinepubs/9699919799/functions/strtol.html#tag_16_590_04