### PR TITLE
Extend Cell to non-Copy types

### DIFF
--- a/text/0000-movecell.md
+++ b/text/0000-movecell.md
@@ -24,7 +24,7 @@ impl<T> Cell<T> {
 }
 
 impl<T: Copy> Cell<T> {
-    fn get(&self);
+    fn get(&self) -> T;
 }
 
 impl<T: Default> Cell<T> {
@@ -42,6 +42,8 @@ Finally, a `take` method is added which is equivalent to `self.replace(Default::
 [drawbacks]: #drawbacks
 
 It makes the `Cell` type more complicated.
+
+`Cell` will only be able to derive traits like `Eq` and `Ord` for types that are `Copy`, since there is no way to non-destructively read the contents of a non-`Copy` `Cell`.
 
 # Alternatives
 [alternatives]: #alternatives

--- a/text/0000-movecell.md
+++ b/text/0000-movecell.md
@@ -18,8 +18,8 @@ It allows safe inner-mutability of non-`Copy` types without the overhead of `Ref
 
 ```rust
 impl<T> Cell<T> {
-    fn set(&mut self, val: T);
-    fn replace(&mut self, val: T) -> T;
+    fn set(&self, val: T);
+    fn replace(&self, val: T) -> T;
     fn into_inner(self) -> T;
 }
 
@@ -28,7 +28,7 @@ impl<T: Copy> Cell<T> {
 }
 
 impl<T: Default> Cell<T> {
-    fn take(&mut self) -> T;
+    fn take(&self) -> T;
 }
 ```
 

--- a/text/0000-movecell.md
+++ b/text/0000-movecell.md
@@ -1,0 +1,54 @@
+- Feature Name: move_cell
+- Start Date: 2016-06-15
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Extend `Cell` to work with non-`Copy` types.
+
+# Motivation
+[motivation]: #motivation
+
+It allows safe inner-mutability of non-`Copy` types without the overhead of `RefCell`'s reference counting.
+
+# Detailed design
+[design]: #detailed-design
+
+```rust
+impl<T> Cell<T> {
+    fn set(&mut self, val: T);
+    fn replace(&mut self, val: T) -> T;
+    fn into_inner(self) -> T;
+}
+
+impl<T: Copy> Cell<T> {
+    fn get(&self);
+}
+
+impl<T: Default> Cell<T> {
+    fn take(&mut self) -> T;
+}
+```
+
+The `get` method is kept but is only available for `T: Copy`. The `set` method is available for all `T`.
+
+The `into_inner` and `replace` methods are added, which allow the value in a cell to be read even if `T` is not `Copy`. The `get` method can't be used since the cell must always contain a valid value.
+
+Finally, a `take` method is added which is equivalent to `self.replace(Default::default())`.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+It makes the `Cell` type more complicated.
+
+# Alternatives
+[alternatives]: #alternatives
+
+The alternative is to use the `MoveCell` type from crates.io which provides the same functionality.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+None

--- a/text/0000-movecell.md
+++ b/text/0000-movecell.md
@@ -32,7 +32,9 @@ impl<T: Default> Cell<T> {
 }
 ```
 
-The `get` method is kept but is only available for `T: Copy`. The `set` method is available for all `T`.
+The `get` method is kept but is only available for `T: Copy`.
+
+The `set` method is available for all `T`. It will need to be implemented by calling `replace` and dropping the returned value. Dropping the old value in-place is unsound since the `Drop` impl will hold a mutable reference to the cell contents.
 
 The `into_inner` and `replace` methods are added, which allow the value in a cell to be read even if `T` is not `Copy`. The `get` method can't be used since the cell must always contain a valid value.
 

--- a/text/0000-movecell.md
+++ b/text/0000-movecell.md
@@ -13,6 +13,10 @@ Extend `Cell` to work with non-`Copy` types.
 
 It allows safe inner-mutability of non-`Copy` types without the overhead of `RefCell`'s reference counting.
 
+The key idea of `Cell` is to provide a primitive building block to safely support inner mutability. This must be done while maintaining Rust's aliasing requirements for mutable references. Unlike `RefCell` which enforces this at runtime through reference counting, `Cell` does this statically by disallowing any reference (mutable or immutable) to the data contained in the cell.
+
+While the current implementation only supports `Copy` types, this restriction isn't actually necessary to maintain Rust's aliasing invariants. The only affected API is the `get` function which, by design, is only usable with `Copy` types.
+
 # Detailed design
 [design]: #detailed-design
 


### PR DESCRIPTION
This RFC extends the `Cell` type to work with non-`Copy` types.

[Rendered](https://github.com/Amanieu/rfcs/blob/movecell/text/0000-movecell.md)
