### PR TITLE
Abort by default v2

### DIFF
--- a/text/0000-abort-by-default.md
+++ b/text/0000-abort-by-default.md
@@ -1,0 +1,70 @@
+- Feature Name: abort_by_default
+- Start Date: 2016-10-01
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Use abort as the standard panic method rather than unwind.
+
+# Motivation
+[motivation]: #motivation
+
+## Performance
+
+Generally, the performance of bigger programs [improves by 10%](https://www.youtube.com/watch?v=mRGb4hoGuPs), which is no small amount. When overflow checking is enabled, it is as high as 2x, making overflowing checking plausible in production.
+
+The performance gains mainly originates in the fact that it is a lot easier for the compiler to optimize, due to the unwind path disappearing, and hence reasoning about the code becomes easier.
+
+## Binary size
+
+Binary size improves by 10% as well. This is due to the lack of landing pads which are injected in the stack when unwinding is enabled.
+
+## Compile time
+
+Compile time in debug mode improves by 20% on average. In release mode, the number is around 10%.
+
+## Runtime size
+
+Unwinding requires a fair amount of runtime code, which can be seen as conflicting with the goals of Rust.
+
+## Correctness
+
+You often see people abusing `std::panic::catch_unwind` for exception handling. Forcing the user to explicitly opt in to unwinding will make it harder to unintentionally misuse it.
+
+# Detailed design
+[design]: #detailed-design
+
+Default to `panic=abort`.
+
+## Backwards compatibility
+
+No code should rely on a particular default panicking strategy, and code which do is already broken. However, this broken code might start actually encountering the issues. In a sense, that is actually positive, since it reveals that the code is broken.
+
+No invariants are broken, and no code is going to emit Undefined Behavior due to this change (this can be seen by observing that aborting is globally diverging, and hence no code is run after).
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+While not breaking, the behavior of certain broken programs can change.
+
+It makes panics global by default (i.e., panicking in some thread will abort the whole program).
+
+It might make it tempting to ignore the existence of an unwind option and consequently shaping the code after panicking being aborting.
+
+# Alternatives
+[alternatives]: #alternatives
+
+Keep unwinding as default.
+
+Make Cargo set `panic=abort` in all new binaries.
+
+Use unwind in `debug` and abort in `release`.
+
+Make use of more exotic instructions like `bound`, allowing e.g. overflow or bound checking without branches. This comes at the expense of error output.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+None.

--- a/text/0000-abort-by-default.md
+++ b/text/0000-abort-by-default.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Use abort as the standard panic method rather than unwind.
+Specify `panic=abort` in `Cargo.toml` when the user does `cargo new --bin`.
 
 # Motivation
 [motivation]: #motivation
@@ -36,18 +36,16 @@ You often see people abusing `std::panic::catch_unwind` for exception handling. 
 # Detailed design
 [design]: #detailed-design
 
-Default to `panic=abort`.
+Have `cargo` generate `panic=abort` to the `Cargo.toml`. Whenever the user inteacts with `cargo` (by using a command) and the `Cargo.toml` has no specified panicking strategy, it will add `panic=unwind` and leave a note to the user: 
 
-## Backwards compatibility
+    Warning: No panic strategy was specified, added unwinding to the `Cargo.toml` file, please consider change it to your needs.
 
-No code should rely on a particular default panicking strategy, and code which do is already broken. However, this broken code might start actually encountering the issues. In a sense, that is actually positive, since it reveals that the code is broken.
+For libraries, nothing is modified, as they inherit the strategy of the binary.
 
-No invariants are broken, and no code is going to emit Undefined Behavior due to this change (this can be seen by observing that aborting is globally diverging, and hence no code is run after).
+After several release cycles, an extension could be added, which makes specifying the strategy mandatory.
 
 # Drawbacks
 [drawbacks]: #drawbacks
-
-While not breaking, the behavior of certain broken programs can change.
 
 It makes panics global by default (i.e., panicking in some thread will abort the whole program).
 

--- a/text/0000-abort-by-default.md
+++ b/text/0000-abort-by-default.md
@@ -51,6 +51,12 @@ It makes panics global by default (i.e., panicking in some thread will abort the
 
 It might make it tempting to ignore the existence of an unwind option and consequently shaping the code after panicking being aborting.
 
+## Unwinding is not bad per se
+
+Unwinding has numerous advantages. Especially for certain classes of applications. These includes better error handling and better cleanup.
+
+Unwinding is especially important to long-running applications.
+
 # Alternatives
 [alternatives]: #alternatives
 

--- a/text/0000-abort-by-default.md
+++ b/text/0000-abort-by-default.md
@@ -36,11 +36,21 @@ You often see people abusing `std::panic::catch_unwind` for exception handling. 
 # Detailed design
 [design]: #detailed-design
 
-Have `cargo` generate `panic=abort` to the `Cargo.toml`. Whenever the user inteacts with `cargo` (by using a command) and the `Cargo.toml` has no specified panicking strategy, it will add `panic=unwind` and leave a note to the user: 
+Have `cargo` generate `panic=abort` to the `Cargo.toml`. Whenever the user inteacts with `cargo` (by using a command) and the `Cargo.toml` has no specified panicking strategy, it will add `panic=unwind` and leave a note to the user:
 
     Warning: No panic strategy was specified, added unwinding to the `Cargo.toml` file, please consider change it to your needs.
 
-For libraries, nothing is modified, as they inherit the strategy of the binary.
+## Libraries
+
+For libraries, the `Cargo.toml` is not modified, as they inherit the strategy of the binary.
+
+### Relying on unwinding
+
+If a library specifies `panic=unwind`, it will stored in a rlib metadata field, `unwind_needed`. If this field does not match with the crate which is linking against the library, `rustc` will produce an error.
+
+This is done in order to make sure that applications can rely on unwinding without leading to unsafety when being linked against by an aborting runtime.
+
+## Extensions
 
 After several release cycles, an extension could be added, which makes specifying the strategy mandatory.
 


### PR DESCRIPTION
This version is updated to reflect all the concerns mentioned in [the previous proposal](https://github.com/rust-lang/rfcs/pull/1759). Especially the concerns for stability are now fixed. Instead of switching the default, we switch what `cargo new` generates as well as making `cargo build` add `panic=unwind` to smoothen the transition to mandatory choice of panicking strategy.

[Rendered](https://github.com/ticki/rfcs/blob/abort-by-default/text/0000-abort-by-default.md)

cc. @Ericson2314 @eddyb @rkruppe @petrochenkov @apasel422 @steveklabnik @sfackler @Amanieu @frewsxcv @aturon @brson @Valloric @gnzlbg @nikomatsakis (participants in the previous thread).
