### PR TITLE
Update the alternative section for #1268

### DIFF
--- a/text/1268-allow-overlapping-impls-on-marker-traits.md
+++ b/text/1268-allow-overlapping-impls-on-marker-traits.md
@@ -112,9 +112,10 @@ probably be considered an acceptable breakage.
 
 # Alternatives
 
-Once specialization lands, there does not appear to be a case that is impossible
-to write, albeit with some additional boilerplate, as you'll have to manually
-specify the empty impl for any overlap that might occur.
+If the lattice rule for specialization is eventually accepted, there does not
+appear to be a case that is impossible to write, albeit with some additional
+boilerplate, as you'll have to manually specify the empty impl for any overlap
+that might occur.
 
 # Unresolved questions
 


### PR DESCRIPTION
This RFC was written at a time where the specialization RFC appeared to include the lattice rule. Since the RFC was accepted without it, this RFC implies that it is superseded by specialization, but it is not.