### PR TITLE
extern types

### DIFF
--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -64,7 +64,7 @@ These types are FFI-safe. They are also DSTs, meaning that they do not implement
 In Rust, pointers to DSTs carry metadata about the object being pointed to.
 For strings and slices this is the length of the buffer, for trait objects this is the object's vtable.
 For extern types the metadata is simply `()`.
-This means that a pointer to an extern type is identical to a raw pointer (ie. it is not a "fat pointer").
+This means that a pointer to an extern type has the same size as a `usize` (ie. it is not a "fat pointer").
 It also means that if we store an extern type at the end of a container (such as a struct or tuple) pointers to that container will also be identical to raw pointers (despite the container as a whole being unsized).
 This is useful to support a pattern found in some C APIs where structs are passed around which have arbitrary data appended to the end of them: eg.
 

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -64,7 +64,7 @@ These types are FFI-safe. They are also DSTs, meaning that they do not implement
 In Rust, pointers to DSTs carry metadata about the object being pointed to.
 For strings and slices this is the length of the buffer, for trait objects this is the object's vtable.
 For extern types the metadata is simply `()`.
-This means that a pointer to an extern type is identical to a raw pointer.
+This means that a pointer to an extern type is identical to a raw pointer (ie. it is not a "fat pointer").
 It also means that if we store an extern type at the end of a container (such as a struct or tuple) pointers to that container will also be identical to raw pointers (despite the container as a whole being unsized).
 This is useful to support a pattern found in some C APIs where structs are passed around which have arbitrary data appended to the end of them: eg.
 

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -59,7 +59,7 @@ extern {
 }
 ```
 
-These types are FFI-safe. They are also DSTs, meaning that they do not implement `Sized`. Being DSTs, they cannot be kept on the stack and can only be accessed through pointers.
+These types are FFI-safe. They are also DSTs, meaning that they do not implement `Sized`. Being DSTs, they cannot be kept on the stack, can only be accessed through pointers and references and cannot be moved from.
 
 In Rust, pointers to DSTs carry metadata about the object being pointed to.
 For strings and slices this is the length of the buffer, for trait objects this is the object's vtable.
@@ -111,6 +111,9 @@ This should be taught in the foreign function interface chapter of the rust book
 
 Very slight addition of complexity to the language.
 
+The syntax has the potential to be confused with introducing a type alias, rather than a new nominal type.
+The use of `extern` here is also a bit of a misnomer as the name of the type does not refer to anything external to Rust.
+
 # Alternatives
 [alternatives]: #alternatives
 
@@ -119,6 +122,9 @@ Not do this.
 Alternatively, rather than provide a way to create opaque types, we could just offer one distinguished type (`std::mem::OpaqueData` or something like that).
 Then, to create new opaque types, users just declare a struct with a member of type `OpaqueData`.
 This has the advantage of introducing no new syntax, and issues like FFI-compatibility would fall out of existing rules.
+
+Another alternative is to drop the `extern` and allow a declaration to be written `type A;`.
+This removes the (arguably disingenuous) use of the `extern` keyword although it makes the syntax look even more like a type alias.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -95,9 +95,9 @@ And `libc` can, in the worst-case, make a breaking change.
 
 Really, the question is "how do we teach *without* this".
 As described above, the current tricks for doing this are wrong.
-Furthermore, they are quite advanced touching upon many advanced corners of the language: zero-sized and uninhabited types are phenomena few programmer coming from mainstream languages have considered.
+Furthermore, they are quite advanced touching upon many advanced corners of the language: zero-sized and uninhabited types are phenomena few programmer coming from mainstream languages have encountered.
 From reading around other RFCs, issues, and internal threads, one gets a sense of two issues:
-First, even among the group Rust programmers enthusiastic enough to participate in these fora, the semantics of foreign types are not widely understood.
+First, even among the group of Rust programmers enthusiastic enough to participate in these fora, the semantics of foreign types are not widely understood.
 Second, there is annoyance that none of the current tricks, by nature of them all being flawed in different ways, would become standard.
 
 By contrast, `extern type` does exactly what one wants, with an obvious and guessable syntax, without forcing the user to immediately understand all the nuance about why *these* semantics are indeed the right ones.

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -116,6 +116,10 @@ Very slight addition of complexity to the language.
 
 Not do this.
 
+Alternatively, rather than provide a way to create opaque types, we could just offer one distinguished type (`std::mem::OpaqueData` or something like that).
+Then, to create new opaque types, users just declare a struct with a member of type `OpaqueData`.
+This has the advantage of introducing no new syntax, and issues like FFI-compatibility would fall out of existing rules.
+
 # Unresolved questions
 [unresolved]: #unresolved-questions
 

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -91,7 +91,8 @@ The exact mechanism is more the domain of the custom DST RFC, [RFC 1524](https:/
 
 C's "pointer `void`" (not `()`, but the `void` used in `void*` and similar) is currently defined in two official places: [`std::os::raw::c_void`](https://doc.rust-lang.org/stable/std/os/raw/enum.c_void.html) and [`libc::c_void`](https://doc.rust-lang.org/libc/x86_64-unknown-linux-gnu/libc/enum.c_void.html).
 Unifying these is out of scope for this RFC, but this feature should be used in their definition instead of the current tricks.
-Strictly speaking, this is breaking change, but the `std` docs explicitly say this shouldn't be used without indirection, and `libc` worse-case can make a breaking release.
+Strictly speaking, this is a breaking change, but the `std` docs explicitly say that `void` shouldn't be used without indirection.
+And `libc` can, in the worst-case, make a breaking change.
 
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -22,15 +22,15 @@ In Rust, we don't have this feature. Instead, a couple of problematic hacks are 
 One is, we define the type as an uninhabited type. eg.
 
 ```rust
-    enum MyFfiType {}
+enum MyFfiType {}
 ```
 
 Another is, we define the type with a private field and no methods to construct it.
 
 ```rust
-    struct MyFfiType {
-        _priv: (),
-    }
+struct MyFfiType {
+    _priv: (),
+}
 ```
 
 The point of both these constructions is to prevent the user from being able to create or deal directly with instances of the type.
@@ -51,18 +51,12 @@ Just like unions, this is an unsafe feature necessary for dealing with legacy co
 # Detailed design
 [design]: #detailed-design
 
-Add a new kind of type declaration, an `extern type`:
+Add a new kind of type declaration, an extern type:
 
 ```rust
-    extern type Foo;
-```
-
-These can also be declared inside an `extern` block:
-
-```rust
-    extern {
-        type Foo;
-    }
+extern {
+    type Foo;
+}
 ```
 
 These types are FFI-safe. They are also DSTs, meaning that they do not implement `Sized`. Being DSTs, they cannot be kept on the stack and can only be accessed through pointers.
@@ -75,7 +69,9 @@ It also means that if we store an extern type at the end of a container (such as
 This is useful to support a pattern found in some C APIs where structs are passed around which have arbitrary data appended to the end of them: eg.
 
 ```rust
-extern type OpaqueTail;
+extern {
+    type OpaqueTail;
+}
 
 #[repr(C)]
 struct FfiStruct {

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -1,0 +1,110 @@
+- Feature Name: extern_types
+- Start Date: 2017-01-18
+- RFC PR: 
+- Rust Issue: 
+
+# Summary
+[summary]: #summary
+
+Add an `extern type` syntax for declaring types which are opaque to Rust's type
+system.
+
+# Motivation
+[motivation]: #motivation
+
+When interacting with external libraries we often need to be able to handle
+pointers to data that we don't know the size or layout of.
+
+In C it's possible to declare a type but not define it. These incomplete types
+can only be used behind pointers, a compilation error will result if the
+user tries to use them in such a way that the compiler would need to know their
+layout.
+
+In Rust, we don't have this feature. Instead, a couple of problematic hacks are
+used in its place.
+
+One is, we define the type as an uninhabited type. eg.
+
+    enum MyFfiType {}
+
+Another is, we define the type with a private field and no methods to construct
+it.
+
+    struct MyFfiType {
+        _priv: (),
+    }
+
+The point of both these constructions is to prevent the user from being able to
+create or deal directly with instances of
+the type. Niether of these types accurately reflect the reality of the
+situation. The first definition is logically problematic as it defines a type
+which can never exist. This means that references to the type can also -
+logically - never exist and raw pointers to the type are guaranteed to be
+invalid. The second definition says that the type is a ZST, that we can store
+it on the stack and that we can call `ptr::read`, `mem::size_of` etc. on it.
+None of this is of course valid.
+
+This RFC instead proposes a way to directly express that a type exists but is
+unknown to Rust.
+
+# Detailed design
+[design]: #detailed-design
+
+Add a new kind of type declaration, an `extern type`:
+
+    extern type Foo;
+
+These can also be declared inside an `extern` block:
+
+    extern {
+        type Foo;
+    }
+
+These types are FFI-safe. They are also DSTs, meaning that they implement
+`?Sized`. Being DSTs, they cannot be kept on the stack and can only be
+accessed through pointers.
+
+In Rust, pointers to DSTs carry metadata about the object being pointed to. For
+strings and slices this is the length of the buffer, for trait objects this is
+the object's vtable. For extern types the metadata is simply `()`. This means
+that a pointer to an extern type is identical to a raw pointer. It also means
+that if we store an extern type at the end of a container (such as a struct or
+tuple) pointers to that container will also be identical to raw pointers
+(despite the container as a whole being unsized). This is useful to support a
+pattern found in some C APIs where structs are passed around which have
+arbitrary data appended to the end of them: eg.
+
+```rust
+extern type OpaqueTail;
+
+#[repr(C)]
+struct FfiStruct {
+    data: u8,
+    more_data: u32,
+    tail: OpaqueTail,
+}
+```
+
+# How We Teach This
+[how-we-teach-this]: #how-we-teach-this
+
+This should be taught in the foreign function interface chapter of the rust
+book in place of where it currently tells people to use uninhabited enums
+(ack!).
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Very slight addition of complexity to the language.
+
+# Alternatives
+[alternatives]: #alternatives
+
+Not do this.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+Should we allow generic lifetime and type parameters on extern types? If so,
+how do they effect the type in terms of variance?
+

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -98,7 +98,7 @@ As described above, the current tricks for doing this are wrong.
 Furthermore, they are quite advanced touching upon many advanced corners of the language: zero-sized and uninhabited types are phenomena few programmer coming from mainstream languages have considered.
 From reading around other RFCs, issues, and internal threads, one gets a sense of two issues:
 First, even among the group Rust programmers enthusiastic enough to participate in these fora, the semantics of foreign types are not widely understood.
-Send, there is annoyance that none of the current tricks, by nature of them all being flawed in different ways, would become standard.
+Second, there is annoyance that none of the current tricks, by nature of them all being flawed in different ways, would become standard.
 
 By contrast, `extern type` does exactly what one wants, with an obvious and guessable syntax, without forcing the user to immediately understand all the nuance about why *these* semantics are indeed the right ones.
 As they see various options fail: moves, stack variables, they can discover these semantics incrementally.

--- a/text/1861-extern-types.md
+++ b/text/1861-extern-types.md
@@ -1,7 +1,7 @@
 - Feature Name: extern_types
 - Start Date: 2017-01-18
-- RFC PR: 
-- Rust Issue: 
+- RFC PR: https://github.com/rust-lang/rfcs/pull/1861
+- Rust Issue: https://github.com/rust-lang/rust/issues/43467
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
Add `extern type` declarations for declaring types from external libraries which have an unknown size/layout.

[Rendered](https://github.com/canndrew/rfcs/blob/extern-types/text/0000-extern-types.md)