### PR TITLE
Add 'How We Teach This' to template, per RFC 1636.

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -23,9 +23,11 @@ This should get into specifics and corner-cases, and include examples of how the
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
-What names and terminology work best for these concepts and why? How is this idea best presented—as a continuation of existing Rust patterns, or as a wholly new one?
+What names and terminology work best for these concepts and why? 
+How is this idea best presented—as a continuation of existing Rust patterns, or as a wholly new one?
 
-Would the acceptance of this proposal change how Rust is taught to new users at any level? How should this feature be introduced and taught to existing Rust users?
+Would the acceptance of this proposal change how Rust is taught to new users at any level? 
+How should this feature be introduced and taught to existing Rust users?
 
 What additions or changes to the Rust Reference, _The Rust Programming Language_, and/or _Rust by Example_ does it entail?
 

--- a/0000-template.md
+++ b/0000-template.md
@@ -20,6 +20,15 @@ This is the bulk of the RFC. Explain the design in enough detail for somebody fa
 with the language to understand, and for somebody familiar with the compiler to implement.
 This should get into specifics and corner-cases, and include examples of how the feature is used.
 
+# How We Teach This
+[how-we-teach-this]: #how-we-teach-this
+
+What names and terminology work best for these concepts and why? How is this idea best presented—as a continuation of existing Rust patterns, or as a wholly new one?
+
+Would the acceptance of this proposal change how Rust is taught to new users at any level? How should this feature be introduced and taught to existing Rust users?
+
+What additions or changes to the Rust Reference, _The Rust Programming Language_, and/or _Rust by Example_ does it entail?
+
 # Drawbacks
 [drawbacks]: #drawbacks
 


### PR DESCRIPTION
You have taken your first step into a larger world (of new features—and some old ones—being documented)!

![first-step](https://cloud.githubusercontent.com/assets/2403023/20952918/d1449aa8-bbfd-11e6-8bd6-e2a623483dfb.jpg)

Implements the required change to the RFC template per #1636.