### PR TITLE
Add unstable sort to libcore

### DIFF
--- a/text/0000-unstable-sort.md
+++ b/text/0000-unstable-sort.md
@@ -42,7 +42,7 @@ equivalent to stable sort.
 **Q: Why is `slice::sort` stable?**<br>
 A: Because stability is a good default. A programmer might call a sort function
 without checking in the documentation whether it is stable or unstable. It is very
-inutitive to assume stability, so having `slice::sort` perform unstable sorting might
+intuitive to assume stability, so having `slice::sort` perform unstable sorting might
 cause unpleasant surprises.
 
 **Q: Why does `slice::sort` allocate?**<br>

--- a/text/0000-unstable-sort.md
+++ b/text/0000-unstable-sort.md
@@ -31,8 +31,9 @@ assert!(orig == v); // MAY FAIL!
 
 **Q: When is stability useful?**<br>
 A: Not very often. A typical example is sorting columns in interactive GUI tables.
-If you want to have rows sorted by column X while breaking ties by column Y, you
-first have to click on column Y and then click on column X.
+E.g. you want to have rows sorted by column X while breaking ties by column Y, so you
+first click on column Y and then click on column X. This is a rare case where stable
+sorting is important.
 
 **Q: Can stable sort be performed using unstable sort?**<br>
 A: Yes. If we transform `[T]` into `[(T, usize)]` by pairing every element with it's
@@ -57,7 +58,7 @@ A: Sorting 64-bit integers using [pdqsort][stjepang-pdqsort] (an
 unstable sort implementation) is **40% faster** than using `slice::sort`.
 Detailed benchmarks are [here](https://github.com/stjepang/pdqsort#extensive-benchmarks).
 
-**Q: Can unstable sorting benefit from allocation?**<br>
+**Q: Can unstable sort benefit from allocation?**<br>
 A: Generally, no. There is no fundamental property in computer science saying so,
 but this has always been true in practice. Zero-allocation and instability go
 hand in hand.
@@ -153,8 +154,11 @@ instantly benefit from higher performance and lower memory use.
 **Q: Is `slice::sort` ever faster than pdqsort?**<br>
 A: Yes, there are a few cases where it is faster. For example, if the slice
 consists of several pre-sorted sequences concatenated one after another, then
-`slice::sort` will most probably be faster. But other than that, it should be
-generally slower than pdqsort.
+`slice::sort` will most probably be faster. Another case is when using costly
+comparison functions, e.g. when sorting strings. `slice::sort` optimizes the
+number of comparisons very well, while pdqsort optimizes for fewer writes to
+memory at expense of slightly larger number of comparisons. But other than
+that, `slice::sort` should be generally slower than pdqsort.
 
 **Q: What about radix sort?**<br>
 A: Radix sort is usually blind to patterns in slices. It treats totally random

--- a/text/0000-unstable-sort.md
+++ b/text/0000-unstable-sort.md
@@ -25,7 +25,7 @@ v.sort_by_key(|p| p.0);
 assert!(orig == v); // OK!
 
 /// Unstable sort may or may not preserve the original order.
-v.unstable_sort_by_key(|p| p.0);
+v.sort_unstable_by_key(|p| p.0);
 assert!(orig == v); // MAY FAIL!
 ```
 
@@ -72,9 +72,9 @@ systems programming language by not offering a built-in alternative.
 
 The API will consist of three functions that mirror the current sort in libstd:
 
-1. `core::slice::unstable_sort`
-2. `core::slice::unstable_sort_by`
-3. `core::slice::unstable_sort_by_key`
+1. `core::slice::sort_unstable`
+2. `core::slice::sort_unstable_by`
+3. `core::slice::sort_unstable_by_key`
 
 By contrast, C++ has functions `std::sort` and `std::stable_sort`, where the
 defaults are set up the other way around.
@@ -121,13 +121,13 @@ pub trait SliceExt {
 
     // ...
 
-    fn unstable_sort(&mut self)
+    fn sort_unstable(&mut self)
         where Self::Item: Ord;
 
-    fn unstable_sort_by<F>(&mut self, compare: F)
+    fn sort_unstable_by<F>(&mut self, compare: F)
         where F: FnMut(&Self::Item, &Self::Item) -> Ordering;
   
-    fn unstable_sort_by_key<B, F>(&mut self, mut f: F)
+    fn sort_unstable_by_key<B, F>(&mut self, mut f: F)
         where F: FnMut(&Self::Item) -> B,
               B: Ord;
 }
@@ -138,17 +138,17 @@ pub trait SliceExt {
 ```rust
 let mut v = [-5i32, 4, 1, -3, 2];
 
-v.unstable_sort();
+v.sort_unstable();
 assert!(v == [-5, -3, 1, 2, 4]);
 
-v.unstable_sort_by(|a, b| b.cmp(a));
+v.sort_unstable_by(|a, b| b.cmp(a));
 assert!(v == [4, 2, 1, -3, -5]);
 
-v.unstable_sort_by_key(|k| k.abs());
+v.sort_unstable_by_key(|k| k.abs());
 assert!(v == [1, 2, -3, 4, -5]);
 ```
 
-In most cases it's sufficient to prepend `sort` with `unstable_` and
+In most cases it's sufficient to append `_unstable` to `sort` and
 instantly benefit from higher performance and lower memory use.
 
 **Q: Is `slice::sort` ever faster than pdqsort?**<br>
@@ -171,14 +171,14 @@ not even that much faster than pdqsort anyway.
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
-Stability is a confusing and loaded term. Function `slice::unstable_sort` might be
+Stability is a confusing and loaded term. Function `slice::sort_unstable` might be
 misunderstood as a function that has unstable API. That said, there is no
 less confusing alternative to "unstable sorting". Documentation should
 clearly state what "stable" and "unstable" mean.
 
-`slice::unstable_sort` will be mentioned in the documentation for `slice::sort`
+`slice::sort_unstable` will be mentioned in the documentation for `slice::sort`
 as a faster non-allocating alternative. The documentation for
-`slice::unstable_sort` must also clearly state that it guarantees no allocation.
+`slice::sort_unstable` must also clearly state that it guarantees no allocation.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -187,7 +187,7 @@ The implementation of sort algorithms will grow bigger, and there will be more
 code to review.
 
 It might be surprising to discover cases where `slice::sort` is faster than
-`slice::unstable_sort`. However, these peculiarities can be explained in
+`slice::sort_unstable`. However, these peculiarities can be explained in
 documentation.
 
 # Alternatives
@@ -195,12 +195,12 @@ documentation.
 
 Unstable sorting is indistinguishable from stable sorting when sorting
 primitive integers. It's possible to specialize `slice::sort` to fall back
-to `slice::unstable_sort`. This would improve performance for primitive integers in
+to `slice::sort_unstable`. This would improve performance for primitive integers in
 most cases, but patching cases type by type with different algorithms makes
 performance more inconsistent and less predictable.
 
-Unstable sort guarantees no allocation. Instead of naming it `slice::unstable_sort`,
-it could also be named `slice::noalloc_sort` or `slice::noalloc_unstable_sort`.
+Unstable sort guarantees no allocation. Instead of naming it `slice::sort_unstable`,
+it could also be named `slice::sort_noalloc` or `slice::sort_unstable_noalloc`.
 This may slightly improve clarity, but feels much more awkward.
 
 Unstable sort can also be provided as a standalone crate instead of

--- a/text/0000-unstable-sort.md
+++ b/text/0000-unstable-sort.md
@@ -1,4 +1,4 @@
-- Feature Name: unstable_sort
+- Feature Name: sort_unstable
 - Start Date: 2017-02-03
 - RFC PR: (leave this empty)
 - Rust Issue: (leave this empty)

--- a/text/0000-unstable-sort.md
+++ b/text/0000-unstable-sort.md
@@ -54,8 +54,8 @@ considerably slower.
 A: Because it allocates additional memory.
 
 **Q: How much faster can unstable sort be?**<br>
-A: Sorting 64-bit integers using [pdqsort][stjepang-pdqsort] (an
-unstable sort implementation) is **40% faster** than using `slice::sort`.
+A: Sorting 10M 64-bit integers using [pdqsort][stjepang-pdqsort] (an
+unstable sort implementation) is **45% faster** than using `slice::sort`.
 Detailed benchmarks are [here](https://github.com/stjepang/pdqsort#extensive-benchmarks).
 
 **Q: Can unstable sort benefit from allocation?**<br>

--- a/text/0000-unstable-sort.md
+++ b/text/0000-unstable-sort.md
@@ -20,7 +20,7 @@ of sort algorithms like higher performance or lower memory overhead are often mo
 desirable.
 
 Having a performant, non-allocating unstable sort function in libcore would cover those
-needs. At the moment Rust is not offering a built-in alternative (only crates), which
+needs. At the moment Rust is not offering this solution as a built-in (only crates), which
 is unusual for a systems programming language.
 
 **Q: What is stability?**<br>
@@ -54,6 +54,8 @@ A: Because stability is a good default. A programmer might call a sort function
 without checking in the documentation whether it is stable or unstable. It is very
 intuitive to assume stability, so having `slice::sort` perform unstable sorting might
 cause unpleasant surprises.
+See this [story](https://medium.com/@cocotutch/a-swift-sorting-problem-e0ebfc4e46d4#.yfvsgjozx)
+for an example.
 
 **Q: Why does `slice::sort` allocate?**<br>
 A: It is possible to implement a non-allocating stable sort, but it would be


### PR DESCRIPTION
Every other systems programming language has a fast, non-allocating, unstable sort in standard library. Rust still doesn't. This is a proposal to add one to libcore.

The proposed implementation is **very fast**, faster than `std::slice::sort` and `std::sort` in C++ by a wide margin.

This topic was discussed before in the issue #790

[Rendered](https://github.com/stjepang/rfcs/blob/unstable-sort/text/0000-unstable-sort.md)