### PR TITLE
Extend the `Hasher` trait with `fn delimit` to support one-shot hashing

### DIFF
--- a/text/0000-one-shot-hashing.md
+++ b/text/0000-one-shot-hashing.md
@@ -1,0 +1,96 @@
+- Feature Name: one_shot_hashing
+- Start Date: 2016-07-04
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Extend the `Hasher` trait with a `fn delimit` method. Add an unstable Farmhash
+implementation to the standard library.
+
+# Motivation
+[motivation]: #motivation
+
+The current hashing architecture is suitable for streaming hashing.
+
+In general, for each type which implements Hasher, there cannot be two values
+that produce the same stream. Delimiters are inserted so that values of
+compound types produce unique streams. For example, hashing `("ab", "c")` and
+`("a", "bc")` must produce different results.
+
+Hashing in one shot is possible even today with a custom hasher for constant-
+sized types. However, HashMap keys are often strings and slices. In order to
+allow fast, specialized hashing for more types, we need a clean way of
+handling single writes. Hashing of strings and slices performs two writes to a
+stream: one for a delimiter and the other for the content. We need a way of
+conveying the distinction between the delimiter and actual content. In the
+case of one-shot hashing, the delimiter can be ignored.
+
+# Detailed design
+[design]: #detailed-design
+
+The functionality of streaming hashers remains the same.
+
+A `delimit` method with default implementation is added to the `Hasher` trait as
+follows.
+
+```rust
+trait Hasher {
+    // ...
+
+    /// Emit a delimiter for an array of length `len`.
+    #[inline]
+    #[unstable(feature = "hash_delimit", since = "...", issue="...")]
+    fn delimit(&mut self, len: usize) {
+        self.write_usize(len);
+    }
+}
+```
+
+Farmhash is introduced as an unstable struct at `core::hash::FarmHasher`. It
+should not be exposed in to users of stable Rust.
+
+It may be implemented in the standard library as follows.
+
+```rust
+struct FarmHasher {
+    hash: u64
+}
+
+impl Hasher for FarmHasher {
+    fn write(&mut self, input: &[u8]) {
+        self.hash = farmhash::hash64(input);
+    }
+
+    fn delimit(&mut self, _len: usize) {
+        // Nothing to do.
+    }
+
+    fn finish(&mut self) -> u64 {
+        self.hash
+    }
+}
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+* There will be yet another hashing algorithm to maintain in the standard library.
+* The `Hasher` trait becomes larger.
+
+# Alternatives
+[alternatives]: #alternatives
+
+* Leaving out either or both of these. This means adaptive hashing won't work for
+  string and slice types.
+* Introducing Farmhash as an unstable function.
+* Adding the `fn delimit` method, but leaving out Farmhash.
+* Using MetroHash or some other algorithm instead of Farmhash.
+* Changing SipHash to ignore the first delimiter.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+* Should `str` and `[u8]` get hashed the same way?
+* Can streaming hashers such as SipHash ignore the first or the last delimiter?

--- a/text/0000-one-shot-hashing.md
+++ b/text/0000-one-shot-hashing.md
@@ -6,8 +6,7 @@
 # Summary
 [summary]: #summary
 
-Extend the `Hasher` trait with a `fn delimit` method. Add an unstable Farmhash
-implementation to the standard library.
+Extend the `Hasher` trait with a `fn delimit` method.
 
 # Motivation
 [motivation]: #motivation
@@ -48,45 +47,16 @@ trait Hasher {
 }
 ```
 
-Farmhash is introduced as an unstable struct at `core::hash::FarmHasher`. It
-should not be exposed in to users of stable Rust.
-
-It may be implemented in the standard library as follows.
-
-```rust
-struct FarmHasher {
-    hash: u64
-}
-
-impl Hasher for FarmHasher {
-    fn write(&mut self, input: &[u8]) {
-        self.hash = farmhash::hash64(input);
-    }
-
-    fn delimit(&mut self, _len: usize) {
-        // Nothing to do.
-    }
-
-    fn finish(&mut self) -> u64 {
-        self.hash
-    }
-}
-```
-
 # Drawbacks
 [drawbacks]: #drawbacks
 
-* There will be yet another hashing algorithm to maintain in the standard library.
 * The `Hasher` trait becomes larger.
 
 # Alternatives
 [alternatives]: #alternatives
 
-* Leaving out either or both of these. This means adaptive hashing won't work for
+* Leaving out this, which means adaptive hashing may not work for
   string and slice types.
-* Introducing Farmhash as an unstable function.
-* Adding the `fn delimit` method, but leaving out Farmhash.
-* Using MetroHash or some other algorithm instead of Farmhash.
 * Changing SipHash to ignore the first delimiter.
 
 # Unresolved questions

--- a/text/0000-one-shot-hashing.md
+++ b/text/0000-one-shot-hashing.md
@@ -14,7 +14,7 @@ Extend the `Hasher` trait with a `fn delimit` method.
 Streaming hashing is a way of hashing values of any type. Every significant
 byte of the hashed value is included in a stream. The entire stream is hashed.
 One-shot hashing is a simplification of streaming hashing. It is limited to a
-single scalar value.
+single primitive value.
 
 The current hashing architecture is used for streaming hashing. However, it is
 unfit for optimal one-shot hashing. Consider the following interface for
@@ -47,8 +47,8 @@ In general, for each type which implements Hasher, there cannot be two values
 that produce the same stream. For example, hashing `("ab", "c")` and `("a",
 "bc")` must produce different results. To ensure that, a special value is
 inserted in the stream after the contents of every string. One-shot hashing
-should be able to ignore such delimiters, because compound types can't be
-hashed in one shot.
+should be able to ignore such delimiters, because compound types can't even
+be hashed in one shot.
 
 # Detailed design
 [design]: #detailed-design

--- a/text/0000-one-shot-hashing.md
+++ b/text/0000-one-shot-hashing.md
@@ -20,10 +20,10 @@ compound types produce unique streams. For example, hashing `("ab", "c")` and
 
 Hashing in one shot is possible even today with a custom hasher for constant-
 sized types. However, HashMap keys are often strings and slices. In order to
-allow fast, specialized hashing for more types, we need a clean way of
-handling single writes. Hashing of strings and slices performs two writes to a
-stream: one for a delimiter and the other for the content. We need a way of
-conveying the distinction between the delimiter and actual content. In the
+allow fast, specialized hashing for variable-length types, we need a clean way
+of handling single writes. Hashing of strings and slices performs two writes
+to a stream: one for a delimiter and the other for the content. We need a way
+of conveying the distinction between the delimiter and actual content. In the
 case of one-shot hashing, the delimiter can be ignored.
 
 # Detailed design


### PR DESCRIPTION
[Rich view](https://github.com/pczarn/rfcs/blob/one-shot-hashing/text/0000-one-shot-hashing.md)

Related work
https://github.com/rust-lang/rust/pull/28044 "WIP: Hash and Hasher update for faster common case hashing"
https://github.com/rust-lang/rust/pull/29139 "Make short string hashing 30% faster by splitting Hash::hash_end from Hash::hash"
https://github.com/contain-rs/hashmap2/pull/5 "Implement adaptive hashing using specialization"
