### PR TITLE
RFC - Add an owning "borrowed" pointer type `&move`

### DIFF
--- a/text/0000-move-pointer.md
+++ b/text/0000-move-pointer.md
@@ -1,0 +1,51 @@
+- Feature Name: `move_pointer`
+- Start Date: 2016-05-12
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Introduce a new pointer type `&move` that logically owns the pointed-to data, but does not control the backing memory. Also introduces the DerefMove trait to provide access to such a pointer.
+
+# Motivation
+[motivation]: #motivation
+
+This provides an elegant solution to passing DSTs by value, allowing `Box<FnOnce>` to work. It also will allow other usecases where trait methods should take self by "value".
+
+# Detailed design
+[design]: #detailed-design
+
+- Add a new pointer type `&move T`
+- Add a new unary operation `&move <value>`. With a special case such that `&move |x| x` parses as a move closure, requiring parentheses to parse as an owned pointer to a closure.
+- Add a new operator trait `DerefMove` to allow smart pointer types to return owned pointers to their contained data. 
+ - ```rust
+trait DerefMove: DerefMut
+{
+    /// Return an owned pointer to inner data
+    fn deref_move(&mut self) -> &move Self::Target;
+    /// Drop self without calling destructor for Self::Target
+    fn deallocate(self);
+}
+```
+
+
+When an owned pointer is created to a variable (e.g. on the stack) the owner of the pointer takes responsability of calling the destructor on the pointed-to data (and can do any operation assuming that it has full ownership of the object). The original owner still controls the memory allocation used to hold the type, and will deallocate that memory in the same way as if the object had been passed by value.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- Adding a new pointer type to the language is a large change
+
+# Alternatives
+[alternatives]: #alternatives
+
+- Previous discussions have used `&own` as the pointer type
+ - Since `own` is not a reserved word, such a change would be breaking.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+- `IndexMove` trait to handle moving out of collection types in a similar way to `DerefMove`
+- Should (can?) the `box` destructuring pattern be implemented using `DerefMove`?
+

--- a/text/0000-move-pointer.md
+++ b/text/0000-move-pointer.md
@@ -53,4 +53,5 @@ When an owned pointer is created to a variable (e.g. on the stack) the owner of 
 - `IndexMove` trait to handle moving out of collection types in a similar way to `DerefMove`
 - Should (can?) the `box` destructuring pattern be implemented using `DerefMove`?
 - Potential interactions of what happens when a `&move` is stored
+- Should `&move` allow mutation without annotations?
 

--- a/text/0000-move-pointer.md
+++ b/text/0000-move-pointer.md
@@ -17,9 +17,14 @@ This provides an elegant solution to passing DSTs by value, allowing `Box<FnOnce
 [design]: #detailed-design
 
 - Add a new pointer type `&move T`
+ - This pointer will get the same lifetime rules as `&` and `&mut` (such that it cannot outlive the allocation)
+ - but, it will allow the value to become invalid before the allocation does.
+ - Deref coercions as per RFC #241 apply.
 - Add a new unary operation `&move <value>`. With a special case such that `&move |x| x` parses as a move closure, requiring parentheses to parse as an owned pointer to a closure.
+ - This precedence can be implemented by ignoring the `move` when parsing unary operators if it is followed by a `|` or `||` token.
 - Add a new operator trait `DerefMove` to allow smart pointer types to return owned pointers to their contained data. 
- - ```rust
+
+```rust
 trait DerefMove: DerefMut
 {
     /// Return an owned pointer to inner data
@@ -28,7 +33,6 @@ trait DerefMove: DerefMut
     fn deallocate(self);
 }
 ```
-
 
 When an owned pointer is created to a variable (e.g. on the stack) the owner of the pointer takes responsability of calling the destructor on the pointed-to data (and can do any operation assuming that it has full ownership of the object). The original owner still controls the memory allocation used to hold the type, and will deallocate that memory in the same way as if the object had been passed by value.
 
@@ -48,4 +52,5 @@ When an owned pointer is created to a variable (e.g. on the stack) the owner of 
 
 - `IndexMove` trait to handle moving out of collection types in a similar way to `DerefMove`
 - Should (can?) the `box` destructuring pattern be implemented using `DerefMove`?
+- Potential interactions of what happens when a `&move` is stored
 

--- a/text/0000-move-pointer.md
+++ b/text/0000-move-pointer.md
@@ -75,11 +75,13 @@ fn main() {
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-- `IndexMove` trait to handle moving out of collection types in a similar way to `DerefMove`
-- Should (can?) the `box` destructuring pattern be implemented using `DerefMove`?
 - Potential interactions of what happens when a `&move` is stored.
  - If a `&move` is stored in the current scope, when is the original storage freed?
  - If a `&move` isn't stored, is the storage freed right then, or when it would have otherwise gone out of scope?
+
+- `IndexMove` trait to handle moving out of collection types in a similar way to `DerefMove`
+- Should (can?) the `box` destructuring pattern be implemented using `DerefMove`?
+ - This would be a larger RFC specifying the `box` pattern using the `Deref` family of traits
 
 
 # Appendix: Implementations of `DerefMove`


### PR DESCRIPTION
[Rendered](https://github.com/thepowersgang/rust-lang_rfcs/blob/move-pointer/text/0000-move-pointer.md)

Big remaining questions:
- When is the memory deallocated when a `&move` is stored somewhere? Ideally when it's not stored, the memory is released as soon as possible (i.e. at the end of the statement), but when stored that would have to be deferred until the end of the original scope.