### PR TITLE
Add std::function_name macro for getting the name of the current function

### DIFF
--- a/text/0000-std-function-macro.md
+++ b/text/0000-std-function-macro.md
@@ -56,4 +56,7 @@ would have to be provided by the compiler and standard library.
  - Should a different naming scheme be used?
    - It seems beneficial to use exactly the same as used by backtraces for
      consistency
- - Should the hash at the end be included or not?
+   - Should the hash at the end be included or not?
+   - Using names as in the code seems more intuitive, i.e.
+     `hello::bar::Foo<T>::new` instead of
+     `_<hello..bar..Foo<T>>::new::hee51585ff2209513`

--- a/text/0000-std-function-macro.md
+++ b/text/0000-std-function-macro.md
@@ -6,9 +6,9 @@
 # Summary
 [summary]: #summary
 
-`function` is a macro, which expands to the fully qualified function name from which
-it was invoked. It works similar to `std::file` or `std::line` and expands to
-an expression of type `&'static str`.
+`function_name` is a macro, which expands to the fully qualified function name
+from which it was invoked. It works similar to `std::file`, `std::line` or
+`std::module_path` and expands to an expression of type `&'static str`.
 
 # Motivation
 [motivation]: #motivation
@@ -27,12 +27,83 @@ without even having to look into the source code.
 This feature would have an equivalent design and implementation to
 `std::file`. It would return the fully qualified function name, e.g.
 
- - `hello::main` for function `main` crate `hello`
- - `hello::bar::foo` for function `foo` in crate `hello` and module `bar`
- - `hello::bar::Foo::new` for function `new` in implementation of struct
-   `Foo`, in crate `hello` and module `bar`
- - `hello::bar::Foo<T>::new` for function `new` in implementation of struct
-   `Foo<T>`, in crate `hello` and module `bar`
+ - Plain functions use their name, e.g.
+
+````
+    fn some_function(arg: SomeThing) {
+    ...
+    }
+````
+
+   would result in `some_function`
+
+ - Generic functions use their name, followed by the generic arguments, e.g.
+
+````
+    fn some_function<T, U>(arg: SomeThing) {
+    ...
+    }
+````
+
+   would result in `some_function<T, U>`
+
+
+ - Functions inside non-generic `impl` blocks for structs would use the name of the
+   struct, followed by `::` and the function name, e.g.
+
+````
+    struct SomeStruct {...}
+
+    impl SomeStruct {
+        fn some_function(&self, arg: SomeThing) {
+        ...
+    }
+````
+
+   would result in `SomeStruct::some_function`
+
+ - Functions inside generic `impl` blocks for structs would use the name of the
+   struct, followed by the generic parameters as given by the `impl` block,
+   followed by `::` and the function name, e.g.
+
+````
+    struct SomeStruct<T> {...}
+
+    impl SomeStruct<i32> {
+        fn some_function(&self, arg: SomeThing) {
+        ...
+    }
+````
+
+   would result in `SomeStruct<i32>::some_function` and e.g.
+
+````
+    struct SomeStruct<T> {...}
+
+    impl<T> SomeStruct<T> {
+        fn some_function(&self, arg: SomeThing) {
+        ...
+    }
+````
+
+   would result in `SomeStruct<T>::some_function`
+
+ - Functions inside trait `impl` blocks would use, enclosed in angle brackets,
+   the name of the type, followed by `as`, followed by the trait name, and
+   then `::` followed by the name of the function, e.g.
+
+````
+    impl SomeTrait for SomeStruct {
+        fn some_function(&self, arg: SomeThing) {
+        ...
+    }
+````
+
+   would result in `<SomeStruct as SomeTrait>::some_function`
+
+ - Closures are using the name of the surrounding function, followed by `::`
+   and the string `<closure>`. As closures are not named, coming up with a
+   meaningful name for them automatically is not possible.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -41,6 +112,10 @@ Any addition to the standard library will need to be maintained forever, so it
 is worth weighing the maintenance cost over the value added. Given that this
 is a feature that is considered useful in other languages (e.g. `__FUNC__` in
 C) and is widely used there, it seems to be a useful addition to Rust too.
+
+Also adding a new macro to the standard library will make it impossible to use
+a macro with the same name in user code, because macros are (as of now) not
+namespaced.
 
 # Alternatives
 [alternatives]: #alternatives
@@ -51,6 +126,19 @@ would have to be provided by the compiler and standard library.
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
+ - Different name for the macro
+   - `function` would be nicer but easily conflicts with existing code
+   - `fn` would be consistent with how functions are declared
+   - `function_path`, makes more sense if the `module_path` would be
+     prepended (see below)
  - Should a different naming scheme be used?
    - An alternative would be using the naming scheme of backtraces, but
      that is implementation defined and more disconnected from the code
+ - Should `module_path` be prepended or not?
+   - Seems redundant and easy to get in any case via the other macro
+ - A macro or intrinsic?
+   - Macro would be more in line with existing, similar macros. As such more
+     discoverable and consistent
+   - Intrinsic would not pollute the global namespace
+   - Intrinsics are (currently) not stable
+ - Are there better ways of naming closures?

--- a/text/0000-std-function-macro.md
+++ b/text/0000-std-function-macro.md
@@ -25,16 +25,14 @@ without even having to look into the source code.
 [design]: #detailed-design
 
 This feature would have an equivalent design and implementation to
-`std::file`. It would return the fully qualified function name, which would be
-the same as seen with `RUST_BACKTRACE=1`, e.g.
+`std::file`. It would return the fully qualified function name, e.g.
 
- - `hello::main::h14dbb225e6ef2d49` for function `main` crate `hello`
- - `hello::bar::foo::h98c67baa13aa8344` for function `foo` in crate `hello`
-   and module `bar`
- - `hello::bar::Foo::new::hc3a143caab084f76` for function `new` in
-   implementation of struct `Foo`, in crate `hello` and module `bar`
- - `_<hello..bar..Foo<T>>::new::hee51585ff2209513` for function `new` in
-   implementation of struct `Foo<T>`, in crate `hello` and module `bar`
+ - `hello::main` for function `main` crate `hello`
+ - `hello::bar::foo` for function `foo` in crate `hello` and module `bar`
+ - `hello::bar::Foo::new` for function `new` in implementation of struct
+   `Foo`, in crate `hello` and module `bar`
+ - `hello::bar::Foo<T>::new` for function `new` in implementation of struct
+   `Foo<T>`, in crate `hello` and module `bar`
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -54,9 +52,5 @@ would have to be provided by the compiler and standard library.
 [unresolved]: #unresolved-questions
 
  - Should a different naming scheme be used?
-   - It seems beneficial to use exactly the same as used by backtraces for
-     consistency
-   - Should the hash at the end be included or not?
-   - Using names as in the code seems more intuitive, i.e.
-     `hello::bar::Foo<T>::new` instead of
-     `_<hello..bar..Foo<T>>::new::hee51585ff2209513`
+   - An alternative would be using the naming scheme of backtraces, but
+     that is implementation defined and more disconnected from the code

--- a/text/0000-std-function-macro.md
+++ b/text/0000-std-function-macro.md
@@ -105,6 +105,15 @@ For example the following scheme could be used:
    of the line where the closure is defined. As closures are not named, coming
    up with a meaningful name for them automatically is not easily possible.
 
+ - Nested functions are using the same scheme as closures, but instead of the
+   string `closure` they use their name. The line number of the definition is
+   included to prevent ambiguity with multiple nested functions with the same
+   name defined inside the same function.
+
+   If a nested function defines another nested function, the names are
+   appended to each other and separated by `::`, e.g.
+   `<fn1/definition_line_number_of_fn1::fn2/definition_line_number_of_fn2>`.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 

--- a/text/0000-std-function-macro.md
+++ b/text/0000-std-function-macro.md
@@ -1,0 +1,59 @@
+- Feature Name: Function Name Macro
+- Start Date: (2016-08-19)
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+`function` is a macro, which expands to the fully qualified function name from which
+it was invoked. It works similar to `std::file` or `std::line` and expands to
+an expression of type `&'static str`.
+
+# Motivation
+[motivation]: #motivation
+
+There are currently macros for getting the source file name, `std::file`, and
+the line number, `std::line`. To complete this pair, a macro to for getting
+the current function name would be useful. All three macros are useful for
+e.g. generating log output with more context about where something was
+happening. The file and line is good for being able to look up the exact
+location, however the fully qualified function name gives additional context
+without even having to look into the source code.
+
+# Detailed design
+[design]: #detailed-design
+
+This feature would have an equivalent design and implementation to
+`std::file`. It would return the fully qualified function name, which would be
+the same as seen with `RUST_BACKTRACE=1`, e.g.
+
+ - `hello::main::h14dbb225e6ef2d49` for function `main` crate `hello`
+ - `hello::bar::foo::h98c67baa13aa8344` for function `foo` in crate `hello`
+   and module `bar`
+ - `hello::bar::Foo::new::hc3a143caab084f76` for function `new` in
+   implementation of struct `Foo`, in crate `hello` and module `bar`
+ - `_<hello..bar..Foo<T>>::new::hee51585ff2209513` for function `new` in
+   implementation of struct `Foo<T>`, in crate `hello` and module `bar`
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Any addition to the standard library will need to be maintained forever, so it
+is worth weighing the maintenance cost over the value added. Given that this
+is a feature that is considered useful in other languages (e.g. `__FUNC__` in
+C) and is widely used there, it seems to be a useful addition to Rust too.
+
+# Alternatives
+[alternatives]: #alternatives
+
+There are no alternatives to implement this in user code at this point, it
+would have to be provided by the compiler and standard library.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+ - Should a different naming scheme be used?
+   - It seems beneficial to use exactly the same as used by backtraces for
+     consistency
+ - Should the hash at the end be included or not?

--- a/text/0000-std-function-macro.md
+++ b/text/0000-std-function-macro.md
@@ -25,9 +25,15 @@ without even having to look into the source code.
 [design]: #detailed-design
 
 This feature would have an equivalent design and implementation to
-`std::file`. It would return the fully qualified function name, e.g.
+`std::file`. It would return a fully qualified function name but the actual
+string returned is implementation defined. The string is meant to be used by
+the user to get an idea about the context of the code in e.g. debug output,
+and should be meaningful for a human, but is not meant to be analyzed by a
+program.
 
- - Plain functions use their name, e.g.
+For example the following scheme could be used:
+
+ - Plain functions use their name, e.g. `some_function` for
 
 ````
     fn some_function(arg: SomeThing) {
@@ -35,9 +41,8 @@ This feature would have an equivalent design and implementation to
     }
 ````
 
-   would result in `some_function`
-
  - Generic functions use their name, followed by the generic arguments, e.g.
+   `some_function<T, U>` for
 
 ````
     fn some_function<T, U>(arg: SomeThing) {
@@ -45,11 +50,9 @@ This feature would have an equivalent design and implementation to
     }
 ````
 
-   would result in `some_function<T, U>`
-
-
  - Functions inside non-generic `impl` blocks for structs would use the name of the
    struct, followed by `::` and the function name, e.g.
+   `SomeStruct::some_function` for
 
 ````
     struct SomeStruct {...}
@@ -60,11 +63,10 @@ This feature would have an equivalent design and implementation to
     }
 ````
 
-   would result in `SomeStruct::some_function`
-
  - Functions inside generic `impl` blocks for structs would use the name of the
    struct, followed by the generic parameters as given by the `impl` block,
    followed by `::` and the function name, e.g.
+   `SomeStruct<i32>::some_function` for
 
 ````
     struct SomeStruct<T> {...}
@@ -75,7 +77,7 @@ This feature would have an equivalent design and implementation to
     }
 ````
 
-   would result in `SomeStruct<i32>::some_function` and e.g.
+ - Similar for generic `impl` blocks, e.g. `SomeStruct<T>::some_function` for
 
 ````
     struct SomeStruct<T> {...}
@@ -86,11 +88,10 @@ This feature would have an equivalent design and implementation to
     }
 ````
 
-   would result in `SomeStruct<T>::some_function`
-
  - Functions inside trait `impl` blocks would use, enclosed in angle brackets,
    the name of the type, followed by `as`, followed by the trait name, and
    then `::` followed by the name of the function, e.g.
+   `<SomeStruct as SomeTrait>::some_function` for
 
 ````
     impl SomeTrait for SomeStruct {
@@ -99,11 +100,10 @@ This feature would have an equivalent design and implementation to
     }
 ````
 
-   would result in `<SomeStruct as SomeTrait>::some_function`
-
  - Closures are using the name of the surrounding function, followed by `::`
-   and the string `<closure>`. As closures are not named, coming up with a
-   meaningful name for them automatically is not possible.
+   and the string `<closure/definition_line_number>`, where `definition_line_number` is the number
+   of the line where the closure is defined. As closures are not named, coming
+   up with a meaningful name for them automatically is not easily possible.
 
 # Drawbacks
 [drawbacks]: #drawbacks


### PR DESCRIPTION
This was previously discussed in https://github.com/rust-lang/rust/issues/35651

[Rendered](https://github.com/sdroege/rfcs/blob/standard-function-macro/text/0000-std-function-macro.md)
