### PR TITLE
Fix typo in fn variance

### DIFF
--- a/text/0738-variance.md
+++ b/text/0738-variance.md
@@ -264,7 +264,7 @@ as desired:
 PhantomData<T>         // covariance
 PhantomData<*mut T>    // invariance, but see "unresolved question"
 PhantomData<Cell<T>>   // invariance
-PhantomData<fn() -> T> // contravariant
+PhantomData<fn(T)>     // contravariant
 ```
 
 Even better, the user doesn't really have to understand the terms


### PR DESCRIPTION
Per https://github.com/rust-lang/rfcs/pull/738#discussion_r23849477

I'm a little unsure though since this hasn't been fixed for so long?