### PR TITLE
Conversions from `&mut T` to `&Cell<T>`

### DIFF
--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -118,7 +118,7 @@ for (i, j) in v_slice[n..].iter().zip(v_slice) {
 
 ## Language
 
-The core of this proposal is the ability to cast a `&T` to a `&Cell<T>`,
+The core of this proposal is the ability to convert a `&T` to a `&Cell<T>`,
 so in order for it to be safe, __it needs to be guaranteed that
 `T` and `Cell<T>` have the same memory layout__, and that there are no codegen
 issues based on viewing a reference to a type that does not contain a
@@ -175,7 +175,7 @@ effect on any existing code.
 
 ### Cell Slicing
 
-We enable a cast from `&Cell<[T]>` to `&[Cell<T>]`. This seems like it violates
+We enable a conversion from `&Cell<[T]>` to `&[Cell<T>]`. This seems like it violates
 the "no interior references" API of `Cell` at first glance, but is actually
 safe:
 
@@ -189,10 +189,10 @@ safe:
   through a `&Cell<[T]>`, or just a memcopy to a single element through a
   `&Cell<T>`.
 - Yet another way to look at it is that if we created a `&mut T` to each element
-  of a `&mut [T]`, and casted each of them to a `&Cell<T>`, their addresses
+  of a `&mut [T]`, and converted each of them to a `&Cell<T>`, their addresses
   would allow "stitching" them back together to a single `&[Cell<T>]`
 
-For convenience, we expose this cast by implementing `Index` for `Cell<[T]>`:
+For convenience, we expose this conversion by implementing `Index` for `Cell<[T]>`:
 
 ```rust
 impl<T> Index<RangeFull> for Cell<[T]> {
@@ -286,8 +286,8 @@ you have mutable access to it.
 > Would the acceptance of this proposal change how Rust is taught to new users at any level?
 How should this feature be introduced and taught to existing Rust users?
 
-As it is, the API just provides a few neat casting functions. Nevertheless,
-with the legalization of the `&mut T -> &Cell<T>` cast there is the
+As it is, the API just provides a few neat conversion functions. Nevertheless,
+with the legalization of the `&mut T -> &Cell<T>` conversion there is the
 potential for a major change in how accessors to data structures are provided:
 
 In todays Rust, there are generally three different ways:
@@ -317,8 +317,8 @@ of ownership and change it to a "rule of four".
 
 > What additions or changes to the Rust Reference, _The Rust Programming Language_, and/or _Rust by Example_ does it entail?
 
-- The reference should explain that the `&mut T -> &Cell<T>` cast,
-  or specifically the `&mut T -> &UnsafeCell<T>` cast is fine.
+- The reference should explain that the `&mut T -> &Cell<T>` conversion,
+  or specifically the `&mut T -> &UnsafeCell<T>` conversion is fine.
 - The book could use the API introduced here if it talks about internal mutability,
   and use it as a "temporary opt-in" example.
 - Rust by Example could have a few basic examples of situations where this API
@@ -378,13 +378,13 @@ conversions steps, while still offering essentially the same API.
 
 ## Just the language guarantee
 
-The cast could be guaranteed as correct, but not be provided by std
+The conversion could be guaranteed as correct, but not be provided by std
 itself. This would serve as legitimization of external implementations like
 [alias](https://crates.io/crates/alias).
 
 ## No guarantees
 
-If the casting guarantees can not be granted,
+If the safety guarantees of the conversion can not be granted,
 code would have to use direct indexing as today, with either possible
 bound checking costs or the use of unsafe code to avoid them.
 
@@ -416,10 +416,10 @@ Cons:
 
 ## Cast to `&mut Cell<T>` instead of `&Cell<T>`
 
-Nothing that makes the `&mut T -> &Cell<T>` cast safe would prevent
+Nothing that makes the `&mut T -> &Cell<T>` conversion safe would prevent
 `&mut T -> &mut Cell<T>` from being safe either, and the latter can be
 trivially turned into a `&Cell<T>` while also allowing mutable access - eg to
-call `Cell::as_mut()` to cast back again.
+call `Cell::as_mut()` to conversion back again.
 
 Similar to that, there could also be a way to turn a `&mut [Cell<T>]` back
 into a `&mut [T]`.

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -131,7 +131,9 @@ However, if changes as proposed in https://github.com/rust-lang/rfcs/pull/1651 s
 get implemented, the `Copy` bound might get relaxed or removed entirely,
 which would affect the ergonomics here.
 
-The proposed implementation only covers the base case `&mut T -> &Cell<T>`
+It might also be possible to add `AsRef` implementations for this conversion.
+
+The proposal only covers the base case `&mut T -> &Cell<T>`
 and the trivially implementable extension to `[T]`,
 but in theory this conversion could be enabled for
 many "higher level mutable reference" types, like for example

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -335,18 +335,6 @@ of ownership and change it to a "rule of four".
 # Alternatives
 [alternatives]: #alternatives
 
-## Just the language guarantee
-
-The cast could be guaranteed as correct, but not be provided by std
-itself. This would serve as legitimization of external implementations like
-[alias](https://crates.io/crates/alias).
-
-## No guarantees
-
-If the casting guarantees can not be granted,
-code would have to use direct indexing as today, with either possible
-bound checking costs or the use of unsafe code to avoid them.
-
 ## Removing cell slicing
 
 Instead of allowing unsized types in `Cell` and adding the `Index` impls,
@@ -387,6 +375,31 @@ for (i, j) in v_slice[n..].iter().zip(v_slice) {
 
 This would be less modular than the `&mut [T] -> &Cell<[T]> -> &[Cell<T>]`
 conversions steps, while still offering essentially the same API.
+
+## Cast to `&mut Cell<T>` instead of `&Cell<T>`
+
+Nothing that makes the `&mut T -> &Cell<T>` cast safe would prevent
+`&mut T -> &mut Cell<T>` from being safe either, and the latter can be
+trivially turned into a `&Cell<T>` while also allowing mutable access - eg to
+call `Cell::as_mut()` to cast back again.
+
+Similar to that, there could also be a way to turn a `&mut [Cell<T>]` back
+into a `&mut [T]`.
+
+However, this does not seem to be actually useful since the only reason to use
+this API is to make use of shared internal mutability.
+
+## Just the language guarantee
+
+The cast could be guaranteed as correct, but not be provided by std
+itself. This would serve as legitimization of external implementations like
+[alias](https://crates.io/crates/alias).
+
+## No guarantees
+
+If the casting guarantees can not be granted,
+code would have to use direct indexing as today, with either possible
+bound checking costs or the use of unsafe code to avoid them.
 
 ## Exposing the functions differently
 

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -366,7 +366,7 @@ impl<T> Cell<T> {
 
 Usage:
 
-```
+```rust
 let mut v: Vec<i32> = ...;
 
 // convert the mutable borrow

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -1,5 +1,5 @@
-- Feature Name: (fill me in with a unique ident, my_awesome_feature)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Feature Name: as_cell
+- Start Date: 2016-11-13
 - RFC PR: (leave this empty)
 - Rust Issue: (leave this empty)
 

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -309,7 +309,7 @@ For example, today there exist:
 
 We could then add a fourth iterator like this:
 
-- &mut [T] -> `std::slice::CellIter<T>`, which yields `&Cell<T>` values and is
+- `&mut [T] -> std::slice::CellIter<T>`, which yields `&Cell<T>` values and is
   cloneable because it does a shared borrow.
 
 So there is the potential that we go away from teaching the "rule of three"

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -182,7 +182,7 @@ safe:
 - A slice represents a number of elements next to each other.
   Thus, if `&mut T -> &Cell<T>` is ok, then `&mut [T] -> &[Cell<T>]` would be as well.
   `&mut [T] -> &Cell<[T]>` follows from `&mut T -> &Cell<T>` through substitution,
-  so `&Cell<T> <-> &[Cell<T>]` has to be valid.
+  so `&Cell<[T]> <-> &[Cell<T>]` has to be valid.
 - The API of a `Cell<T>` is to allow internal mutability through single-threaded
   memcopies only. Since a memcopy is just a copy of all bits that make up a type,
   it does not matter if we logically do a memcopy to all elements of a slice

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -58,14 +58,14 @@ to enable safe mutation even with only shared views into the data:
 let v: Vec<Cell<i32>> = ...;
 
 // example 1
-for i in v.iter() {
-    for j in v.iter() {
+for i in &v {
+    for j in &v {
         j.set(f(i.get(), j.get()));
     }
 }
 
 // example 2
-for (i, j) in v[n..].iter().zip(v.iter()) {
+for (i, j) in v[n..].iter().zip(&v) {
     i.set(g(g.get()));
 }
 
@@ -99,14 +99,14 @@ let mut v: Vec<i32> = ...;
 let v_slice: &[Cell<T>] = Cell::from_mut_slice(&mut v);
 
 // example 1
-for i in v_slice.iter() {
-    for j in v_slice.iter() {
+for i in v_slice {
+    for j in v_slice {
         j.set(f(i.get(), j.get()));
     }
 }
 
 // example 2
-for (i, j) in v_slice[n..].iter().zip(v_slice.iter()) {
+for (i, j) in v_slice[n..].iter().zip(v_slice) {
     i.set(g(g.get()));
 }
 

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -167,7 +167,22 @@ an example implementation and a more complex use case.
 [alternatives]: #alternatives
 
 Instead of a dedicated trait, the functionality could be provided
-by standalone functions like this:
+as `Cell` constructors:
+
+```rust
+
+impl<T: Copy> Cell<T> {
+    fn from_mut<'a>(t: &'a mut T) -> &'a Cell<T> {
+        unsafe { mem::transmute(t) }
+    }
+    fn from_mut<'a>(t: &'a mut [T]) -> &'a [Cell<T>] {
+        unsafe { mem::transmute(t) }
+    }
+}
+
+```
+
+Or more simple, by standalone functions like this:
 
 ```rust
 fn ref_as_cell<T: Copy>(t: &mut T) -> &Cell<T> {

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -175,7 +175,7 @@ impl<T: Copy> Cell<T> {
     fn from_mut<'a>(t: &'a mut T) -> &'a Cell<T> {
         unsafe { mem::transmute(t) }
     }
-    fn from_mut<'a>(t: &'a mut [T]) -> &'a [Cell<T>] {
+    fn from_mut_slice<'a>(t: &'a mut [T]) -> &'a [Cell<T>] {
         unsafe { mem::transmute(t) }
     }
 }

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -1,0 +1,191 @@
+- Feature Name: (fill me in with a unique ident, my_awesome_feature)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+For `T: Copy`, add conversion functions with the following signatures to std:
+
+- `&mut T -> &Cell<T>`
+- `&mut [T] -> &[Cell<T>]`
+
+# Motivation
+[motivation]: #motivation
+
+Rusts iterators offer a safe, fast way to iterate over collections while avoiding
+additional bound checks.
+
+However, due to the borrow checker, they run into issues if you try to have
+more than one iterator into the same data structure while mutating elements in it.
+
+Wanting to do this is not that unusual for many low level algorithms
+that deal with integers, floats or similar primitive data types.
+
+For example, an algorithm might...
+
+- For each element, access each other element.
+- For each element, access an element a number of elements before or after it.
+
+Todays answer for algorithms like that is to fall back to C-style
+for loops and indexing, which might look like this...
+
+```rust
+
+let v: Vec<i32> = ...;
+
+// example 1
+for i in 0..v.len() {
+    for j in 0..v.len() {
+        v[j] = f(v[i], v[j]);
+    }
+}
+
+// example 2
+for i in n..v.len() {
+    v[i] = g(v[i - n]);
+}
+
+```
+
+...but this reintroduces the bound-checking costs.
+
+However, there exists a third alternative: Using internal mutability
+to enable safe mutation even with only shared views into the data:
+
+```rust
+let v: Vec<Cell<i32>> = ...;
+
+// example 1
+for i in v.iter() {
+    for j in v.iter() {
+        j.set(f(i.get(), j.get()));
+    }
+}
+
+// example 2
+for (i, j) in v[n..].iter().zip(v.iter()) {
+    i.set(g(g.get()));
+}
+
+```
+
+This has the advantages of allowing both bound-check free iteration and
+aliasing references, but comes with restrictions that makes it not generally
+applicable, namely:
+
+- The need to modify the data structure containing the data (Which might not
+  always be possible because it might come from external code).
+- Restriction to `Copy` types for `Cell`, and ref count overhead for `RefCell`.
+- Loss of the ability to directly hand out `&T` and `&mut T` references to the data.
+
+This RFC proposes a way to address the first and the last of the
+previous restrictions by introducing simple conversions functions
+to the standard library that allow the creation of `&Cell<T>`s from `&mut T`s.
+
+This allows the original data structure to remain unchanged in type, which makes
+this approach more applicable to more problems, and an answer to many of the
+situations that require C-style for loops at the moment.
+
+# Detailed design
+[design]: #detailed-design
+
+Add conversions functions for `&mut T -> &Cell<T>` and `&mut [T] -> &[Cell<T>]`
+to std, implemented with the equivalent of a simple `transmute()`.
+
+As an initial design, `std::cell` would provide them through this trait:
+
+```rust
+trait AsCell {
+    type Cell;
+    fn as_cell(self) -> Self::Cell;
+}
+
+impl<'a, T: Copy> AsCell for &'a mut T {
+    type Cell = &'a Cell<T>;
+    fn as_cell(self) -> Self::Cell {
+        unsafe { mem::transmute(t) }
+    }
+}
+
+impl<'a, T: Copy> AsCell for &'a mut [T] {
+    type Cell = &'a [Cell<T>];
+    fn as_cell(self) -> Self::Cell {
+        unsafe { mem::transmute(t) }
+    }
+}
+```
+
+In theory it could get added to the prelude, but it should probably
+follow `Cell`s lead there, which is currently not in there.
+
+Method dispatch would work as expected with this design:
+
+- `v.as_cell()` where `v: Vec` would correctly pick the `[T]` impl.
+- `x.as_cell()` where `x` is a copyable type correctly picks the `T` impl.
+- `a.as_cell()` where `a` is a copyable array would pick the `T` impl,
+  and require explicit slicing with `a[..].as_cell()` to pick the `[T]` one.
+
+However, if changes as proposed in https://github.com/rust-lang/rfcs/pull/1651 should
+get implemented, the `Copy` bound might get relaxed or removed entirely,
+which would affect the ergonomics here.
+
+The proposed implementation only covers the base case `&mut T -> &Cell<T>`
+and the trivially implementable extension to `[T]`,
+but in theory this conversion could be enabled for
+many "higher level mutable reference" types, like for example
+mutable iterators (with the goal of making them cloneable through this).
+
+In order for this proposal to be safe, it needs to be guaranteed that
+`T` and `Cell<T>` have the same memory layout, and that there are no codegen
+issues based on viewing a reference to a `UnsafeCell`-less types as a
+reference to a `UnsafeCell`-containing type.
+
+As far as the author is aware, both should already fall out of the semantic of
+`Cell` and llvms notion of aliasing:
+
+- `Cell` is safe interior mutability based on memcopying the `T`,
+  and thus does not need additional fields.
+- `&mut T -> &U` is a sub borrow, which prevents access to the original `&mut T`
+  for its duration, thus no aliasing.
+
+See https://play.rust-lang.org/?gist=d012cebf462841887323185cff8ccbcc&version=stable&backtrace=0 for
+an example implementation and a more complex use case.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+> Why should we *not* do this?
+
+- More complexity around the `Cell` API.
+- `T` -> `Cell<T>` transmute compatibility might not be a desired guarantee.
+
+# Alternatives
+[alternatives]: #alternatives
+
+Instead of a dedicated trait, the functionality could be provided
+by standalone functions like this:
+
+```rust
+fn ref_as_cell<T: Copy>(t: &mut T) -> &Cell<T> {
+    unsafe { mem::transmute(t) }
+}
+
+fn slice_as_cell<T: Copy>(t: &mut [T]) -> &[Cell<T>] {
+    unsafe { mem::transmute(t) }
+}
+```
+
+The cast could also be guaranteed as correct, but not be provided by std
+itself, and rather be provided by an external crate.
+
+Lastly, if the casting guarantees can not be granted,
+code would have to use direct indexing as today, with either possible
+bound checking costs or the use of unsafe code to avoid them.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+Interactions with proposals like https://github.com/rust-lang/rfcs/pull/1651
+is unclear, but possibly beneficial.

--- a/text/0000-as-cell.md
+++ b/text/0000-as-cell.md
@@ -82,11 +82,35 @@ applicable, namely:
 
 This RFC proposes a way to address the first and the last of the
 previous restrictions by introducing simple conversions functions
-to the standard library that allow the creation of `&Cell<T>`s from `&mut T`s.
+to the standard library that allow the creation of shared borrowed
+`Cell<T>`s from mutably borrowed `T`s.
 
 This allows the original data structure to remain unchanged in type, which makes
 this approach more applicable to more problems, and an answer to many of the
 situations that require C-style for loops at the moment.
+
+As an example, given `Cell::from_mut_slice(&mut [T]) -> &[Cell<T>]`,
+the previous Example can be written as this:
+
+```rust
+let mut v: Vec<i32> = ...;
+
+// convert the mutable borrow
+let v_slice: &[Cell<T>] = Cell::from_mut_slice(&mut v);
+
+// example 1
+for i in v_slice.iter() {
+    for j in v_slice.iter() {
+        j.set(f(i.get(), j.get()));
+    }
+}
+
+// example 2
+for (i, j) in v_slice[n..].iter().zip(v_slice.iter()) {
+    i.set(g(g.get()));
+}
+
+```
 
 # Detailed design
 [design]: #detailed-design

--- a/text/1789-as-cell.md
+++ b/text/1789-as-cell.md
@@ -1,7 +1,7 @@
 - Feature Name: as_cell
 - Start Date: 2016-11-13
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: https://github.com/rust-lang/rfcs/pull/1789
+- Rust Issue: https://github.com/rust-lang/rust/issues/43038
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
A proposal about legitimizing the cast of a `&mut T` to a `&Cell<T>`.

[Rendered](https://github.com/Kimundi/rfcs/blob/as-cell/text/0000-as-cell.md)