### PR TITLE
Shuffle around text to avoid > at beginning of line (block quote)

### DIFF
--- a/text/0560-integer-overflow.md
+++ b/text/0560-integer-overflow.md
@@ -130,10 +130,10 @@ defined results today. The only change is that now a panic may result.
   wrap.
 - The operations `/`, `%` for the arguments `INT_MIN` and `-1`
   will unconditionally panic. This is unconditional for legacy reasons.
-- Shift operations (`<<`, `>>`) on a value of with `N` can be passed a shift value
-  >= `N`. It is unclear what behaviour should result from this, so the shift value 
-  is unconditionally masked to be modulo `N` to ensure that the argument is always 
-  in range.
+- Shift operations (`<<`, `>>`) on a value of with `N` can be passed a shift
+  value >= `N`. It is unclear what behaviour should result from this, so the
+  shift value is unconditionally masked to be modulo `N` to ensure that the
+  argument is always in range.
 
 ## Enabling overflow checking
 


### PR DESCRIPTION
Compare the third bullet point (shift operations) under

 - (original) https://github.com/rust-lang/rfcs/blob/master/text/0560-integer-overflow.md#arithmetic-operations-with-error-conditions
 - (new) https://github.com/aidanhs/rfcs/blob/aphs-fix-integer-overflow-markdown/text/0560-integer-overflow.md#arithmetic-operations-with-error-conditions