### PR TITLE
Braceless Else on Braced Expressions

### DIFF
--- a/text/0000-braceless-else-on-braced-expressions.md
+++ b/text/0000-braceless-else-on-braced-expressions.md
@@ -18,7 +18,7 @@ the bodies of `if` and `else`.
 This is good because it avoids the ambiguity and the potential for mistakes around nested `if`s and
 `else`s that exists in other C-family languages.
 
-But this can get sverbose when writing single nested expressions after `else` clauses.
+But this can get needlessly verbose when writing single nested expressions after `else` clauses.
 
 ```rust
 if foo() {
@@ -33,7 +33,8 @@ if foo() {
 }
 ```
 
-A better solution would be to *omit* the braces around the body of an `else`.
+A better solution would be to *omit* the braces around the body of an `else`. This leads to a
+more flattened and easily navigable hierarchy.
 
 ```
 if foo() {
@@ -46,8 +47,8 @@ if foo() {
 }
 ```
 
-This type of syntax should only be allowed on *single expressions that require braced blocks*. This
-is to prevent `goto fail` errors when writing code.
+Additionally, this type of syntax should only be allowed on *single expressions that require braced
+blocks*. This is to prevent `goto fail` errors when writing code.
 
 ```
 if foo() {
@@ -57,13 +58,10 @@ if foo() {
     do_the_other(); // oops, this line always runs
 ```
 
-An interesting observation is that this type of syntax already exists in the form of an `else if`
-clause. An `else if` clause can be expanded into an equivalent nested `else ... { if ... }`.
-
 # Detailed design
 [design]: #detailed-design
 
-This proposal can be seen as the natural progression from an `else if` clause to the other
+This proposal can be seen as the generalized version of `else if` that extends to include other
 expressions.
 
 Braces can only be omitted around the body of an `else` if the body is a single expression which
@@ -128,7 +126,7 @@ if foo() {
 // is valid
 ```
 
-Currently the only expression that satisfies this rule are the `if` and `if let` expressions.
+Currently the only expressions that satisfies this rule are the `if` and `if let` expressions.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-braceless-else-on-braced-expressions.md
+++ b/text/0000-braceless-else-on-braced-expressions.md
@@ -1,0 +1,208 @@
+- Feature Name: Braceless Else on Braced Expressions
+- Start Date: 2016-07-25
+- RFC PR:
+- Rust Issue:
+
+# Summary
+[summary]: #summary
+
+Make braces around `else` body optional on single expressions that require braces to increase
+brevity.
+
+# Motivation
+[motivation]: #motivation
+
+Rust doesn't require parenthesis around the condition of an `if`, but does require braces around
+the bodies of `if` and `else`.
+
+This is good because it avoids the ambiguity and the potential for mistakes around nested `if`s and
+`else`s that exists in other C-family languages.
+
+But this can be too verbose when writing stuff like `match` statements inside `else` clauses.
+
+```rust
+if foo() {
+    do_this()
+} else if bar() {
+    do_this_other_thing()
+} else {
+    match baz() {
+        A => do_that(),
+        B => do_the_other(),
+        _ => do_something_else()
+    }
+}
+```
+
+A better solution would be to *omit* the braces around the body of an `else`.
+
+```
+if foo() {
+    do_this()
+} else if bar() {
+    do_this_other_thing()
+} else match baz() {
+    A => do_that(),
+    B => do_the_other(),
+    _ => do_something_else()
+}
+```
+
+However, there's another problem. If we do this for *any* time of expression or statement, a
+potential bug may occur.
+
+```
+if foo() {
+    do_this()
+} else
+    do_that();
+    do_the_other(); // oops, this line always runs
+```
+
+A solution is to limit this behavior to only *single expressions which itself require braces*. This
+includes `match`, `for`, `loop`, and `while`.
+
+An interesting observation is that this type of syntax already exists in the form of an `else if`
+clause. Writing the following code:
+
+```rust
+if foo() {
+    do_this()
+} else if bar() {
+    do_that()
+} else if baz() {
+    do_this_other_thing();
+}
+```
+
+is the same as writing:
+
+```rust
+if foo() {
+    do_this()
+} else {
+    if bar() {
+        do_that()
+    } else {
+        if baz() {
+            do_this_other_thing();
+        }
+    }
+}
+```
+
+This proposal can be seen as the natural progression from the previous syntax to the other
+expressions.
+
+# Detailed design
+[design]: #detailed-design
+
+Braces can only be omitted around the body of an `else` if the body is a single expression which
+itself requires braces.
+
+So these examples are valid:
+
+```
+if foo() {
+    do_this()
+} else match bar() {
+    A => do_that(),
+    B => do_the_other()
+}
+
+if foo() {
+    do_this()
+} else loop {
+    do_this_forever();
+}
+
+if foo() {
+    do_this()
+} else for x in 0..10 {
+    do_this_ten_times();
+}
+```
+
+This example however is not:
+
+```
+if foo() {
+    do_this()
+} else do_that();
+```
+
+An extra `else` clause should be declared as a syntax error if the previous `else <expr>` has no
+`else` clause.
+
+```
+if foo() {
+    do_this()
+} else match bar() {
+    A => do_that(),
+    B => do_the_other()
+} else {
+    // syntax error
+}
+```
+
+As this is equivalent to:
+
+```
+if foo() {
+    do_this()
+} else {
+    match bar() {
+        A => do_that(),
+        B => do_the_other()
+    } else {
+        // syntax error
+    }
+}
+```
+
+As of writing this includes all expressions except `if`.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- This syntax may look foreign to newcomers and may lead to mistaken assumptions such as:
+
+  ```
+  if foo() {
+      do_this()
+  } else match bar() {
+      A => do_that(),
+      B => do_the_other(),
+      _ => do_something_else()
+  } else {
+      // syntax error
+  }
+  ```
+
+  There's no solution for this, other than allowing `else` clauses on these expressions. For the
+  previous example, `match` *does* have a sort of `else` clause in the form of an `_ => ...` match.
+  So something like:
+
+  ```
+  if foo() {
+      do_this()
+  } else match bar() {
+      A => do_that(),
+      B => do_the_other()
+  } else { // hypothetical
+      do_something_else()
+  }
+  ```
+
+  should theoretically work. However this does not exist yet in current Rust and is outside the
+  scope of this proposal.
+
+# Alternatives
+[alternatives]: #alternatives
+
+None.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+None.

--- a/text/0000-braceless-else-on-braced-expressions.md
+++ b/text/0000-braceless-else-on-braced-expressions.md
@@ -134,6 +134,8 @@ if foo() {
 An extra `else` clause should be declared as a syntax error if the previous `else <expr>` has no
 `else` clause.
 
+This is invalid:
+
 ```
 if foo() {
     do_this()
@@ -145,7 +147,7 @@ if foo() {
 }
 ```
 
-As this is equivalent to:
+as it's equivalent to:
 
 ```
 if foo() {
@@ -189,7 +191,7 @@ As of writing this includes all expressions except `if`.
   } else match bar() {
       A => do_that(),
       B => do_the_other()
-  } else { // hypothetical
+  } else { // hypothetical syntax
       do_something_else()
   }
   ```

--- a/text/0000-braceless-else-on-braced-expressions.md
+++ b/text/0000-braceless-else-on-braced-expressions.md
@@ -61,6 +61,43 @@ if foo() {
 # Detailed design
 [design]: #detailed-design
 
+## Examples
+
+```
+if foo() {
+    do_this()
+} else match baz() {
+    A => do_that(),
+    B => do_the_other()
+}
+```
+
+```
+if foo() {
+    do_this()
+} else for i in 0..10 {
+    do_something_ten_times(i);
+}
+```
+
+```
+if foo() {
+    do_this()
+} else loop {
+    do_something_forever();
+}
+```
+
+```
+if foo() {
+    do_this()
+} else while let ("Bacon", b) = get_dish() {
+    println!("Bacon is served with {}", b);
+}
+```
+
+## Description
+
 This proposal can be seen as the generalized version of `else if` that extends to include other
 expressions.
 

--- a/text/0000-braceless-else-on-braced-expressions.md
+++ b/text/0000-braceless-else-on-braced-expressions.md
@@ -48,7 +48,7 @@ if foo() {
 ```
 
 Additionally, this type of syntax should only be allowed on *single expressions that require braced
-blocks*. This is to prevent `goto fail` errors when writing code.
+blocks*. This is to prevent `goto fail`-type errors when writing code.
 
 ```
 if foo() {
@@ -101,10 +101,8 @@ if foo() {
 This proposal can be seen as the generalized version of `else if` that extends to include other
 expressions.
 
-Braces can only be omitted around the body of an `else` if the body is a single expression which
-itself requires braces.
-
-This applies to the following expressions:
+Braces can be omitted around the body of an `else` if the body is a single expression which itself
+requires braces. This includes the following expressions:
 
 - `if`
 - `if let`
@@ -119,6 +117,16 @@ The following code:
 ```
 if foo() {
     do_this()
+} else <expr> {
+    do_that()
+}
+```
+
+is expanded to:
+
+```
+if foo() {
+    do_this()
 } else {
     <expr> {
         do_that();
@@ -126,20 +134,10 @@ if foo() {
 }
 ```
 
-can be flattened to:
-
-```
-if foo() {
-    do_this()
-} else <expr> {
-    do_that()
-}
-```
-
 where `<expr>` is a valid expression from the previously-stated list.
 
-Additional `else` clauses after the `else <expr>` clause can only be valid as long as the
-previous expression has a valid `else` clause.
+Additional `else` clauses after the `else <expr>` clause is only be valid as long as the previous
+expression has a valid `else` clause.
 
 ```
 // the following code is valid

--- a/text/0000-braceless-else-on-braced-expressions.md
+++ b/text/0000-braceless-else-on-braced-expressions.md
@@ -173,10 +173,9 @@ Currently the only expressions that satisfies this rule are the `if` and `if let
       do_this()
   } else match bar() {
       A => do_that(),
-      B => do_the_other(),
-      _ => do_something_else()
+      B => do_the_other()
   } else {
-      // syntax error
+      do_something_else()
   }
   ```
 
@@ -189,10 +188,9 @@ Currently the only expressions that satisfies this rule are the `if` and `if let
   } else {
       match bar() {
           A => do_that(),
-          B => do_the_other(),
-          _ => do_something_else()
+          B => do_the_other()
       } else {
-          // syntax error
+          do_something_else()
       }
   }
   ```
@@ -204,7 +202,10 @@ Currently the only expressions that satisfies this rule are the `if` and `if let
 # Alternatives
 [alternatives]: #alternatives
 
-Don't do this.
+Apply this rule only to `match` expressions. This is to make code feel less "magic" as `match`
+expressions are very similar to `if` expressions.
+
+Or, don't do this.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions


### PR DESCRIPTION
Make braces around `else` body optional on single expressions that require braces to increase brevity.

Addresses issue #1616.