### PR TITLE
Add non-panicking abs() functions to all signed integer types.

### DIFF
--- a/text/0000-no-panic-abs.md
+++ b/text/0000-no-panic-abs.md
@@ -1,4 +1,4 @@
-- Feature Name: wrapping_abs
+- Feature Name: no_panic_abs
 - Start Date: 2016-07-14
 - RFC PR: (leave this empty)
 - Rust Issue: (leave this empty)
@@ -6,15 +6,16 @@
 # Summary
 [summary]: #summary
 
-Add a `wrapping_abs` function to all signed integer types.
+Add the non-panicking `checked_abs`, `overflowing_abs` and `wrapping_abs` 
+functions to all signed integer types.
 
 # Motivation
 [motivation]: #motivation
 
 Currently, calling `abs()` on one of the signed integer types might panic (in 
 debug mode at least) because the absolute value of the largest negative value 
-can not be represented in that signed type. However, this number could be 
-represented correctly when converting to an unsigned type of the same size.
+can not be represented in that signed type. Unlike all other integer 
+operations, there is currently not a non-panicking version on this function.
 
 # Detailed design
 [design]: #detailed-design
@@ -34,6 +35,22 @@ pub fn abs(self) -> Self {
 This RFC proposes to add the following:
 
 ```rust
+pub fn checking_abs(self) -> Option<Self> {
+	if self.is_negative() {
+		self.checked_neg()
+	} else {
+		Some(self)
+	}
+}
+
+pub fn overflowing_abs(self) -> (Self,bool) {
+	if self.is_negative() {
+		self.overflowing_neg()
+	} else {
+		(self,false)
+	}
+}
+
 pub fn wrapping_abs(self) -> Self {
 	if self.is_negative() {
 		self.wrapping_neg()
@@ -43,9 +60,6 @@ pub fn wrapping_abs(self) -> Self {
 }
 ```
 
-The user can then cast the return value to the appropriate unsigned type and 
-use that absolute value.
-
 # Drawbacks
 [drawbacks]: #drawbacks
 
@@ -54,10 +68,15 @@ Can't think of any.
 # Alternatives
 [alternatives]: #alternatives
 
-* One could make a function that returns the unsigned type directly. This RFC 
+* The absolute value of the largest negative value this number could be 
+represented correctly when converting to an unsigned type of the same size.
+One could make a function that returns the unsigned type directly. This RFC 
 does not propose that because the author could not think of a good name for 
 that function. In retrospect, this is probably what the `abs()` function should 
-have done.
+have done. With the proposed new set of functions, the user can then cast the 
+return value of `wrapping_abs` to the appropriate unsigned type and use that 
+absolute value.
+
 * Do nothing, requiring people to implement the functionality manually when 
 needed.
 

--- a/text/0000-no-panic-abs.md
+++ b/text/0000-no-panic-abs.md
@@ -35,7 +35,7 @@ pub fn abs(self) -> Self {
 This RFC proposes to add the following:
 
 ```rust
-pub fn checking_abs(self) -> Option<Self> {
+pub fn checked_abs(self) -> Option<Self> {
 	if self.is_negative() {
 		self.checked_neg()
 	} else {

--- a/text/0000-wrapping-abs.md
+++ b/text/0000-wrapping-abs.md
@@ -1,0 +1,67 @@
+- Feature Name: wrapping_abs
+- Start Date: 2016-07-14
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Add a `wrapping_abs` function to all signed integer types.
+
+# Motivation
+[motivation]: #motivation
+
+Currently, calling `abs()` on one of the signed integer types might panic (in 
+debug mode at least) because the absolute value of the largest negative value 
+can not be represented in that signed type. However, this number could be 
+represented correctly when converting to an unsigned type of the same size.
+
+# Detailed design
+[design]: #detailed-design
+
+This is the current implementation of `abs()`:
+
+```rust
+pub fn abs(self) -> Self {
+	if self.is_negative() {
+		-self
+	} else {
+		self
+	}
+}
+```
+
+This RFC proposes to add the following:
+
+```rust
+pub fn wrapping_abs(self) -> Self {
+	if self.is_negative() {
+		self.wrapping_neg()
+	} else {
+		self
+	}
+}
+```
+
+The user can then cast the return value to the appropriate unsigned type and 
+use that absolute value.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Can't think of any.
+
+# Alternatives
+[alternatives]: #alternatives
+
+* One could make a function that returns the unsigned type directly. This RFC 
+does not propose that because the author could not think of a good name for 
+that function. In retrospect, this is probably what the `abs()` function should 
+have done.
+* Do nothing, requiring people to implement the functionality manually when 
+needed.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+Should there be a similar function on the `Wrapping` wrapper as well?


### PR DESCRIPTION
[Rendered](https://github.com/jethrogb/rfcs/blob/wrapping_abs/text/0000-no-panic-abs.md)