### PR TITLE
Generic closures

### DIFF
--- a/text/0000-generic-closures.md
+++ b/text/0000-generic-closures.md
@@ -76,6 +76,23 @@ All generic parameters must be used in the closure argument list. This is necess
 
 The generated closure type will have generic implementations of `Fn`, `FnMut` and `FnOnce` with the provided type bounds. This is similar to the way closures currently have generic implementations over lifetimes.
 
+The closure itself still only has a single type, but it has a generic implementation of the `Fn` traits. Example:
+
+```rust
+<T: Debug>|x: T| println!("{:?}", x);
+
+// Is expanded to:
+struct Closure;
+impl<T: Debug> FnOnce<(T,)> for Closure {
+    type Output = ();
+    extern "rust-call" fn call_once(self, args: (T,)) {
+        println!("{:?}", x);
+    }
+}
+```
+
+This implementation means that a closure may not be generic over its return type only (unless that type is also used in the argument list), since that would not result in a valid impl.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 

--- a/text/0000-generic-closures.md
+++ b/text/0000-generic-closures.md
@@ -77,14 +77,26 @@ The generated closure type will have generic implementations of `Fn`, `FnMut` an
 # Drawbacks
 [drawbacks]: #drawbacks
 
-None
+Increased language complexity.
 
 # Alternatives
 [alternatives]: #alternatives
 
-None
+If the given syntax is determined to be ambiguous, this one can be used instead:
+
+```rust
+for<T: Debug>|x: T| println!("{:?}", x);
+
+for<T>|x: T| where T: Debug {
+    println!("{:?}", x);
+}
+```
+
+We could just not add this, however it would make generic operations on tuples less ergonomic. This feature is going to be even more useful when variadic generics are added in the future.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
 What are the syntax interactions of `move` generic closures with the proposed `&move` reference type?
+
+Is the syntax in this RFC ambiguous for the parser?

--- a/text/0000-generic-closures.md
+++ b/text/0000-generic-closures.md
@@ -60,6 +60,16 @@ There are two ways to specify generic bounds on closures:
 
 When using the `where` syntax, the braces around the closure body are mandatory.
 
+If the `move` keyword is used then it must appear before the generic parameter list:
+
+```rust
+move <T: Debug>|x: T| println!("{:?}", x);
+
+move <T>|x: T| where T: Debug {
+    println!("{:?}", x);
+}
+```
+
 ## Implementation
 
 The generated closure type will have generic implementations of `Fn`, `FnMut` and `FnOnce` with the provided type bounds. This is similar to the way closures currently have generic implementations over lifetimes.
@@ -77,4 +87,4 @@ None
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-None
+What are the syntax interactions of `move` generic closures with the proposed `&move` reference type?

--- a/text/0000-generic-closures.md
+++ b/text/0000-generic-closures.md
@@ -1,0 +1,80 @@
+- Feature Name: generic_closure
+- Start Date: 2015-06-15
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+This RFC adds the ability to define closures that are generic over types.
+
+# Motivation
+[motivation]: #motivation
+
+Generic closures can be used to support compound operations on tuple types:
+
+```rust
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+struct Tuple<A, B, C>(pub A, pub B, pub C);
+
+impl<A, B, C> Tuple<A, B, C> {
+    fn map<A2, B2, C2, F>(self, mut f: F) -> Tuple<A2, B2, C2>
+        where F: FnMut(A) -> A2 + FnMut(B) -> B2 + FnMut(C) -> C2
+    {
+        Tuple(f(self.0), f(self.1), f(self.2))
+    }
+    
+    fn fold<T, F>(self, val: T, mut f: F) -> T
+        where F: FnMut(T, A) -> T + FnMut(T, B) -> T + FnMut(T, C) -> T
+    {
+        let val = f(val, self.0);
+        let val = f(val, self.1);
+        let val = f(val, self.2);
+        val
+    }
+}
+
+let a = Tuple(1u8, 2u32, 3.5f32).map(<T: Into<f64>>|x: T| x.into() + 1.0);
+assert_eq!(a, (2f64, 3f64, 4.5f64));
+
+let b = Tuple(1u8, 2u32, 3.5f32).fold(10.0, <T: Into<f64>>|x, y: T| x + y.into());
+assert_eq!(b, 16.5f64);
+```
+
+A fully working example of this code (with manually implemented closures) can be found [here](https://play.rust-lang.org/?gist=ea867336945253752e31873fc752ec06&version=nightly&backtrace=0).
+
+# Detailed design
+[design]: #detailed-design
+
+## Syntax
+
+There are two ways to specify generic bounds on closures:
+
+```rust
+<T: Debug>|x: T| println!("{:?}", x);
+
+<T>|x: T| where T: Debug {
+    println!("{:?}", x);
+}
+```
+
+When using the `where` syntax, the braces around the closure body are mandatory.
+
+## Implementation
+
+The generated closure type will have generic implementations of `Fn`, `FnMut` and `FnOnce` with the provided type bounds. This is similar to the way closures currently have generic implementations over lifetimes.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+None
+
+# Alternatives
+[alternatives]: #alternatives
+
+None
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+None

--- a/text/0000-generic-closures.md
+++ b/text/0000-generic-closures.md
@@ -70,6 +70,8 @@ move <T>|x: T| where T: Debug {
 }
 ```
 
+All generic parameters must be used in the closure argument list. This is necessary to ensure that the closure can implement all the required `Fn` traits.
+
 ## Implementation
 
 The generated closure type will have generic implementations of `Fn`, `FnMut` and `FnOnce` with the provided type bounds. This is similar to the way closures currently have generic implementations over lifetimes.


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/1650)*

This RFC adds the ability to define generic closures:

``` rust
<T: Debug>|x: T| println!("{:?}", x);
```

[Rendered](https://github.com/Amanieu/rfcs/blob/generic_closure/text/0000-generic-closures.md)
