### PR TITLE
Clarify behviour when writing to a union field that implements Drop

### DIFF
--- a/text/1444-union.md
+++ b/text/1444-union.md
@@ -114,6 +114,18 @@ If a union contains multiple fields of different sizes, assigning to a field
 smaller than the entire union must not change the memory of the union outside
 that field.
 
+Union fields will normally not implement `Drop`, and by default, declaring a
+union with a field type that implements `Drop` will produce a lint warning.
+Assigning to a field with a type that implements `Drop` will call `drop()` on
+the previous value of that field.  This matches the behavior of `struct` fields
+that implement `Drop`.  To avoid this, such as if interpreting the union's
+value via that field and dropping it would produce incorrect behavior, Rust
+code can assign to the entire union instead of the field.  A union does not
+implicitly implement `Drop` even if its field types do.
+
+The lint warning produced when declaring a union field of a type that
+implements `Drop` should document this caveat in its explanatory text.
+
 ## Pattern matching
 
 Unsafe code may pattern match on union fields, using the same syntax as a
@@ -244,10 +256,12 @@ A union may have trait implementations, using the same `impl` syntax as a
 struct.
 
 The compiler should provide a lint if a union field has a type that implements
-the `Drop` trait.  The compiler may optionally provide a pragma to disable that
-lint, for code that intentionally stores a type with Drop in a union.  The
-compiler must never implicitly generate a Drop implementation for the union
-itself, though Rust code may explicitly implement Drop for a union type.
+the `Drop` trait.  The explanation for that lint should include an explanation
+of the caveat documented in the section "Writing fields".  The compiler may
+optionally provide a pragma to disable that lint, for code that intentionally
+stores a type with Drop in a union.  The compiler must never implicitly
+generate a Drop implementation for the union itself, though Rust code may
+explicitly implement Drop for a union type.
 
 ## Generic unions
 

--- a/text/1444-union.md
+++ b/text/1444-union.md
@@ -257,11 +257,11 @@ struct.
 
 The compiler should provide a lint if a union field has a type that implements
 the `Drop` trait.  The explanation for that lint should include an explanation
-of the caveat documented in the section "Writing fields".  The compiler may
-optionally provide a pragma to disable that lint, for code that intentionally
-stores a type with Drop in a union.  The compiler must never implicitly
-generate a Drop implementation for the union itself, though Rust code may
-explicitly implement Drop for a union type.
+of the caveat documented in the section "Writing fields".  The compiler should
+allow disabling that lint with `#[allow(union_field_drop)]`, for code that
+intentionally stores a type with Drop in a union.  The compiler must never
+implicitly generate a Drop implementation for the union itself, though Rust
+code may explicitly implement Drop for a union type.
 
 ## Generic unions
 

--- a/text/1444-union.md
+++ b/text/1444-union.md
@@ -388,6 +388,17 @@ languages.  Union field accesses already require unsafe blocks, which calls
 attention to them.  Calls to unsafe functions use the same syntax as calls to
 safe functions.
 
+Much discussion in the [tracking issue for
+unions](https://github.com/rust-lang/rust/issues/32836) debated whether
+assigning to a union field that implements Drop should drop the previous value
+of the field.  This produces potentially surprising behavior if that field
+doesn't currently contain a valid value of that type.  However, that behavior
+maintains consistency with assignments to struct fields and mutable variables,
+which writers of unsafe code must already take into account; the alternative
+would add an additional special case for writers of unsafe code.  This does
+provide further motivation for the lint for union fields implementing Drop;
+code that explicitly overrides that lint will need to take this into account.
+
 # Unresolved questions
 [unresolved]: #unresolved-questions
 


### PR DESCRIPTION
Discussion in the [tracking issue for unions](https://github.com/rust-lang/rust/issues/32836) turned up a corner case not addressed by RFC1444: whether assigning to a union field that implements `Drop` should drop the previous value of the field.  Based on that discussion, document that such an assignment does drop the previous value of the field.  Also document how to work around that if needed, and add a note that the lint warning for declaring a union field with a type implementing `Drop` should explicitly document this issue in its explanation.
