### PR TITLE
RFC: const-dependent type system.

### DIFF
--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -156,7 +156,7 @@ struct Array<n: const usize, T> {
 impl<n: const usize, T> Array<n, T> {
     // This is simple statically checked indexing.
     fn const_index<i: const usize>(&self) -> &T where i < n {
-    //                        note that this is constexpr  ^^^^^
+    //                   note that this is constexpr  ^^^^^
         unsafe { self.content.unchecked_index(i) }
     }
 
@@ -202,6 +202,41 @@ Another draw back is the lack of implication proves.
 
 Use full SMT-based dependent types. These are more expressive, but severely
 more complex as well.
+
+## Alternative syntax
+
+The syntax is described above is, in fact, ambiguous, and multiple other better or worse
+candidates exists:
+
+### Blending the value parameters into the arguments
+
+This one is an interesting one. It allows for defining functions with constant
+_arguments_ instead of constant _parameters_. This allows for bounds on e.g.
+`atomic::Ordering`.
+
+```rust
+fn do_something(const x: u32) -> u32 where x < 5 { x }
+```
+
+### Angle brackets
+
+Use angle brackets for dependent parameters:
+
+```rust
+fn do_something[x: u32]() -> u32 where x < 5 { x }
+
+do_something::[2]();
+```
+
+### `const` _before_ the parameter
+
+Use the proposed syntax in similar manner to constant definitions:
+
+```rust
+fn do_something<const x: u32>() -> u32 where x < 5 { x }
+
+do_something::<2>();
+```
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -9,7 +9,36 @@
 We propose a simple, yet sufficiently expressive, addition of dependent-types
 (also known as, Π-types and value-types).
 
-Type checking remains decidable.
+Type checking will not require SMT-solvers or other forms of theorem provers.
+
+## Generic value parameters
+
+A `const` type parameter acts like a generic parameter, containing a constant
+expression. Declaring a generic parameter `a: const usize`, creates a constant
+variable `a` of type `usize`.
+
+One can create implementations, structs, enums, and traits, abstracting over
+this generic value parameter.
+
+We use the syntax `a: const value` to denote the constant type parameter, `a`,
+of constant value, `value`.  This can be used at both type-level (as parameter)
+and value-level (as expression).
+
+## Compile time calculations on constant parameters
+
+Since it is simply consisting of constexprs, one can apply constant functions
+(`const fn`) to the parameter, to perform compile time, type level calculations
+on the parameter. This allows for great expressiveness as `const fn` improves.
+
+## Expression `where` bounds
+
+The second construct added is the constant expression in `where` bounds. These
+contains statements about the constant parameters, which are checked at compile
+time.
+
+## Type checking
+
+Type checking is done eagerly by evaluating the bounds and constexprs.
 
 # Motivation
 [motivation]: #motivation
@@ -67,7 +96,7 @@ function.
 
 ## Type inference
 
-Since we are able to evaluate the function on compile time, we can easily infer
+Since we are able to evaluate the function at compile time, we can easily infer
 const types, by adding an unification relation, from the rule above.
 
 The relational edge between two const types is simple a const fn, which is
@@ -179,4 +208,5 @@ more complex as well.
 
 What syntax is preferred? How does this play together with HKP? Can we improve
 the converse type inference? What should be the naming conventions? Should we
-segregate the value parameters and type parameters by `;`?
+segregate the value parameters and type parameters by `;`? Disjoint
+implementations satisfying some bound?

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -770,7 +770,7 @@ An example is:
 // Note: This should be read from bottom to top!
 
 // Now, we replace a with a + 3 in our postcondition, and get a + 3 = 42 in our precondition.
-a = a + 2;
+a = a + 3;
 // Assume we know that a = 42 here.
 ```
 
@@ -851,7 +851,7 @@ It should be obvious that this extension is a big change, both internally and
 externally. It makes Rust much more complicated, and drives it in a direction,
 which might not be wanted.
 
-It aligns with Rust's goals: effective statical checking. As such, runtime
+It aligns with Rust's goals: effective static checking. As such, runtime
 assertions are to a less extend needed.
 
 # How we teach this

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -54,6 +54,21 @@ type level arithmetics, lattice types).
 
 It allows for creating powerful abstractions without type-level hackery.
 
+## What we want, and what we don't want
+
+We have to be very careful to avoid certain things, while still preserving the core features:
+
+1. Ability to use, manipulate, and constraint values at type-level.
+2. The ability to use said values on expression-level (runtime).
+
+Yet, we do not want:
+
+1. SMT-solvers, due to not only undecidability (note, although, that SAT is
+   decidable) and performance, but the complications it adds to `rustc`.
+2. Monomorphisation-time errors, i.e. errors that happens during codegen of
+   generic functins. We try to avoid adding _more_ of these (as noted by
+   petrochenkov, these [already exists](https://github.com/rust-lang/rfcs/pull/1657#discussion_r68202733))
+
 ## Examples
 
 ### Bounded integers/interval arithmetics

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -355,8 +355,8 @@ One can show this by considering each case:
 1. `ExpandBooleanAnd` eliminates `{P ∧ Q} ⊢ {P, Q}`. The right hand side's
    depth is `max(dep(P), dep(Q))`, which is smaller than the original,
    `max(dep(P), dep(Q)) + 1`
-2. `SubstituteEquality` eliminates `{a = b, P} ⊢ {P[b/a]}`, which is an
-   elimination, since `dep(P) + 1 > dep(P[b/a]) = dep(P)`.
+2. `SubstituteEquality` eliminates `{a = b, P} ⊢ {P[b ← a]}`, which is an
+   elimination, since `dep(P) + 1 > dep(P[b ← a]) = dep(P)`.
 3. `DoubleNegation` eliminates `{¬¬x} ⊢ {x}`, which is an elimination, since
    `dep(x) + 2 > dep(x)`.
 
@@ -506,6 +506,11 @@ fn main() {
 ```
 
 # Experimental extensions open to discussion
+
+## Remark!
+
+These are _possible_ extensions, and not something that would be a part of the
+initial implementation. These a brought up for the sake of discussion.
 
 ## SMT-solvers?
 
@@ -687,6 +692,167 @@ struct Abc {
 It is unclear how it plays together with `where` bounds.
 
 The pro is that it adds ability to implement e.g. constant indexing, `Index<Const<usize>>`.
+
+## Towards a "fully" dependent type system
+
+In the future, we might like to extend it to a fully dependent type system.
+While this is, by definition, a dependent type system, one could extend it to
+allow runtime defind value parameters.
+
+Consider the `index` example. If one wants to index with a runtime defined
+integer, the compiler have to be able to show that this value does, in fact,
+satisfy the `where` clause.
+
+There are multiple ways to go about this. We will investigate the Hoare logic way.
+
+### Is this bloat?
+
+Well, we can't know if it is. It depends on how expressive, const parameters
+are in practice, or more so, if there exists edge cases, which they do not cover.
+
+### "Sizingness"
+
+Certain value parameters have impact on the size of some type (e.g., consider
+`[T; N]`). It would make little to no sense, to allow one to determine the size
+of some value, say a constant sized array, at runtime.
+
+Thus, one must find out if a value parameter is impacting the size of some
+type, before one can allow runtime parameterization.
+
+Currently, only one of such cases exists: constant sized arrays. One could as
+well have a struct containing such a primitive, thus we have to require
+transitivity.
+
+If a value parameter has no impact on the size, nor is used in a parameter of a
+constructor, which is "sizing", we call this value "non-sizing".
+
+Only non-sizing value parameters can be runtime defined.
+
+### Hoare logic invariants and runtime calls
+
+As it stands currently, one cannot "mix up" runtime values and value parameter
+(the value parameters are entirely determined on compile time).
+
+It turns out reasoning about invariants is not as hard as expected. [Hoare
+logic](https://en.wikipedia.org/wiki/Hoare_logic) allows for this.
+
+One need not SMT solvers for such a feature. In fact, one can reason from the
+rules, we have already provided. With the addition of MIR, this might turn out
+to be more frictionless than previously thought.
+
+Hoare logic can be summarized as a way to reason about a program, by giving
+each statement a Hoare triple. In particular, in addition to the statement
+itself, it carries a post- and precondition. These are simple statements that
+can be incrementally inferred by the provided Hoare rules.
+
+Multiple sets of axioms for Hoare logics exists. The most famous one is the set
+Tony Hoare originally formulated.
+
+For a successful implementation, one would likely only need a tiny subset of
+these axioms:
+
+#### Assignment axiom schema
+
+This is, by no doubt, the most important rule in Hoare logic. It allows us to
+carry an assumption from one side of an assignment to another.
+
+It states:
+
+    ────────────────────
+    {P[x ← E]} x = E {P}
+
+That is, one can take a condition right after the assignment, and move it prior
+to the assignment, by replacing the variable with the assigned value.
+
+An example is:
+
+```rust
+// Note: This should be read from bottom to top!
+
+// Now, we replace a with a + 3 in our postcondition, and get a + 3 = 42 in our precondition.
+a = a + 2;
+// Assume we know that a = 42 here.
+```
+
+This rule propagate "backwards". Floyd formulated a more complicated, but forwards rule.
+
+#### `while` rule
+
+The `while` rule allows us to reason about loop invariants.
+
+Formally, it reads
+
+    {P ∧ B} S {P}
+    ───────────────────────────
+    {P} (while B do S) {¬B ∧ P}
+
+`P`, in this case, is the loop invariant, a condition that much be preserved
+for each iteration of the body.
+
+`B` is the loop condition. The loop ends when `P` is false, thus, as a
+postcondition to the loop, `¬B`.
+
+#### Conditional rule
+
+The conditional rule allows one to reason about path-specific invariants in
+e.g. `if` statements.
+
+Formally, it reads
+
+    {B ∧ P} S {Q}
+    {¬B ∧ P } T {Q}
+    ────────────────────────────
+    {P} (if B then S else T) {Q}
+
+This allows us to do two things:
+
+1. Lift conditionals down to the branch, as precondition.
+
+2. Lift conditions up as postconditions to the branching statement.
+
+---
+
+In addition, we propose these Rust specific axioms:
+
+#### Non-termination rule
+
+This can be used for reasoning about assertions and panics, along with aborts
+and other functions returning `!`.
+
+Formally, the rule is:
+
+    f: P → !
+    p: P
+    ───────────────────────────
+    (if P then f p else E) {¬P}
+
+This simply means that:
+
+```rust
+if a {
+    // Do something `!` here, e.g. loop infinitely:
+    loop {}
+} else {
+    // stuff
+}
+// We know, since we reached this, that !a.
+```
+
+#### How this allows runtime calls
+
+Runtime calls are parameterized over runtime values. These allows the compiler
+to semantically reason about the value of some variable. Thus, the bound can be
+enforced on compile time, by making sure the statements of the value iplies
+whatever bound that must be satisfied.
+
+#### Advantages and tradeoffs
+
+It should be obvious that this extension is a big change, both internally and
+externally. It makes Rust much more complicated, and drives it in a direction,
+which might not be wanted.
+
+It aligns with Rust's goals: effective statical checking. As such, runtime
+assertions are to a less extend needed.
 
 # How we teach this
 

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -52,6 +52,8 @@ There is a whole lot of other usecases as well. These allows certain often
 requested features to live in standalone libraries (e.g., bounded-integers,
 type level arithmetics, lattice types).
 
+It allows for creating powerful abstractions without type-level hackery.
+
 # Detailed design
 [design]: #detailed-design
 
@@ -245,6 +247,34 @@ fn main() {
 }
 ```
 
+# How we teach this
+
+This RFC aims to keep a "symmetric" syntax to the current construct, giving an
+intuitive behavior, however there are multiple things that are worth explaining
+and/or clearing up:
+
+1. What are Π-types? How are they different from those from other languages?
+
+2. One will have to understand what `const fn`s are and how they are linked to
+   Π-types.
+
+3. What are the usecases?
+
+4. What are the edge cases, and how can one work around those (e.g. failed
+   unification)?
+
+5. How can I use this to create powerful abstractions?
+
+6. Extensive examples.
+
+Moreover, we need to "informalize" the rules defined in this RFC.
+
+I believe this subject is complex enough to have its own chapter in The Holy
+Book, answering these questions in detail.
+
+Lastly, the FAQ will need to be updated to answer various questions related to
+this.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 
@@ -325,3 +355,5 @@ Should we segregate the value parameters and type parameters by `;`?
 Should disjoint implementations satisfying some bound be allowed?
 
 Should there be a way to parameterize functions dynamically?
+
+What API would need to be rewritten to take advantage of Π-types?

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -392,6 +392,8 @@ mathematical limitations.
 
 ### SMT-solvers?
 
+This RFC doesn't propose such thing, but future possibilities are worth discussing:
+
 #### What a Rusty SMT-solver would look like
 
 The simplest and least obstructive SMT-solver is the SAT-based one. SAT is a

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -319,13 +319,33 @@ do_something::[2]();
 
 ### `const` as an value-type constructor
 
-Use the proposed syntax in similar manner to constant definitions:
+Create a keyword, `const`:
 
 ```rust
 fn do_something<x: const u32>() -> u32 where x < 5 { x }
 
 do_something::<2>();
 ```
+
+### An extension: A constexpr type constructor
+
+Add some language item type constructor, `Const<T>`, allowing for constructing
+a constexpr-only types.
+
+`x: T` can coerce into `Const<T>` if `x` is constexpr. Likewise, can `Const<T>`
+coerce into `T`.
+
+```rust
+fn do_something(x: Const<u32>) -> u32 { x }
+
+struct Abc {
+    constfield: Const<u32>,
+}
+```
+
+It is unclear how it plays together with `where` bounds.
+
+The pro is that it adds ability to implement e.g. constant indexing, `Index<Const<usize>>`.
 
 ### `with` instead of `where`
 

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -88,7 +88,7 @@ we can derive the rule,
     PiConstructorInference:
       Π ⊢ x: const c
       Π ⊢ f(c): τ
-      --------------
+      -----------------
       Π ⊢ f(x): const τ
 
 This allows one to take some const parameter and map it by some arbitrary, pure
@@ -101,6 +101,29 @@ const types, by adding an unification relation, from the rule above.
 
 The relational edge between two const types is simple a const fn, which is
 resolved under unification.
+
+We add an extra rule to improve inference:
+
+    PiDependencyInference:
+      Γ ⊢ T: A → 𝓤
+      Γ ⊢ a: T<c>
+      Γ ⊢ a: T<x>
+      --------------
+      Γ ⊢ x: const c
+
+This allows us infer:
+
+```rust
+// [T; N] is a constructor, T → usize → 𝓤 (parameterize over T and you get A → 𝓤).
+fn foo<n: const usize, l: const [u32; n]>() -> [u32; n] {
+    // ^ note how l depends on n.
+    l
+}
+
+// We know n from the length of the array.
+let l = baz::<_, [1, 2, 3, 4, 5, 6]>();
+//            ^   ^^^^^^^^^^^^^^^^
+```
 
 ## `where` clauses
 

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -537,6 +537,10 @@ fn main() {
 
 ## Candidates for additional rules
 
+Currently, the set of rules is rather conservative for rewriting. To make it
+easier to work with, one can add multiple new reductive rules, at the expense
+of implementation complexity:
+
     RewriteOr:
       P ∨ Q
       ──────────
@@ -654,7 +658,7 @@ constructing the type. Dependent types, in a sense, are similar to normal
 generics, where types can depend on other types (e.g. `Vec<T>`), whereas
 dependent types depend on values.
 
-**We achieve this by using const fns, which allow us to take ...**
+**How does this differ from other languages' implementations of dependent types?**
 
 Various other languages have dependent type systems. Strictly speaking, all
 that is required for a dependent type system is value-to-type constructors,

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -279,7 +279,7 @@ let l = foo::<_, [1, 2, 3, 4, 5, 6]>();
 
 Often, it is wanted to have some statically checked clause satisfied by the
 constant parameters (e.g., for the sake of compile-time bound checking). To
-archive this, in a reasonable manner, we use const exprs, returning a boolean.
+archive this, in a reasonable manner, we use constexprs, returning a boolean.
 
 We allow such constexprs in `where` clauses of functions. Whenever the
 function is invoked given constant parameters `<a, b...>`, the compiler
@@ -547,7 +547,7 @@ these problems will likely be marginalized in a few years.
 Another issue which is present in Rust, is that you don't have any logical
 (invariant) information about the return values. Thus, a SMT-solver would work
 relatively poorly (if at all) non-locally (e.g. user defined functions). This
-is often solved by having an exression of "unknown function", which can have
+is often solved by having an expression of "unknown function", which can have
 any arbitrary body.
 
 That issue is not something that prevents us from adopting a SMT-solver, but it
@@ -566,7 +566,7 @@ essentially get the same functionality.
 ### Implementation complications
 
 It will likely not be hard to implement itself, by using an external SMT-solver
-(e.g., Z3). The real proble lies in the probles with performance and
+(e.g., Z3). The real problem lies in the issues with performance and
 "obviousness" of the language.
 
 ## Candidates for additional rules
@@ -718,9 +718,10 @@ Unfortunately, transitivity is not reductive.
 
 Non-equality is defined by:
 
-    a ≠ b
-    ────────
-    ¬(a = b)
+    NeqDefinition:
+      a ≠ b
+      ────────
+      ¬(a = b)
 
 ## Expression reduction rules
 
@@ -768,7 +769,7 @@ of these when unfolding the `where` clause, it returns "True":
     OrTrue2:
         true ∨ P
 
-### A constexpr type constructor
+## A constexpr type constructor
 
 Add some language item type constructor, `Const<T>`, allowing for constructing
 a constexpr-only types.
@@ -831,7 +832,7 @@ As it stands currently, one cannot "mix up" runtime values and value parameter
 It turns out reasoning about invariants is not as hard as expected. [Hoare
 logic](https://en.wikipedia.org/wiki/Hoare_logic) allows for this.
 
-One need not SMT solvers for such a feature. In fact, one can reason from the
+One need not SMT-solvers for such a feature. In fact, one can reason from the
 rules, we have already provided. With the addition of MIR, this might turn out
 to be more frictionless than previously thought.
 

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -816,14 +816,27 @@ do_something::<2>();
 Some have raised concerns of mixing things up there. Thus one can use the
 syntax `with` to denote bounds instead.
 
-## Lazily type check without transitivity rule
-
-Simply evaluate the bounds when calling. Remove the requirement of implication.
-
 ## Allow multiple implementation bounds
 
 Allow overlapping implementations carrying bounds, such that only one of the
 conditions may be true under monomorphization.
+
+## Type/`where` clause checking
+
+### Lazily type check without transitivity rule
+
+Simply evaluate the bounds when calling. Remove the requirement of implication.
+This introduces errors at monomorphization time.
+
+### Inheriting `where` clauses
+
+An interesting idea to investigate is to let functions inherit called
+function's `where` clauses. This allows for non-monomorphization, yet
+ergonomic, `where` clauses.
+
+An important symmetry is lost, though: trait bounds in `where` clauses. These
+are not inherited, but explicit. A way to avoid this asymmetry, [`with` could
+be used](#with-instead-of-where).
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -388,50 +388,6 @@ thus calculate the two bounds, which will clearly fail. We cannot, however,
 stop such malformed bounds in _declarations_ and _function definitions_, due to
 mathematical limitations.
 
-### SMT-solvers?
-
-This RFC doesn't propose such thing, but future possibilities are worth discussing:
-
-#### What a Rusty SMT-solver would look like
-
-The simplest and least obstructive SMT-solver is the SAT-based one. SAT is a
-class of decision problem, where a boolean formula, with some arbitrary number
-of free variables, is determined to be satisfiable or not. Obviously, this is
-decidable (bruteforcing is the simplest algorithm, since the search space is
-finite, bruteforcing is guaranteed to terminate).
-
-SAT is NP-complete, and even simple statements such as `x + y = y + x` can take
-a long time to prove. A non-SAT (symbolic) SMT-solver is strictly more
-expressive, due to not being limited to finite integers, however first-order
-logic is not generally decidable, and thus such solvers are often returning
-"Satisfiable", "Not satisfiable", "Not known".
-
-In general, such algorithms are either slow or relatively limited. An example
-of such a limitation is in the [Dafny
-language](https://github.com/Microsoft/dafny), where programs exist that
-compile when having the bound `a \/ b`, but fails when having the bound `b \/
-a`. This can be relatively confusing the user.
-
-It is worth noting that the technology on this area is still improving, and
-these problems will likely be marginalized in a few years.
-
-Another issue which is present in Rust, is that you don't have any logical
-(invariant) information about the return values. Thus, a SMT-solver would work
-relatively poorly (if at all) non-locally (e.g. user defined functions).
-
-That issue is not something that prevents us from adopting a SMT-solver, but it
-limits the experience with having one.
-
-#### Backwards compatibility
-
-While I am against adding SMT-solvers to `rustc`, it is worth noting that this
-change is, in fact, compatible with future extensions for more advanced theorem
-provers.
-
-The only catch with adding a SMT-solver is that errors on unsatisfiability or
-contradictions would be a breaking change. By throwing a warning instead, you
-essentially get the same functionality.
-
 ## The grammar
 
 These extensions expand the type grammar to:
@@ -550,6 +506,58 @@ fn main() {
 ```
 
 # Experimental extensions open to discussion
+
+## SMT-solvers?
+
+This RFC doesn't propose such thing, but future possibilities are worth discussing:
+
+### What a Rusty SMT-solver would look like
+
+The simplest and least obstructive SMT-solver is the SAT-based one. SAT is a
+class of decision problem, where a boolean formula, with some arbitrary number
+of free variables, is determined to be satisfiable or not. Obviously, this is
+decidable (bruteforcing is the simplest algorithm, since the search space is
+finite, bruteforcing is guaranteed to terminate).
+
+SAT is NP-complete, and even simple statements such as `x + y = y + x` can take
+a long time to prove. A non-SAT (symbolic) SMT-solver is strictly more
+expressive, due to not being limited to finite integers, however first-order
+logic is not generally decidable, and thus such solvers are often returning
+"Satisfiable", "Not satisfiable", "Not known".
+
+In general, such algorithms are either slow or relatively limited. An example
+of such a limitation is in the [Dafny
+language](https://github.com/Microsoft/dafny), where programs exist that
+compile when having the bound `a \/ b`, but fails when having the bound `b \/
+a`. This can be relatively confusing the user.
+
+It is worth noting that the technology on this area is still improving, and
+these problems will likely be marginalized in a few years.
+
+Another issue which is present in Rust, is that you don't have any logical
+(invariant) information about the return values. Thus, a SMT-solver would work
+relatively poorly (if at all) non-locally (e.g. user defined functions). This
+is often solved by having an exression of "unknown function", which can have
+any arbitrary body.
+
+That issue is not something that prevents us from adopting a SMT-solver, but it
+limits the experience with having one.
+
+### Backwards compatibility
+
+While I am against adding SMT-solvers to `rustc`, it is worth noting that this
+change is, in fact, compatible with future extensions for more advanced theorem
+provers.
+
+The only catch with adding a SMT-solver is that errors on unsatisfiability or
+contradictions would be a breaking change. By throwing a warning instead, you
+essentially get the same functionality.
+
+### Implementation complications
+
+It will likely not be hard to implement itself, by using an external SMT-solver
+(e.g., Z3). The real proble lies in the probles with performance and
+"obviousness" of the language.
 
 ## Candidates for additional rules
 

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -127,7 +127,7 @@ fn foo<const n: usize, const l: [u32; n]>() -> [u32; n] {
 }
 
 // We know n from the length of the array.
-let l = baz::<_, [1, 2, 3, 4, 5, 6]>();
+let l = foo::<_, [1, 2, 3, 4, 5, 6]>();
 //            ^   ^^^^^^^^^^^^^^^^
 ```
 

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -716,7 +716,7 @@ Unfortunately, transitivity is not reductive.
 
 ### Other relational definitions
 
-Non-eqaulity is defined by:
+Non-equality is defined by:
 
     a ≠ b
     ────────
@@ -741,7 +741,7 @@ This is simply the distributive property of multiplication.
 
 This rules allows us to observe that `a(bc)` is no different from `(ab)c`
 
-Lastly, we are nterested in rewriting subtraction in terms of addition:
+Lastly, we are interested in rewriting subtraction in terms of addition:
 
     SubtractionToAddition:
       a - b ↦ a + (-b)
@@ -937,7 +937,7 @@ if a {
 
 Runtime calls are parameterized over runtime values. These allows the compiler
 to semantically reason about the value of some variable. Thus, the bound can be
-enforced on compile time, by making sure the statements of the value iplies
+enforced on compile time, by making sure the statements of the value implies
 whatever bound that must be satisfied.
 
 #### Advantages and tradeoffs

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -140,6 +140,15 @@ To sum up, the check happens at monomorphization, thus a function can type
 check until it is called (note that this is already possible in present day
 Rust, through `where` bounds).
 
+### (Optional extension:) Transitivity of bounds.
+
+An optional extension is to require a bound of a function to imply the bounds
+of the functions it calls, through a simple unification + alpha-substitution
+algorithm.
+
+The compiler would then enforce that if `f` calls `g`, `unify(bound(g))	⊆
+unify(bound(f))` (by structural equality).
+
 ## The type grammar
 
 These extensions expand the type grammar to:

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -286,6 +286,10 @@ unify(bound(f))` (by structural equality):
       a = b
       ─────
       P(b)
+    DoubleNegation:
+      ¬¬x
+      ───
+      x
 
 These rules are "exhausting" (recursing downwards the tree and decreasing the
 structure), and thus it is possible to check, in this language, that `a ⇒ b`
@@ -309,6 +313,8 @@ of these in the `where` clause unfolding, it returns "True":
         f(x) >= f(x)
     EqReflexive:
         f(x) = f(x)
+    NegFalseIsTrue:
+        ¬false
 
 #### An example
 
@@ -375,6 +381,12 @@ Likewise are disjointness checks based on structural equality.
 Since not all parameters' edges are necessarily the identity function,
 dispatching these would be undecidable. A way to solve this problem is to
 introduce some syntax allowing to specify the `impl` parameters.
+
+## Division by zero
+
+If some function contain a constexpr divisor, dependent on some value parameter
+of the function, that is (`a / f(x)`), the compiler must ensure that the bound
+implies that `f(x) != 0`.
 
 ## An example
 

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -222,6 +222,8 @@ const parameters, by adding an unification relation, simply
       ──────────────
       Γ ⊢ T: U<f(x)>
 
+Informally, this means that, you can substitute equal terms (in this case, `const fn` relations).
+
 The relational edge between two const parameters is simple a const fn, which is
 resolved under unification.
 
@@ -237,9 +239,10 @@ We add an extra rule to improve inference:
       Γ ⊢ c = x
 
 So, if two types share constructor by some Π-constructor, share a value, their
-value parameter is equal.
+value parameter is equal. Take `a: [u8; 4]` as an example. If we have some
+unknown variable `x`, such that `a: [u8; x]`, we can infer that `x = 4`.
 
-This allows us infer:
+This allows us infer e.g. array length parameters in functions:
 
 ```rust
 // [T; N] is a constructor, T → usize → 𝓤 (parameterize over T and you get A → 𝓤).
@@ -284,15 +287,25 @@ unify(bound(f))` (by structural equality):
       ──────
       P
       Q
+
+This simply means that `a && b` means `a` and `b`.
+
     SubstituteEquality:
       P(a)
       a = b
       ─────
       P(b)
+
+This is an important inference rule, when doing unification. This means that
+you can substitute all `a` for all free `b`s, if `a = b`.
+
     DoubleNegation:
       ¬¬x
       ───
       x
+
+The last rule for now is simply stating that double negation is identity, that
+is, `!!a` means that `a` is true.
 
 These rules are "eliminatory" (recursing downwards the tree and decreasing the
 structure), and thus it is possible to check, in this language, that `a ⇒ b`

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -121,7 +121,7 @@ This allows us infer:
 
 ```rust
 // [T; N] is a constructor, T → usize → 𝓤 (parameterize over T and you get A → 𝓤).
-fn foo<n: const usize, l: const [u32; n]>() -> [u32; n] {
+fn foo<const n: usize, const l: [u32; n]>() -> [u32; n] {
     // ^ note how l depends on n.
     l
 }

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -1,0 +1,182 @@
+- Feature Name: pi-types
+- Start Date: 2016-06-22
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+We propose a simple, yet sufficiently expressive, addition of dependent-types
+(also known as, Π-types and value-types).
+
+Type checking remains decidable.
+
+# Motivation
+[motivation]: #motivation
+
+An often requested feature is the "type-level numerals", which enables generic
+length arrays. The current proposals are often limited to integers or even lack
+of value maps, and other critical features.
+
+There is a whole lot of other usecases as well. These allows certain often
+requested features to live in standalone libraries (e.g., bounded-integers,
+type level arithmetics, lattice types).
+
+# Detailed design
+[design]: #detailed-design
+
+## The new value-type construct, `const`
+
+The first construct, we will introduce is `ε → τ` constructor, `const`. All this
+does is taking a const-expr (struct construction, arithmetic expression, and so
+on) and constructs a _type-level version_ of this.
+
+In particular, we extend the type grammar with an additional `const C`, a type
+whose semantics can be described as follows,
+
+    ValueTypeRepresentation:
+      Π ⊢ x: const c
+      --------------
+      Π ⊢ x = c
+
+In other words, if `x` has type `const c`, its value _is_ `c`. That is, any
+constexpr, `c`, will either be of its underlying type or of the type, `const
+c`.
+
+It is important to understand that values of `const c` are constexprs, and
+follows their rules.
+
+## `const fn`s as Π-constructors
+
+We are interested in value dependency, but at the same time, we want to avoid
+complications such as SMT-solvers and so on.
+
+Thus, we follow a purely constructible model, by using `const fn`s.
+
+Let `f` be a `const fn` function. From the rules of `const fn`s and constexprs,
+we can derive the rule,
+
+    PiConstructorInference:
+      Π ⊢ x: const c
+      Π ⊢ f(c): τ
+      --------------
+      Π ⊢ f(x): const τ
+
+This allows one to take some const parameter and map it by some arbitrary, pure
+function.
+
+## Type inference
+
+Since we are able to evaluate the function on compile time, we can easily infer
+const types, by adding an unification relation, from the rule above.
+
+The relational edge between two const types is simple a const fn, which is
+resolved under unification.
+
+## `where` clauses
+
+Often, it is wanted to have some statically checked clause satisfied by the
+constant parameters. To archive this, in a reasonable manner, we use const
+exprs, returning a boolean.
+
+We allow such constexprs in `where` clauses of functions. Whenever the
+function is invoked given constant parameters `<a, b...>`, the compiler
+evaluates this expression, and if it returns `false`, an aborting error is
+invoked.
+
+## The type grammar
+
+These extensions expand the type grammar to:
+
+    T = scalar (i32, u32, ...)        // Scalars
+      | X                             // Type variable
+      | Id<P0..Pn>                    // Nominal type (struct, enum)
+      | &r T                          // Reference (mut doesn't matter here)
+      | O0..On+r                      // Object type
+      | [T]                           // Slice type
+      | for<r..> fn(T1..Tn) -> T0     // Function pointer
+      | <P0 as Trait<P1..Pn>>::Id     // Projection
+      | C                             // const types
+    F = c                             // const fn name
+    C = E                             // Pi constructed const type
+    P = r                             // Region name
+      | T                             // Type
+    O = for<r..> TraitId<P1..Pn>      // Object type fragment
+    r = 'x                            // Region name
+    E = F(E)                          // Constant function application.
+      | p                             // const type parameter
+      | [...]                         // etc.
+
+Note that the `const` prefix is only used when declaring the parameter.
+
+## An example
+
+This is the proposed syntax:
+
+```rust
+use std::{mem, ptr};
+
+// We start by declaring a struct which is value dependent.
+struct Array<n: const usize, T> {
+    // `n` is a constexpr, sharing similar behavior with `const`s, thus this
+    // is possible.
+    content: [T; n],
+}
+
+// We are interested in exploring the `where` clauses and Π-constructors:
+impl<n: const usize, T> Array<n, T> {
+    // This is simple statically checked indexing.
+    fn const_index<i: const usize>(&self) -> &T where i < n {
+    //                        note that this is constexpr  ^^^^^
+        unsafe { self.content.unchecked_index(i) }
+    }
+
+    // "Push" a new element, incrementing its length **statically**.
+    fn push(self, elem: T) -> Array<n + 1, T> {
+        let mut new: [T; n + 1] = mem::uninitialized();
+        //               ^^^^^ constexpr
+        unsafe {
+            ptr::copy(self.content.as_ptr(), new.as_mut_ptr(), n);
+            ptr::write(new.as_mut_ptr().offset(n), elem);
+        }
+
+        // Don't call destructors.
+        mem::forget(self.content);
+
+        // So, the compiler knows the type of `new`. Thus, it can easily check
+        // if the return type is matching. By siply evaluation `n + 1`, then
+        // comparing against the given return type.
+        Array { content: new }
+    }
+}
+
+fn main() {
+    let array: Array<2, u32> = Array { content: [1, 2] };
+
+    assert_eq!(array.const_index::<0>(), 1);
+    assert_eq!(array.const_index::<1>(), 2);
+    assert_eq!(array.push(3).const_index::<2>(), 3);
+}
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+If we want to have type-level Turing completeness, the halting problem is
+inevitable. One could "fix" this by adding timeouts, like the current recursion
+bounds.
+
+Another draw back is the lack of implication proves.
+
+# Alternatives
+[alternatives]: #alternatives
+
+Use full SMT-based dependent types. These are more expressive, but severely
+more complex as well.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+What syntax is preferred? How does this play together with HKP? Can we improve
+the converse type inference? What should be the naming conventions? Should we
+segregate the value parameters and type parameters by `;`?

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -370,11 +370,11 @@ In fact, this set of rule is strictly reductive (like equality-based unification
 #### An example
 
 We will quickly give an example of a possible proof. Say we want to show that
-`x = b ∧ x < a ⇒ b < a`. Starting with the left hand side, we can sequentially
+`(x = b) ∧ ¬¬(x < a) ⇒ b < a`. Starting with the left hand side, we can sequentially
 prove this, by simple unification (which already exists in the Rust type
 checker):
 
-    x = b ∧ ¬¬(x < a)
+    (x = b) ∧ ¬¬(x < a)
     ∴ x = b      (ExpandBooleanAnd)
       ¬¬(x < a)
     ∴ ¬¬(b < a)  (SubstituteEquality)

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -73,7 +73,7 @@ The expr behavior is described as:
 
     ValueParameterDeclaration:
       Π ⊢ const x: T
-      --------------
+      ──────────────
       Π ⊢ x: T
 
 On the type level, we use the very same semantics as the ones generic
@@ -97,7 +97,7 @@ const parameters, by adding an unification relation, simply
     PiRelationInference
       Γ ⊢ y = f(x)
       Γ ⊢ T: U<y>
-      --------------
+      ──────────────
       Γ ⊢ T: U<f(x)>
 
 The relational edge between two const parameters is simple a const fn, which is
@@ -111,7 +111,7 @@ We add an extra rule to improve inference:
       Γ ⊢ x: A
       Γ ⊢ a: T<c>
       Γ ⊢ a: T<x>
-      --------------
+      ──────────────
       Γ ⊢ c = x
 
 So, if two types share constructor by some Π-constructor, share a value, their

--- a/text/0000-pi-types.md
+++ b/text/0000-pi-types.md
@@ -285,7 +285,23 @@ To sum up, the check happens when typechecking the function calls (that is,
 checking if the parameters satisfy the trait bounds). The caller's bounds must
 imply the invoked functions' bounds:
 
-### Transitivity of bounds.
+## Structural equality
+
+Structural equality plays a key role in type checking of dependent types.
+
+Structural equality, in this case, is defined as an equivalence relation, which
+allows substitution without changing semantics.
+
+Any constant parameter must have the `structural_match` property as defined in
+[RFC #1445](https://github.com/rust-lang/rfcs/pull/1445). This property, added
+through the `#[structural_match]` attribute, essentially states that the `Eq`
+implementation is structural.
+
+Without this form of equality, substitution wouldn't be possible, and thus
+typechecking an arbitrarily value-depending type constructor would not be
+possible.
+
+### Transitivity of bounds
 
 We require a bound of a function to imply the bounds of the functions it calls,
 through a simple reductive, unification algorithm. In particular, this means
@@ -534,27 +550,6 @@ fn main() {
 ```
 
 # Experimental extensions open to discussion
-
-## Structural equality will prevail!
-
-When `const fn` methods arrive, we can extend the concept of structural
-equality beyond the "simple" types (e.g., vectors).
-
-Structural equality, in this case, is defined as an equivalence relation, which
-allows substitution without changing semantics.
-
-This trat should be unsafe, and defined as
-
-```rust
-unsafe trait StructuralEq {
-    const fn structural_eq(&self, &Self) -> bool;
-}
-```
-
-This allows us to compare values at type level without loosing the substitution
-property.
-
-Such a thing is unevitable, if we want to be able depend on non-structural values.
 
 ## Candidates for additional rules
 
@@ -833,16 +828,29 @@ conditions may be true under monomorphization.
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-What syntax is preferred?
+## Syntactical/conventional
 
-How does this play together with HKP?
+What syntax is preferred?
 
 What should be the naming conventions?
 
 Should we segregate the value parameters and type parameters by `;`?
 
-Should disjoint implementations satisfying some bound be allowed?
+## Compatibility
+
+How does this play together with HKP?
+
+How can one change bounds without breaking downstream? Shall some form of
+judgemental OR be added?
+
+What API would need to be rewritten to take advantage of Π-types?
+
+## Features
 
 Should there be a way to parameterize functions dynamically?
 
-What API would need to be rewritten to take advantage of Π-types?
+## Semantics
+
+Find some edge cases, which can be confusing.
+
+Are there other rules to consider?

--- a/text/1328-global-panic-handler.md
+++ b/text/1328-global-panic-handler.md
@@ -1,7 +1,7 @@
-- Feature Name: panic_handler
+- Feature Name: `panic_handler`
 - Start Date: 2015-10-08
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: [rust-lang/rfcs#1328](https://github.com/rust-lang/rfcs/pull/1328)
+- Rust Issue: [rust-lang/rust#30449](https://github.com/rust-lang/rust/issues/30449)
 
 # Summary
 


### PR DESCRIPTION
Introduce Π type constructors for Rust.

[Rendered](https://github.com/ticki/rfcs/blob/pi-types/text/0000-pi-types.md)
