### PR TITLE
Specify Rust compatibility of nursery crates

### DIFF
--- a/text/1242-rust-lang-crates.md
+++ b/text/1242-rust-lang-crates.md
@@ -149,6 +149,27 @@ Deprecated crates move to rust-lang-deprecated and are subsequently minimally
 maintained. Alternatively, if someone volunteers to maintain the crate,
 ownership can be transferred externally.
 
+### Compatibility with older compilers
+
+The rust-lang-nursery crates will currently be guaranteed to compile on the
+**previous two stable releases** of Rust and forward. That is, if the current
+stable release is 1.10, all nursery crates will compile successfully on both
+1.8 and 1.9. Some nursery crates may compile on older versions, but this is not
+guaranteed and changes to the crate are allowed which bump the minimum rustc
+version requirement.
+
+This will be implemented in practice by adding continuous integration to all
+nursery crates which runs the test suite on older Rust versions. If a change is
+made that breaks compatibility with an older Rust version, then the version can
+be dropped if it was before two stable releases ago (e.g. by updating the
+continuous integration configuration), or the change must wait to land
+otherwise.
+
+Crates are allowed to experiment with new stable features in Rust, however, that
+are behind off-by-default Cargo features. For example the `panic::catch_unwind`
+API, stabilized, in 1.10, could be behind a feature flag for crates until 1.12
+is released.
+
 ## Advertising
 
 Part of the reason for having rust-lang crates is to have a clear, short list of

--- a/text/1242-rust-lang-crates.md
+++ b/text/1242-rust-lang-crates.md
@@ -151,12 +151,12 @@ ownership can be transferred externally.
 
 ### Compatibility with older compilers
 
-The rust-lang-nursery crates will currently be guaranteed to compile on the
-**previous two stable releases** of Rust and forward. That is, if the current
-stable release is 1.10, all nursery crates will compile successfully on both
-1.8 and 1.9. Some nursery crates may compile on older versions, but this is not
-guaranteed and changes to the crate are allowed which bump the minimum rustc
-version requirement.
+The current version of rust-lang-nursery crates will currently be guaranteed to
+compile on the **previous two stable releases** of Rust and forward. That is, if
+the current stable release is 1.10, all nursery crates will compile successfully
+on both 1.8 and 1.9. Some nursery crates may compile on older versions, but this
+is not guaranteed and changes to the crate are allowed which bump the minimum
+rustc version requirement.
 
 This will be implemented in practice by adding continuous integration to all
 nursery crates which runs the test suite on older Rust versions. If a change is
@@ -170,6 +170,10 @@ Crates are allowed to experiment with new stable features in Rust, however, that
 are behind off-by-default Cargo features. For example the `panic::catch_unwind`
 API, stabilized, in 1.10, could be behind a feature flag for crates until 1.12
 is released.
+
+Note that this policy may change over time. For example if LTS releases of the
+compiler as created then it is likely that nursery crates will guarantee
+compatibility with an LTS release.
 
 ## Advertising
 

--- a/text/1242-rust-lang-crates.md
+++ b/text/1242-rust-lang-crates.md
@@ -163,7 +163,8 @@ nursery crates which runs the test suite on older Rust versions. If a change is
 made that breaks compatibility with an older Rust version, then the version can
 be dropped if it was before two stable releases ago (e.g. by updating the
 continuous integration configuration), or the change must wait to land
-otherwise.
+otherwise. If the minimum vesion of Rust is increased then this is not
+considered a breaking change (e.g. does not require a new major release).
 
 Crates are allowed to experiment with new stable features in Rust, however, that
 are behind off-by-default Cargo features. For example the `panic::catch_unwind`


### PR DESCRIPTION
Currently there is unfortunately not a clear guideline for what the
compatibility of all rust-lang-nursery crates are. The purpose of this change is
to set forth such a guideline to ensure that the nursery crates are all
consistent. It may also likely be the case that many other crates in the
community wish to follow such a policy as well.

This change proposes that all nursery crates are compatible with the **previous
two stable releases** of the compiler. For example, if 1.10 is the current
release then all crates are guaranteed to compile on 1.8 and 1.9. Nursery crates
may compile on older versions, but this is not a guarantee nor can it be relied
on.