### PR TITLE
Allow an optional vert at the beginning of a match branch

### DIFF
--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -6,9 +6,8 @@
 # Summary
 [summary]: #summary
 
-This is a proposal for the rust grammar to support verts `|` *both*
-at the beginning of the pattern and at the end. Consider the following
-example:
+This is a proposal for the rust grammar to support a vert `|` at the
+beginning of the pattern. Consider the following example:
 
 ```rust
 use E::*;
@@ -22,7 +21,7 @@ match foo {
 
 // This is an example of what this proposal should allow.
 match foo {
-    | A | B | C | D | => (),
+    | A | B | C | D => (),
 }
 ```
 
@@ -61,20 +60,13 @@ match foo with
 
 ## Maximizing `|` alignment
 
-In Rust, about the best we can do is an inconsistent alignment:
+In Rust, about the best we can do is an inconsistent alignment with one of the
+following two options:
 
 ```rust
 use E::*;
 
 enum E { A, B, C, D }
-
-match foo {
-    A |
-    B |
-    C |
-    D => (),
-//    ^ Inconsistently missing a `|`
-}
 
 match foo {
 //  |
@@ -84,9 +76,18 @@ match foo {
     | C
     | D => (),
 }
+
+match foo {
+    A |
+    B |
+    C |
+    D => (),
+//    ^ Also inconsistent but since this is the last in the sequence, not having 
+//    | a followup vert could be considered sensible given that no more follow.
+}
 ```
 
-Allowing this proposal would allow this example to take one of the following forms:
+This proposal would allow the example to have the following form:
 
 ```rust
 use E::*;
@@ -94,19 +95,11 @@ use E::*;
 enum E { A, B, C, D }
 
 match foo {
-    A |
-    B |
-    C |
-    D | => (),
-//    ^ Gained consistency by having a vert.
-}
-
-match foo {
     | A
     | B
     | C
     | D => (),
-//  ^ Also gained consistency.
+//  ^ Gained consistency by having a matching vert.
 }
 ```
 
@@ -119,28 +112,18 @@ use E::*;
 
 enum E { A, B, C, D }
 
-// Only trailing `|`.
-match foo {
-    A | B | C | D | => (),
-}
-
-// Only preceding `|`.
+// A preceding vert
 match foo {
     | A | B | C | D => (),
 }
 
-// Both preceding and trailing `|`.
-match foo {
-    | A | B | C | D | => (),
-}
-
-// Neither preceding nor trailing `|`.
+// A match as is currently allowed
 match foo {
     A | B | C | D => (),
 }
 ```
 
-> There should be no ambiguity about what each of these mean. Preference
+> There should be no ambiguity about what either of these means. Preference
 between these should just come down to a choice of style.
 
 ## Benefits to macros
@@ -179,13 +162,6 @@ match foo {
     C | D =>
         println!("Give me C | D!"),
 }
-
-match foo {
-    A |
-    B | => println!("Give me A | B!"),
-    C |
-    D | => println!("Give me C | D!"),
-}
 ```
 
 ## Comparing misalignment
@@ -223,15 +199,15 @@ grammar should need updating.
 // Before
 match_pat : pat [ '|' pat ] * [ "if" expr ] ? ;
 // After
-match_pat : '|' ? pat [ '|' pat ] * '|' ? [ "if" expr ] ? ;
+match_pat : '|' ? pat [ '|' pat ] * [ "if" expr ] ? ;
 ```
 
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
 Adding examples for this are straightforward. You just include an example pointing
-out that leading and trailing verts are allowed. Simple examples such as below should
-be easy to add to all different resources.
+out that leading verts are allowed. Simple examples such as below should be easy
+to add to all different resources.
 
 ```rust
 use Letter::*;
@@ -261,19 +237,6 @@ fn main() {
         | B
         | C
         | D => "B, C, or D",
-    }
-
-    match c {
-        A | => "A",
-        // Trailing `|` is allowed.
-        B |
-        C |
-        D | => "B, C, or D",
-    }
-
-    match d {
-        // Both are allowed.
-        | A | B | C | D | => "Got a letter",
     }
 }
 ```

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -1,4 +1,4 @@
-- Feature Name: `match_vert_prefix
+- Feature Name: `match_vert_prefix`
 - Start Date: 2017-02-23
 - RFC PR: (leave this empty)
 - Rust Issue: (leave this empty)

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -192,8 +192,8 @@ match value {
 [design]: #detailed-design
 
 I don't know about the implementation but the grammar could be updated so that
-an optional `|` is allowed at the beginning and the end. Nothing else in the
-grammar should need updating.
+an optional `|` is allowed at the beginning. Nothing else in the grammar should
+need updating.
 
 ```text
 // Before

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -15,16 +15,14 @@ use E::*;
 
 enum E { A, B, C, D }
 
-fn main() {
-    // This is valid Rust
-    match foo {
-        A | B | C | D => (),
-    }
+// This is valid Rust
+match foo {
+    A | B | C | D => (),
+}
 
-    // This is an example of what this proposal should allow.
-    match foo {
-        | A | B | C | D | => (),
-    }
+// This is an example of what this proposal should allow.
+match foo {
+    | A | B | C | D | => (),
 }
 ```
 
@@ -70,14 +68,12 @@ use E::*;
 
 enum E { A, B, C, D }
 
-fn main() {
-    match foo {
-        A |
-        B |
-        C |
-        D => (),
-    //    ^ Inconsistently missing a `|`
-    }
+match foo {
+    A |
+    B |
+    C |
+    D => (),
+//    ^ Inconsistently missing a `|`
 }
 ```
 
@@ -88,22 +84,20 @@ use E::*;
 
 enum E { A, B, C, D }
 
-fn main() {
-    match foo {
-        A |
-        B |
-        C |
-        D | => (),
-    //    ^ Gained consistency by having a vert.
-    }
+match foo {
+    A |
+    B |
+    C |
+    D | => (),
+//    ^ Gained consistency by having a vert.
+}
 
-    match foo {
-        | A
-        | B
-        | C
-        | D => (),
-    //  ^ Gained *both* an alternative style and consistency.
-    }
+match foo {
+    | A
+    | B
+    | C
+    | D => (),
+//  ^ Gained *both* an alternative style and consistency.
 }
 ```
 
@@ -116,26 +110,24 @@ use E::*;
 
 enum E { A, B, C, D }
 
-fn main() {
-    // Only trailing `|`.
-    match foo {
-        A | B | C | D | => (),
-    }
+// Only trailing `|`.
+match foo {
+    A | B | C | D | => (),
+}
 
-    // Only preceding `|`.
-    match foo {
-        | A | B | C | D => (),
-    }
+// Only preceding `|`.
+match foo {
+    | A | B | C | D => (),
+}
 
-    // Both preceding and trailing `|`.
-    match foo {
-        | A | B | C | D | => (),
-    }
+// Both preceding and trailing `|`.
+match foo {
+    | A | B | C | D | => (),
+}
 
-    // Neither preceding nor trailing `|`.
-    match foo {
-        A | B | C | D => (),
-    }
+// Neither preceding nor trailing `|`.
+match foo {
+    A | B | C | D => (),
 }
 ```
 
@@ -155,37 +147,35 @@ use E::*;
 
 enum E { A, B, C, D }
 
-fn main() {
-    match foo {
-        A | B => println!("Give me A | B!"),
-        C | D => println!("Give me C | D!"),
-    }
+match foo {
+    A | B => println!("Give me A | B!"),
+    C | D => println!("Give me C | D!"),
+}
 
-    match foo {
-        | A | B => println!("Give me A | B!"),
-        | C | D => println!("Give me C | D!"),
-    }
+match foo {
+    | A | B => println!("Give me A | B!"),
+    | C | D => println!("Give me C | D!"),
+}
 
-    match foo {
-        | A
-        | B => println!("Give me A | B!"),
-        | C
-        | D => println!("Give me C | D!"),
-    }
+match foo {
+    | A
+    | B => println!("Give me A | B!"),
+    | C
+    | D => println!("Give me C | D!"),
+}
 
-    match foo {
-        A | B =>
-            println!("Give me A | B!"),
-        C | D =>
-            println!("Give me C | D!"),
-    }
+match foo {
+    A | B =>
+        println!("Give me A | B!"),
+    C | D =>
+        println!("Give me C | D!"),
+}
 
-    match foo {
-        A |
-        B | => println!("Give me A | B!"),
-        C |
-        D | => println!("Give me C | D!"),
-    }
+match foo {
+    A |
+    B | => println!("Give me A | B!"),
+    C |
+    D | => println!("Give me C | D!"),
 }
 ```
 
@@ -196,22 +186,20 @@ use E::*;
 
 enum E { A, B, C }
 
-fn main() {
-    match foo {
-        | A
-        | B => {},
-        | C => {}
-    //  ^ Following the style above, a `|` could be placed before the first
-    // element of every branch.
+match foo {
+    | A
+    | B => {},
+    | C => {}
+//  ^ Following the style above, a `|` could be placed before the first
+// element of every branch.
 
-    match value {
-        | A
-        | B => {},
-        C => {}
-    //  ^ Including a `|` for the `A` but not for the `C` seems inconsistent
-    // but hardly invalid. Branches *always* follow the `=>`. Not something
-    // a *grammar* should be greatly concerned about.
-    }
+match value {
+    | A
+    | B => {},
+    C => {}
+//  ^ Including a `|` for the `A` but not for the `C` seems inconsistent
+// but hardly invalid. Branches *always* follow the `=>`. Not something
+// a *grammar* should be greatly concerned about.
 }
 ```
 
@@ -226,7 +214,7 @@ need updating.
 // Before
 match_pat : pat [ '|' pat ] * [ "if" expr ] ? ;
 // After
-match_pat : '|' ? pat [ '|' pat ] * [ "if" expr ] ? ;
+match_pat : '|' ? pat [ '|' pat ] * '|' ? [ "if" expr ] ? ;
 ```
 
 # How We Teach This

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -230,37 +230,50 @@ match_pat : '|' ? pat [ '|' pat ] * '|' ? [ "if" expr ] ? ;
 [how-we-teach-this]: #how-we-teach-this
 
 Adding examples for this are straightforward. You just include an example pointing
-out that leading verts are allowed. Simple examples such as below should be easy to
-add to all different resources.
+out that leading and trailing verts are allowed. Simple examples such as below should
+be easy to add to all different resources.
 
 ```rust
-enum Cat {
-    Burmese,
-    Munchkin,
-    Siamese,
-}
+use Letter::*;
 
-enum Dog {
-    Dachshund,
-    Poodle,
-    PitBull,
+enum Letter {
+    A,
+    B,
+    C,
+    D,
 }
 
 fn main() {
-    let cat = Cat::MunchKin;
-    let dog = Dog::Poodle;
+    let a = Letter::A;
+    let b = Letter::B;
+    let c = Letter::C;
+    let d = Letter::D;
 
-    match cat {
-        Cat::Burmese => "Burmese",
+    match a {
+        A => "A",
         // Can do alternatives with a `|`.
-        Cat::MunchKin | Cat::Siamese => "Not burmese",
+        B | C | D => "B, C, or D",
     }
 
-    match dog {
-        | Dog::Dachshund => "Dachshund",
+    match b {
+        | A => "A",
         // Leading `|` is allowed.
-        | Dog::Poodle
-        | Dog::PitBull => "Not a dachshund",
+        | B
+        | C
+        | D => "B, C, or D",
+    }
+
+    match c {
+        A | => "A",
+        // Trailing `|` is allowed.
+        B |
+        C |
+        D | => "B, C, or D",
+    }
+
+    match d {
+        // Both are allowed.
+        | A | B | C | D | => "Got a letter",
     }
 }
 ```

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -61,7 +61,7 @@ match foo with
 
 ## Maximizing `|` alignment
 
-In Rust, about the best we can do is align via the trailing edge:
+In Rust, about the best we can do is an inconsistent alignment:
 
 ```rust
 use E::*;
@@ -74,6 +74,15 @@ match foo {
     C |
     D => (),
 //    ^ Inconsistently missing a `|`
+}
+
+match foo {
+//  |
+//  V Inconsistently missing a `|`.
+      A
+    | B
+    | C
+    | D => (),
 }
 ```
 
@@ -97,7 +106,7 @@ match foo {
     | B
     | C
     | D => (),
-//  ^ Gained *both* an alternative style and consistency.
+//  ^ Also gained consistency.
 }
 ```
 
@@ -207,8 +216,8 @@ match value {
 [design]: #detailed-design
 
 I don't know about the implementation but the grammar could be updated so that
-an optional `|` is allowed at the beginning. Nothing else in the grammar should
-need updating.
+an optional `|` is allowed at the beginning and the end. Nothing else in the
+grammar should need updating.
 
 ```text
 // Before

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -268,7 +268,16 @@ fn main() {
 # Detailed design
 [design]: #detailed-design
 
-Unknown
+I don't know about the implementation but the grammar could be updated so that
+an optional `|` is allowed at the beginning. Nothing else in the grammar should
+need updating.
+
+```text
+// Before
+match_pat : pat [ '|' pat ] * [ "if" expr ] ? ;
+// After
+match_pat : '|' ? pat [ '|' pat ] * [ "if" expr ] ? ;
+```
 
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -1,0 +1,339 @@
+- Feature Name: `match_vert_prefix
+- Start Date: 2017-02-23
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+See how in the following, all the `|` bars are mostly aligned except the last one:
+
+```rust
+
+use E::*;
+
+enum E {
+    A,
+    B,
+    C,
+    D,
+}
+
+fn main() {
+    match A {
+        A |
+        B |
+        C |
+        D => (),
+    }
+}
+```
+
+I'd propose it be allowed at the beginning of the pattern as well enabling something like this:
+
+```rust
+use E::*;
+
+enum E {
+    A,
+    B,
+    C,
+    D,
+}
+
+fn main() {
+    match A {
+    | A
+    | B
+    | C
+    | D => (),
+    }
+}
+```
+
+# Motivation
+[motivation]: #motivation
+
+This is taking a feature which is nice about `F#` and allowing it by a straightforward
+extension of the current rust language.
+
+Also, this appears to be the official style for F# matches and it has grown on me a lot.
+It highlights the matches and doesn't require as much deeper nesting. After getting used to the
+F# style, the inability to do this is rust seems a bit limiting.
+
+## F# Context
+
+In `F#`, enumerations (called `unions`) are declared in the following fashion where
+all of these are equivalent:
+
+```F#
+// Normal union
+type IntOrBool = I of int | B of bool
+// For consistency, have all lines look the same
+type IntOrBool = 
+   | I of int
+   | B of bool
+// Collapsing onto a single line is allowed
+type IntOrBool = | I of int | B of bool
+```
+
+Their `match` statements adopt a similar style to this:
+
+```F#
+match foo with
+| I -> ""
+| B -> ""
+```
+
+In Rust, these would look like this:
+
+```rust
+enum IntOrBool {
+    I(i32),
+    B(bool),
+}
+
+// Currently a preceding vert is disallowed
+match foo {
+| I => "",
+| B => "",
+}
+```
+The appealing feature about this is that this style allows `match` semantics without
+requiring the double nesting of a typical `match`.
+
+## Example A
+
+All of these matches are equivalent.
+
+```rust
+enum E {
+    A,
+    B,
+    C,
+    D,
+}
+
+fn main() {
+    match A {
+        A | B => println!("Give me A | B!"),
+        C | D => println!("Give me C | D!"),
+    }
+
+    match A {
+    | A | B => println!("Give me A | B!"),
+    | C | D => println!("Give me C | D!"),
+    }
+
+    match A {
+    | A
+    | B => println!("Give me A | B!"),
+    | C
+    | D => println!("Give me C | D!"),
+    }
+
+    match A {
+        A | B =>
+            println!("Give me A | B!"),
+        C | D =>
+            println!("Give me C | D!"),
+    }
+}
+```
+
+## Example B
+
+```rust
+enum E { A, B, C }
+
+fn main() {
+    use E::*;
+    let value = A;
+
+    match value {
+    | A
+    | B => {},
+    C => {}
+//  ^ Could be interpreted as slightly inconsistent. Nevertheless, it doesn't
+// seem like something to be concerned about.
+    }
+}
+```
+
+## Example C
+
+A more thorough example is included below. Note how the bottom example how at most,
+only tabs in twice from the start of the match. In contrast, the top tabs in four times.
+
+```rust
+struct FavoriteBook {
+    author: &'static str,
+    title: &'static str,
+    date: u64
+}
+
+// Full name and surname. 
+enum Franks { Alice, Brenda, Charles, Dave, Steve }
+enum Sawyer { Tom, Sid, May }
+
+enum Name {
+    Franks(Franks),
+    Sawyer(Sawyer),
+}
+
+fn main() {
+    let name = Name::Sawyer(Sawyer::Tom);
+
+    // Here is the first match in a typical rust style
+    match name {
+        Name::Franks(name) =>
+            match name {
+                Franks::Alice |
+                Franks::Brenda |
+                Franks::Dave => FavoriteBook {
+                    author: "alice berkley",
+                    title: "Name of a popular book",
+                    date: 1982,
+                },
+                Franks::Charles |
+                Franks::Steve => FavoriteBook {
+                    author: "fred marko",
+                    title: "We'll use a different name here",
+                    date: 1960,
+                },
+			},
+        Name::Sawyer(name) =>
+            match name {
+                Sawyer::Tom => FavoriteBook {
+                    author: "another name",
+                    title: "Again we change it",
+                    date: 1999,
+                },
+                Sawyer::Sid |
+                Sawyer::May => FavoriteBook {
+                    author: "again another name",
+                    title: "here is a different title",
+                    date: 1972,
+                },
+            }
+    };
+
+    // An alternate rust style might look something like this:
+    match name {
+    | Name::Franks(name) =>
+        match name {
+        | Franks::Alice
+        | Franks::Brenda
+        | Franks::Dave => FavoriteBook {
+            author: "alice berkley",
+            title: "Name of a popular book",
+            date: 1982
+        },
+        | Franks::Charles
+        | Franks::Steve => FavoriteBook {
+            author: "fred marko",
+            title: "We'll use a different name here",
+            date: 1960
+        },
+        }
+    | Name::Sawyer(name) =>
+        match name {
+        | Sawyer::Tom => FavoriteBook {
+            author: "another name",
+            title: "Again we change it",
+            date: 1999
+        },
+        | Sawyer::Sid
+        | Sawyer::May => FavoriteBook {
+            author: "again another name",
+            title: "here is a different title",
+            date: 1972
+        },
+        }
+    };
+}
+```
+
+
+# Detailed design
+[design]: #detailed-design
+
+Unknown
+
+# How We Teach This
+[how-we-teach-this]: #how-we-teach-this
+
+Adding examples for this are straightforward. You just include an example pointing out that
+leading verts are allowed. That style could also be shown as well if desired. Simple
+examples such as below should be easy to add to all different resources.
+
+```rust
+enum Cat {
+    Burmese,
+    Munchkin,
+    Siamese,
+}
+
+enum Dog {
+    Dachshund,
+    Poodle,
+    PitBull,
+}
+
+fn main() {
+    let cat = Cat::MunchKin;
+    let dog = Dog::Poodle;
+
+    match cat {
+        Cat::Burmese => "Burmese",
+        // Can do alternatives with a `|`.
+        Cat::MunchKin | Cat::Siamese => "Not burmese",
+    }
+
+    match dog {
+    | Dog::Dachshund => "Dachshund",
+    // Leading `|` is allowed.
+    | Dog::Poodle
+    | Dog::PitBull => "Not a dachshund",
+    }
+}
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Nesting braces without nesting gets a little weird. This doesn't seem problematic but
+stylistically, it might just seem quirky. `F#` doesn't have this problem because they use
+whitespace for nesting I believe.
+
+```rust
+struct S {msg: &'static str }
+enum E { A, B, C }
+
+fn main() {
+    let e = E::A;
+
+    match e {
+    | E::A => S {
+        msg: "A",
+    },
+    | E::B => S {
+        msg: "B",
+    },
+    | E::C => S {
+        msg: "C",
+    },
+    }
+//  ^ Braces all hit the same level.
+//    This example may seem trivial but example c also showcased the exact same thing.
+```
+
+# Alternatives
+[alternatives]: #alternatives
+
+N/A
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+N/A

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -150,12 +150,22 @@ fn main() {
     use E::*;
     let value = A;
 
+
+    match value {
+    | A
+    | B => {},
+    | C => {}
+//  ^ Following the style above, a `|` could be placed before the first
+// element of every branch.
+
+
     match value {
     | A
     | B => {},
     C => {}
-//  ^ Could be interpreted as slightly inconsistent. Nevertheless, it doesn't
-// seem like something to be concerned about.
+//  ^ Including a `|` for the `A` but not for the `C` seems inconsistent
+// but hardly invalid. Branches *always* follow the `=>`. Not something
+// to be greatly concerned about.
     }
 }
 ```

--- a/text/0000-optional-match-vert.md
+++ b/text/0000-optional-match-vert.md
@@ -150,14 +150,12 @@ fn main() {
     use E::*;
     let value = A;
 
-
     match value {
     | A
     | B => {},
     | C => {}
 //  ^ Following the style above, a `|` could be placed before the first
 // element of every branch.
-
 
     match value {
     | A

--- a/text/1925-optional-match-vert.md
+++ b/text/1925-optional-match-vert.md
@@ -1,7 +1,7 @@
 - Feature Name: `match_vert_prefix`
 - Start Date: 2017-02-23
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: https://github.com/rust-lang/rfcs/pull/1925
+- Rust Issue: https://github.com/rust-lang/rust/issues/44101
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
This was written to provide a formal proposal to allow a leading `|` at the beginning of a `match` as was discussed in https://github.com/rust-lang/rfcs/issues/1745. In that thread, it was previously stated the language team is [in favor of this change](https://github.com/rust-lang/rfcs/issues/1745#issuecomment-282150644).

Some of the sections I don't know anything about but I tried to fill in what I knew. For such a small topic, this form seems excessive and so a lot of the text seems fairly brief to me. Also, I'm not actually sure all the examples are needed but I thought it wouldn't hurt to add them.

In brief, this is a proposal that the following `match` syntax be legal:

```rust
enum E { A, B, C, D}
use E::*;

match foo {
| A
| B => (),
| C
| D => (),
}
```


---

[Rendered](https://github.com/mdinger/rfcs/blob/3b052a6311cc52d2767790576a8d8ebe443ccd53/text/0000-optional-match-vert.md)