### PR TITLE
RFC for Public/Private Dependencies

### DIFF
--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -276,6 +276,147 @@ how far we are off to making them errors.
 
 Crates.io should be updated to render public and private dependencies separately.
 
+# End user experience
+[end-user-experience]: #end-user-experience
+
+## Author of a crate with one dependency
+
+Assume today that an author of a library crate `onedep` has a dependency on the `url` crate and the `url::Url` type is exposed in `onedep`'s public API.
+
+`onedep`'s `Cargo.toml`:
+
+```toml
+[package]
+name = "onedep"
+version = "0.1.0"
+
+[dependencies]
+url = "1.0.0"
+```
+
+`onedep`'s `src/lib.rs`:
+
+```rust
+extern crate url;
+use url::Origin;
+
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct OriginTracker {
+    origin_counts: HashMap<Origin, usize>,
+}
+
+impl OriginTracker {
+    pub fn log_origin(&mut self, origin: Origin) {
+        let counter = self.origin_counts.entry(origin).or_insert(0);
+        *counter += 1;
+    }
+}
+```
+
+When the author of `onedep` upgrades Rust/Cargo to a version where this RFC is
+completely implemented, the author will notice two changes:
+
+1. When they run `cargo build`, the build will succeed but they will get a warning
+that a private dependency (the `url` crate specifically) is used in their public API
+(the `url::Origin` type in the `pub fn log_origin` function specifically) and that
+they should consider adding `public = true` to their `Cargo.toml`. Ideally the
+warning would say something like:
+
+    ```
+        consider changing dependency:
+
+        ```
+        url = "1.0.0"
+        ```
+
+        to:
+
+        ```
+        url = { version = "1.0.0", public = true}
+        ```
+    ```
+
+The warning could also encourage the author to then bump their crate's major
+version, since adding public dependencies is a breaking change.
+
+2. When they run `cargo publish`, the build check that happens after packaging will
+fail and the publish will fail. This is because [deriving `Hash` on `url::Origin`
+wasn't added until v1.5.1 of the url
+crate](https://github.com/servo/rust-url/commit/42603254fac8d4c446183cba73bbaeb2c3b416c2).
+The author of `onedep` has been running `cargo update` periodically, and their
+`Cargo.lock` has url 1.5.1, but they never updated `Cargo.toml` to indicate that
+they have a new lower bound. Since `cargo publish` will try to resolve dependencies
+to the lowest possible versions, it will choose version 1.0.0 of the url crate,
+which doesn't implement `Hash` on `Origin`.
+
+There should be a clear error message for this case that indicates Cargo has
+resolved crates to their lowest possible versions, that this might be the cause of
+the compilation failure, and that the author should investigate the versions of
+their dependencies in `Cargo.toml` to see if they should be updated. This command
+should change the Cargo.lock so that running `cargo build` will reproduce the error
+for the author to fix.
+
+## Author of a crate with multiple dependencies
+
+`twodep`'s `Cargo.toml`:
+
+```toml
+[package]
+name = "twodep"
+version = "0.1.0"
+
+[dependencies]
+// this is the version of onedep above using a public dep on url 1.5.1
+onedep = "1.0.0"
+url = "1.0.0"
+```
+
+`twodep`'s `src/main.rs`:
+
+```rust
+extern crate url;
+use url::Origin;
+
+extern crate onedep;
+
+fn main() {
+    let mut origin_tracker = onedep::OriginTracker::default();
+
+    loop {
+        println!("Please enter a URL!");
+        // pseudocode because I'm lazy
+        let url = stdin::readline().unwrap();
+        let url = Url::parse(url).unwrap();
+        origin_tracker.log_origin(url.origin());
+        // other stuff
+    }
+    println!("Here are all the origins you mentioned: {:#?}", origin_tracker);
+}
+```
+
+Before upgrading Rust/Cargo to a version where this RFC has been implemented, this
+code might have been getting a compilation error if Cargo had resolved the direct
+dependency on the url crate to a different version than the version of onedep
+resolved to. Or it might have been resolving and compiling fine if the versions had
+resolved to be the same.
+
+After upgrading Rust/Cargo, if this code had a compilation error, it would now have
+a version resolution problem that cargo would either automatically resolve or prompt
+the user to change version constraints/`cargo update` to resolve. If the code was
+compiling before, that must mean the previous resolution graph was good, so nothing
+will change on upgrading.
+
+This crate is a binary and doesn't have a public API, so it won't get any warnings
+about crates not being marked public.
+
+If the author publishes to crates.io after upgrading Rust/Cargo, since onedep's
+public dependency on url now has a lower bound of 1.5.1, the only valid graphs that
+Cargo will generate will be with url 1.5.1 or greater, which is also compatible with
+the url 1.0.0 direct dependency. Publish will work without any errors or further
+changes.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -85,7 +85,8 @@ There are a few areas that need to be changed for this RFC:
 * The compiler needs to be extended to understand when crate dependencies are
   considered a public dependency
 * The `Cargo.toml` manifest needs to be extended to support declaring public
-  dependencies
+  dependencies. This will start as an unstable cargo feature available on nightly
+  and only via opt-in.
 * The `public` attribute of dependencies needs to appear in the Cargo index in order
   to be used by Cargo during version resolution
 * Cargo's version resolution needs to change to reject crate graph resolutions where
@@ -120,6 +121,12 @@ The `Cargo.toml` file will be amended to support the new `public` parameter on
 dependencies. Old Cargo versions will emit a warning when this key is encountered
 but otherwise continue. Since the default for a dependency to be private only,
 public ones will need to be tagged which should be the minority.
+
+This will start as an unstable Cargo feature available on nightly only that authors
+will need to opt into via a feature specified in `Cargo.toml` before Cargo will
+start using the `public` attribute to change the way versions are resolved. The
+Cargo unstable feature will turn on a corresponding rustc unstable feature for
+the compiler changes noted above.
 
 Example dependency:
 

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -100,10 +100,10 @@ There are a few areas that need to be changed for this RFC:
 ## Compiler Changes
 
 The main change to the compiler will be to accept a new parameter that Cargo
-supplies which is a list of public dependencies. The compiler then emits
-warnings if it encounters private dependencies leaking to the public API of a
-crate. `cargo publish` might change this warning into an error in its lint
-step.
+supplies which is a list of public dependencies. The flag will be called
+`--extern-public`. The compiler then emits warnings if it encounters private
+dependencies leaking to the public API of a crate. `cargo publish` might change
+this warning into an error in its lint step.
 
 Additionally, later on, the warning can turn into a hard error in general.
 

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -443,10 +443,9 @@ exist.
 There are a few open questions about how to best hook into the compiler and Cargo
 infrastructure:
 
-* Is passing in the list of public dependencies the correct way to get around it?
-  If yes, what is the parameter supposed to be called?
 * What is the impact of this change going to be? This most likely can be answered
   running cargobomb/crater.
 * Since changing public dependency pins/ranges requires a change in semver, it might
   be worth exploring if Cargo could prevent the user from publishing new crate
   versions that violate that constraint.
+* If this is implemented before [the RFC to deprecate `extern crate`](https://github.com/rust-lang/rfcs/pull/2126), how would this work if you're not using `--extern`?

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -11,97 +11,98 @@ Introduce a public/private distinction to crate dependencies.
 # Motivation
 [motivation]: #motivation
 
-The crates ecosystem has greatly expanded since Rust 1.0 and with that a few patterns for
+The crates ecosystem has greatly expanded since Rust 1.0. With that, a few patterns for
 dependencies have evolved that challenge the currently existing dependency declaration
-system in cargo and rust.  The most common problem is that a crate `A` depends on
-another crate `B` but some of the types from crate `B` are exposed through the API in
-crate `A`.  This causes problems in practice if that dependency `B` is also used by the
-user's code itself which often leaves users in less than ideal situations where either
-their code refuses to compile because different versions of those libraries are requested
-or where compiler messages are less than clear.
+system in Cargo and Rust. The most common problem is that a crate `A` depends on another
+crate `B` but some of the types from crate `B` are exposed through the API in crate `A`.
+This causes problems in practice if that dependency `B` is also used by the user's code
+itself, crate `B` resolves to different versions for each usage, and the values of types
+from the two crate `B` instances need to be used together but don't match. In this case,
+the user's code will refuse to compile because different versions of those libraries are
+requested, and the compiler messages are less than clear.
 
 The introduction of an explicit distinction between public and private dependencies can
-solve some of these issues and also let us lift some restrictions that should make some
-code compile that previously was prevented from compiling by restrictions in cargo.
+solve some of these issues. This distinction should also let us lift some restrictions and
+make some code compile that previously was prevented from compiling.
 
 **Q: What is a public dependency?**<br>
-A: a dependency is public if some of the types or trait of that dependency is itself
-exported through the main crate.  The most common places where this happens is obviously
-return values and function parameter but obviously the same applies to trait implementations
-and many other things.  Because public can be tricky to determine for a user this RFC
-proposes to extend the compiler infrastructure to detect the concept of "public dependency".
-This will help the user understanding this concept and avoid making mistakes in
-the `Cargo.toml`
+A: A dependency is public if some of the types or traits of that dependency are themselves
+exported through the public API of main crate. The most common places where this happens
+are return values and function parameters. The same applies to trait implementations and
+many other things. Because "public" can be tricky to determine for a user, this RFC
+proposes to extend the compiler infrastructure to detect the concept of a "public
+dependency". This will help the user understand this concept so they can avoid making
+mistakes in the `Cargo.toml`.
 
-Effectively the idea is that if your own library bumps a public dependency it means that
-it's a breaking change of your *own* crate.
+Effectively, the idea is that if you bump a public dependency's version, it's a breaking
+change of your *own* crate.
 
 **Q: What is a private dependency?**<br>
-A: On the other hand a private dependency is contained within your crate and effectively
-invisible for users of your crate.  As a result private dependencies can be freely
-duplicated.  This distinction will also make it possible to relax some restrictions that
-currently exist in Cargo which sometimes prevent crates from compiling.
+A: On the other hand, a private dependency is contained within your crate and effectively
+invisible for users of your crate. As a result, private dependencies can be freely
+duplicated in the dependency graph and won't cause compilation errors. This distinction
+will also make it possible to relax some restrictions that currently exist in Cargo which
+sometimes prevent crates from compiling.
 
 **Q: Can public become private later?**<br>
 A: Public dependencies are public within a reachable subgraph but can become private if a
-crate stops exposing a public dependency.  For instance it is very possible to have a
-family of crates that all depend on a utility crate that provides common types which is
-a public dependency for all of them.  However your own crate only ends up being a user of
-this utility crate but none of its types or traits become part of your own API then this
+crate stops exposing a public dependency. For instance, it is very possible to have a
+family of crates that all depend on a utility crate that provides common types which is a
+public dependency for all of them. However, if your own crate ends up being a user of this
+utility crate but none of its types or traits become part of your own API, then this
 utility crate dependency is marked private.
 
 **Q: Where is public / private defined?**<br>
-Dependencies are private by default and are made public through a `public` flag in the
-dependency in the `Cargo.toml` file.  This also means that crates created before the
+Dependencies are private by default and are made public through a `public` flag on the
+dependency in the `Cargo.toml` file. This also means that crates created before the
 implementation of this RFC will have all their dependencies private.
 
 **Q: How is backwards compatibility handled?**<br>
-A: It will continue to be permissible to "leak" dependencies and there are even some
-use cases of this, however the compiler or cargo will emit warnings if private
-dependencies become part of the public API.  Later it might even become invalid to
-publish new crates without explicitly silencing these warnings or marking the
-dependencies as public.
+A: It will continue to be permissible to "leak" dependencies (and there are even some use
+cases of this), however, the compiler or Cargo will emit warnings if private dependencies
+are part of the public API. Later, it might even become invalid to publish new crates
+without explicitly silencing these warnings or marking the dependencies as public.
 
 **Q: Can I export a type from a private dependency as my own?**<br>
-A: For now it will not be strictly permissible to privately depend on a crate and export
-a type from there as your own.  The reason for this is that at the moment it is not
-possible to force this type to be distinct.  This means that users of the crate might
-accidentally start depending on that type to be compatible if the user starts to depend
-on the crate that actually implements that type.  The limitations from the previous
-answer apply (eg: you can currently overrule the restrictions).
+A: For now, it will not be strictly permissible to privately depend on a crate and export a
+type from there as your own. The reason for this is that at the moment it is not possible
+to force this type to be distinct. This means that users of the crate might accidentally
+start depending on that type to be compatible if the user starts to depend on the crate
+that actually implements that type. The limitations from the previous answer apply (eg: you
+can currently overrule the restrictions).
 
-**Q: How does semver and depenencies interact?**<br>
-A: It is already the case that changing your own dependencies would require a semver
-bumb for your own library because your API contract to the outside world changes.  This
-RFC however makes it possible to only have this requirement for public dependencies and
-would permit cargo to prevent new crate releases with semver violations.
+**Q: How do semver and depenencies interact?**<br>
+A: It is already the case that changing your own dependencies would require a semver bump
+for your own library because your API contract to the outside world changes. This RFC,
+however, makes it possible to only have this requirement for public dependencies and would
+permit Cargo to prevent new crate releases with semver violations.
 
 # Detailed design
 [design]: #detailed-design
 
-There are a few areas that require to be changed for this RFC:
+There are a few areas that need to be changed for this RFC:
 
 * The compiler needs to be extended to understand when crate dependencies are
   considered a public dependency
 * The `Cargo.toml` manifest needs to be extended to support declaring public
   dependencies
-* The cargo publish process needs to be changed to warn (or prevent) the publishing
+* The `cargo publish` process needs to be changed to warn (or prevent) the publishing
   of crates that have undeclared public dependencies
-* crates.io should show public dependencies more prominently than private ones.
+* Crates.io should show public dependencies more prominently than private ones.
 
 ## Compiler Changes
 
-The main change to the compiler will be to accept a new parameter that cargo
-supplies which is a list of public dependencies.  The compiler then emits
+The main change to the compiler will be to accept a new parameter that Cargo
+supplies which is a list of public dependencies. The compiler then emits
 warnings if it encounters private dependencies leaking to the public API of a
-crate.  `cargo publish` might change this warning into an error in its lint
+crate. `cargo publish` might change this warning into an error in its lint
 step.
 
-Additionally later on the warning can turn into a hard error in general.
+Additionally, later on, the warning can turn into a hard error in general.
 
-In some situations it can be necessary to allow private dependencies to become
-part of the public API.  In that case one can permit this with
-`#[allow(external_private_dependency)]`.  This is particularly useful when
+In some situations, it can be necessary to allow private dependencies to become
+part of the public API. In that case one can permit this with
+`#[allow(external_private_dependency)]`. This is particularly useful when
 paired with `#[doc(hidden)]` and other already existing hacks.
 
 This most likely will also be necessary for the more complex relationship of
@@ -110,8 +111,8 @@ This most likely will also be necessary for the more complex relationship of
 ## Changes to `Cargo.toml`
 
 The `Cargo.toml` file will be amended to support the new `public` parameter on
-dependencies.  Old cargo versions will emit a warning when this key is encountered
-but otherwise continue.  Since the default for a dependency to be private only
+dependencies. Old Cargo versions will emit a warning when this key is encountered
+but otherwise continue. Since the default for a dependency to be private only,
 public ones will need to be tagged which should be the minority.
 
 Example dependency:
@@ -123,48 +124,47 @@ url = { version = "1.4.0", public = true }
 
 ## Changes to Cargo Publishing
 
-When a new crate version is published Cargo will warn about types and traits that
-the compiler determined to be public but did not come from a public dependency.  For
-now it should be possible to publish anyways but in some period in the future it will
-be necessary to explicitly mark all public dependencies as such or explicitly
+When a new crate version is published, Cargo will warn about types and traits that
+the compiler determined to be public but did not come from a public dependency. For
+now, it should be possible to publish anyways but in some period in the future it
+will be necessary to explicitly mark all public dependencies as such or explicitly
 mark them with `#[allow(external_private_dependency)]`.
 
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
-From the user's perspective the initial scope of the RFC will be quite transparent
+From the user's perspective, the initial scope of the RFC will be quite transparent,
 but it will definitely show up for users as a question of what the new restrictions
-mean.  In particular a common way to leak out types from APIs that most crates do
-is error handling.  Quite frequently it happens that users wrap errors from other
-libraries in their own types.  It might make sense to identify common cases of where
+mean. In particular, a common way to leak out types from APIs that most crates do is
+error handling. Quite frequently it happens that users wrap errors from other
+libraries in their own types. It might make sense to identify common cases of where
 type leakage happens and provide hints in the lint about how to deal with it.
 
 Cases that I anticipate that should be explained separately:
 
-* type leakage through errors. This should be easy to spot for a lint because the
-  wrapper type will implement `std::error::Error`.  The recommendation should most
-  likely be to encourage containing the internal error.
-* traits from other crates.  In particular serde and some other common crates will
-  show up frequently and it might make sense to separately explain types and traits.
-* type leakage through derive.  Users might not be aware they have a dependency to
-  a type when they derive a trait (think `serde_derive`).  The lint might want to
+* Type leakage through errors: This should be easy to spot for a lint because the
+  wrapper type will implement `std::error::Error`. The recommendation should most
+  likely be to encourage wrapping the internal error.
+* Traits from other crates: In particular, serde and some other common crates will
+  show up frequently. It might make sense to separately explain types and traits.
+* Type leakage through derive: Users might not be aware they have a dependency on
+  a type when they derive a trait (think `serde_derive`). The lint might want to
   call this out separately.
 
 The feature will be called `public_private_dependencies` and it comes with one
-lint flag called `external_private_dependency`.  For all intents and purposes this
-should be the extent of the new terms introduced in the beginning.  This RFC however
+lint flag called `external_private_dependency`. For all intents and purposes, this
+should be the extent of the new terms introduced in the beginning. This RFC, however,
 lays the groundwork for later providing aliasing so that a private dependency could
-be forcefully re-exported as own types.  As such it might make sense to already
-consider what this will be referred to.
+be forcefully re-exported as the crate's own types. As such, it might make sense to
+consider how to refer to this.
 
 It is assumed that this feature will eventually become quite popular due to patterns
-that already exist in the crate ecosystem but it's likely that it will evoke some
-negative opinions initially.  As such it would be a good idea to make a run with
+that already exist in the crate ecosystem. It's likely that it will evoke some
+negative opinions initially. As such, it would be a good idea to make a run with
 cargobomb/crater to see what the actual impact of the new linter warnings is and
 how far we are off to making them errors.
 
-crates.io should most likely be updated to render public and private dependencies
-separately.
+Crates.io should be updated to render public and private dependencies separately.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -175,25 +175,25 @@ linters and error messages).
 # Alternatives
 [alternatives]: #alternatives
 
-For me the biggest alternative to this RFC would be a variation of it where type
-and trait aliasing becomes immediately part of it.  This would meant that a crate
+For me, the biggest alternative to this RFC would be a variation of it where type
+and trait aliasing becomes immediately part of it. This would meant that a crate
 can have a private dependency and re-export it as its own type, hiding where it
-came from originally.  This would most likely be easier to teach users and can get
-rid of a few "cul-de-sac" situations where users can end up in and their only way
-out is to introduce a public dependency for now.  The assumption is that if trait
-and type aliasing is available the `external_public_dependency` would not need to
+came from originally. This would most likely be easier to teach users and can get
+rid of a few "cul-de-sac" situations users can end up in where their only way
+out is to introduce a public dependency for now. The assumption is that if trait
+and type aliasing is available, the `external_public_dependency` would not need to
 exist.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-There are a few open questions about how to best hook into the compiler and cargo
+There are a few open questions about how to best hook into the compiler and Cargo
 infrastructure:
 
-* is passing in the list of public dependencies the correct way to get around it?
-  If yes, what is the parameter supposed to be called.
-* what is the impact of this change going to be. This most likely can be answered
+* Is passing in the list of public dependencies the correct way to get around it?
+  If yes, what is the parameter supposed to be called?
+* What is the impact of this change going to be? This most likely can be answered
   running cargobomb/crater.
-* since changing public dependency pins/ranges requires a change in semver it might
-  be worth exploring if cargo could prevent the user in pushing up new crate
+* Since changing public dependency pins/ranges requires a change in semver, it might
+  be worth exploring if Cargo could prevent the user from publishing new crate
   versions that violate that constraint.

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -68,10 +68,10 @@ A: For now, it will not be strictly permissible to privately depend on a crate a
 type from there as your own. The reason for this is that at the moment it is not possible
 to force this type to be distinct. This means that users of the crate might accidentally
 start depending on that type to be compatible if the user starts to depend on the crate
-that actually implements that type. The limitations from the previous answer apply (eg: you
-can currently overrule the restrictions).
+that actually implements that type. The limitations from the previous answer apply (e.g.:
+you can currently overrule the restrictions).
 
-**Q: How do semver and depenencies interact?**<br>
+**Q: How do semver and dependencies interact?**<br>
 A: It is already the case that changing your own dependencies would require a semver bump
 for your own library because your API contract to the outside world changes. This RFC,
 however, makes it possible to only have this requirement for public dependencies and would
@@ -272,7 +272,7 @@ It is assumed that this feature will eventually become quite popular due to patt
 that already exist in the crate ecosystem. It's likely that it will evoke some
 negative opinions initially. As such, it would be a good idea to make a run with
 cargobomb/crater to see what the actual impact of the new linter warnings is and
-how far we are off to making them errors.
+how far away we are from making them errors.
 
 Crates.io should be updated to render public and private dependencies separately.
 
@@ -281,7 +281,9 @@ Crates.io should be updated to render public and private dependencies separately
 
 ## Author of a crate with one dependency
 
-Assume today that an author of a library crate `onedep` has a dependency on the `url` crate and the `url::Url` type is exposed in `onedep`'s public API.
+Assume today that an author of a library crate `onedep` has a
+dependency on the `url` crate and the `url::Url` type is exposed in
+`onedep`'s public API.
 
 `onedep`'s `Cargo.toml`:
 
@@ -334,12 +336,12 @@ warning would say something like:
         to:
 
         ```
-        url = { version = "1.0.0", public = true}
+        url = { version = "1.0.0", public = true }
         ```
     ```
 
 The warning could also encourage the author to then bump their crate's major
-version, since adding public dependencies is a breaking change.
+version since adding public dependencies is a breaking change.
 
 2. When they run `cargo publish`, the build check that happens after packaging will
 fail and the publish will fail. This is because [deriving `Hash` on `url::Origin`
@@ -427,7 +429,7 @@ linters and error messages).
 [alternatives]: #alternatives
 
 For me, the biggest alternative to this RFC would be a variation of it where type
-and trait aliasing becomes immediately part of it. This would meant that a crate
+and trait aliasing becomes immediately part of it. This would mean that a crate
 can have a private dependency and re-export it as its own type, hiding where it
 came from originally. This would most likely be easier to teach users and can get
 rid of a few "cul-de-sac" situations users can end up in where their only way

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -86,6 +86,8 @@ There are a few areas that need to be changed for this RFC:
   considered a public dependency
 * The `Cargo.toml` manifest needs to be extended to support declaring public
   dependencies
+* The `public` attribute of dependencies needs to appear in the Cargo index in order
+  to be used by Cargo during version resolution
 * The `cargo publish` process needs to be changed to warn (or prevent) the publishing
   of crates that have undeclared public dependencies
 * Crates.io should show public dependencies more prominently than private ones.
@@ -120,6 +122,32 @@ Example dependency:
 ```toml
 [dependencies]
 url = { version = "1.4.0", public = true }
+```
+
+## Changes to the Cargo Index
+
+The [Cargo index](https://github.com/rust-lang/crates.io-index) used by Cargo when
+resolving versions will contain the `public` attribute on dependencies as specified
+in `Cargo.toml`. For example, an index line for a crate named `example` that
+publicly depends on the `url` crate would look like (JSON prettified for legibility):
+
+```json
+{
+    "name":"example",
+    "vers":"0.1.0",
+    "deps":[
+        {
+            "name":"url",
+            "req":"^1.4.0",
+            "public":"true",
+            "features":[],
+            "optional":false,
+            "default_features":true,
+            "target":null,
+            "kind":"normal"
+        }
+    ]
+}
 ```
 
 ## Changes to Cargo Publishing

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -46,9 +46,9 @@ currently exist in Cargo which sometimes prevent crates from compiling.
 A: Public dependencies are public within a reachable subgraph but can become private if a
 crate stops exposing a public dependency.  For instance it is very possible to have a
 family of crates that all depend on a utility crate that provides common types which is
-a public dependency for all of them.  However your own crate only becomes a user of this
-utility crate through another dependency that itself does not expose any of the types
-from that utility crate and as such the dependency is marked private.
+a public dependency for all of them.  However your own crate only ends up being a user of
+this utility crate but none of its types or traits become part of your own API then this
+utility crate dependency is marked private.
 
 **Q: Where is public / private defined?**<br>
 Dependencies are private by default and are made public through a `public` flag in the
@@ -63,11 +63,18 @@ publish new crates without explicitly silencing these warnings or marking the
 dependencies as public.
 
 **Q: Can I export a type from a private dependency as my own?**<br>
-For now it will not be strictly permissible to privately depend on a crate and export
-a type from their as your own.  The reason for this is that at the moment it is not
+A: For now it will not be strictly permissible to privately depend on a crate and export
+a type from there as your own.  The reason for this is that at the moment it is not
 possible to force this type to be distinct.  This means that users of the crate might
 accidentally start depending on that type to be compatible if the user starts to depend
-on the crate that actually implements that type.
+on the crate that actually implements that type.  The limitations from the previous
+answer apply (eg: you can currently overrule the restrictions).
+
+**Q: How does semver and depenencies interact?**<br>
+A: It is already the case that changing your own dependencies would require a semver
+bumb for your own library because your API contract to the outside world changes.  This
+RFC however makes it possible to only have this requirement for public dependencies and
+would permit cargo to prevent new crate releases with semver violations.
 
 # Detailed design
 [design]: #detailed-design
@@ -145,8 +152,8 @@ Cases that I anticipate that should be explained separately:
 
 The feature will be called `public_private_dependencies` and it comes with one
 lint flag called `external_private_dependency`.  For all intents and purposes this
-should be the extend of the new terms introduced in the beginning.  This RFC however
-lays the groundwork for later providing aliasing so that a private dependencies could
+should be the extent of the new terms introduced in the beginning.  This RFC however
+lays the groundwork for later providing aliasing so that a private dependency could
 be forcefully re-exported as own types.  As such it might make sense to already
 consider what this will be referred to.
 
@@ -183,7 +190,7 @@ exist.
 There are a few open questions about how to best hook into the compiler and cargo
 infrastructure:
 
-* is passing in the last of public dependencies the correct way to get around it?
+* is passing in the list of public dependencies the correct way to get around it?
   If yes, what is the parameter supposed to be called.
 * what is the impact of this change going to be. This most likely can be answered
   running cargobomb/crater.

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -187,3 +187,6 @@ infrastructure:
   If yes, what is the parameter supposed to be called.
 * what is the impact of this change going to be. This most likely can be answered
   running cargobomb/crater.
+* since changing public dependency pins/ranges requires a change in semver it might
+  be worth exploring if cargo could prevent the user in pushing up new crate
+  versions that violate that constraint.

--- a/text/0000-public-private-dependencies.md
+++ b/text/0000-public-private-dependencies.md
@@ -1,0 +1,189 @@
+- Feature Name: `public_private_dependencies`
+- Start Date: 2017-04-03
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Introduce a public/private distinction to crate dependencies.
+
+# Motivation
+[motivation]: #motivation
+
+The crates ecosystem has greatly expanded since Rust 1.0 and with that a few patterns for
+dependencies have evolved that challenge the currently existing dependency declaration
+system in cargo and rust.  The most common problem is that a crate `A` depends on
+another crate `B` but some of the types from crate `B` are exposed through the API in
+crate `A`.  This causes problems in practice if that dependency `B` is also used by the
+user's code itself which often leaves users in less than ideal situations where either
+their code refuses to compile because different versions of those libraries are requested
+or where compiler messages are less than clear.
+
+The introduction of an explicit distinction between public and private dependencies can
+solve some of these issues and also let us lift some restrictions that should make some
+code compile that previously was prevented from compiling by restrictions in cargo.
+
+**Q: What is a public dependency?**<br>
+A: a dependency is public if some of the types or trait of that dependency is itself
+exported through the main crate.  The most common places where this happens is obviously
+return values and function parameter but obviously the same applies to trait implementations
+and many other things.  Because public can be tricky to determine for a user this RFC
+proposes to extend the compiler infrastructure to detect the concept of "public dependency".
+This will help the user understanding this concept and avoid making mistakes in
+the `Cargo.toml`
+
+Effectively the idea is that if your own library bumps a public dependency it means that
+it's a breaking change of your *own* crate.
+
+**Q: What is a private dependency?**<br>
+A: On the other hand a private dependency is contained within your crate and effectively
+invisible for users of your crate.  As a result private dependencies can be freely
+duplicated.  This distinction will also make it possible to relax some restrictions that
+currently exist in Cargo which sometimes prevent crates from compiling.
+
+**Q: Can public become private later?**<br>
+A: Public dependencies are public within a reachable subgraph but can become private if a
+crate stops exposing a public dependency.  For instance it is very possible to have a
+family of crates that all depend on a utility crate that provides common types which is
+a public dependency for all of them.  However your own crate only becomes a user of this
+utility crate through another dependency that itself does not expose any of the types
+from that utility crate and as such the dependency is marked private.
+
+**Q: Where is public / private defined?**<br>
+Dependencies are private by default and are made public through a `public` flag in the
+dependency in the `Cargo.toml` file.  This also means that crates created before the
+implementation of this RFC will have all their dependencies private.
+
+**Q: How is backwards compatibility handled?**<br>
+A: It will continue to be permissible to "leak" dependencies and there are even some
+use cases of this, however the compiler or cargo will emit warnings if private
+dependencies become part of the public API.  Later it might even become invalid to
+publish new crates without explicitly silencing these warnings or marking the
+dependencies as public.
+
+**Q: Can I export a type from a private dependency as my own?**<br>
+For now it will not be strictly permissible to privately depend on a crate and export
+a type from their as your own.  The reason for this is that at the moment it is not
+possible to force this type to be distinct.  This means that users of the crate might
+accidentally start depending on that type to be compatible if the user starts to depend
+on the crate that actually implements that type.
+
+# Detailed design
+[design]: #detailed-design
+
+There are a few areas that require to be changed for this RFC:
+
+* The compiler needs to be extended to understand when crate dependencies are
+  considered a public dependency
+* The `Cargo.toml` manifest needs to be extended to support declaring public
+  dependencies
+* The cargo publish process needs to be changed to warn (or prevent) the publishing
+  of crates that have undeclared public dependencies
+* crates.io should show public dependencies more prominently than private ones.
+
+## Compiler Changes
+
+The main change to the compiler will be to accept a new parameter that cargo
+supplies which is a list of public dependencies.  The compiler then emits
+warnings if it encounters private dependencies leaking to the public API of a
+crate.  `cargo publish` might change this warning into an error in its lint
+step.
+
+Additionally later on the warning can turn into a hard error in general.
+
+In some situations it can be necessary to allow private dependencies to become
+part of the public API.  In that case one can permit this with
+`#[allow(external_private_dependency)]`.  This is particularly useful when
+paired with `#[doc(hidden)]` and other already existing hacks.
+
+This most likely will also be necessary for the more complex relationship of
+`libcore` and `libstd` in Rust itself.
+
+## Changes to `Cargo.toml`
+
+The `Cargo.toml` file will be amended to support the new `public` parameter on
+dependencies.  Old cargo versions will emit a warning when this key is encountered
+but otherwise continue.  Since the default for a dependency to be private only
+public ones will need to be tagged which should be the minority.
+
+Example dependency:
+
+```toml
+[dependencies]
+url = { version = "1.4.0", public = true }
+```
+
+## Changes to Cargo Publishing
+
+When a new crate version is published Cargo will warn about types and traits that
+the compiler determined to be public but did not come from a public dependency.  For
+now it should be possible to publish anyways but in some period in the future it will
+be necessary to explicitly mark all public dependencies as such or explicitly
+mark them with `#[allow(external_private_dependency)]`.
+
+# How We Teach This
+[how-we-teach-this]: #how-we-teach-this
+
+From the user's perspective the initial scope of the RFC will be quite transparent
+but it will definitely show up for users as a question of what the new restrictions
+mean.  In particular a common way to leak out types from APIs that most crates do
+is error handling.  Quite frequently it happens that users wrap errors from other
+libraries in their own types.  It might make sense to identify common cases of where
+type leakage happens and provide hints in the lint about how to deal with it.
+
+Cases that I anticipate that should be explained separately:
+
+* type leakage through errors. This should be easy to spot for a lint because the
+  wrapper type will implement `std::error::Error`.  The recommendation should most
+  likely be to encourage containing the internal error.
+* traits from other crates.  In particular serde and some other common crates will
+  show up frequently and it might make sense to separately explain types and traits.
+* type leakage through derive.  Users might not be aware they have a dependency to
+  a type when they derive a trait (think `serde_derive`).  The lint might want to
+  call this out separately.
+
+The feature will be called `public_private_dependencies` and it comes with one
+lint flag called `external_private_dependency`.  For all intents and purposes this
+should be the extend of the new terms introduced in the beginning.  This RFC however
+lays the groundwork for later providing aliasing so that a private dependencies could
+be forcefully re-exported as own types.  As such it might make sense to already
+consider what this will be referred to.
+
+It is assumed that this feature will eventually become quite popular due to patterns
+that already exist in the crate ecosystem but it's likely that it will evoke some
+negative opinions initially.  As such it would be a good idea to make a run with
+cargobomb/crater to see what the actual impact of the new linter warnings is and
+how far we are off to making them errors.
+
+crates.io should most likely be updated to render public and private dependencies
+separately.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+I believe that there are no drawbacks if implemented well (this assumes good
+linters and error messages).
+
+# Alternatives
+[alternatives]: #alternatives
+
+For me the biggest alternative to this RFC would be a variation of it where type
+and trait aliasing becomes immediately part of it.  This would meant that a crate
+can have a private dependency and re-export it as its own type, hiding where it
+came from originally.  This would most likely be easier to teach users and can get
+rid of a few "cul-de-sac" situations where users can end up in and their only way
+out is to introduce a public dependency for now.  The assumption is that if trait
+and type aliasing is available the `external_public_dependency` would not need to
+exist.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+There are a few open questions about how to best hook into the compiler and cargo
+infrastructure:
+
+* is passing in the last of public dependencies the correct way to get around it?
+  If yes, what is the parameter supposed to be called.
+* what is the impact of this change going to be. This most likely can be answered
+  running cargobomb/crater.

--- a/text/1977-public-private-dependencies.md
+++ b/text/1977-public-private-dependencies.md
@@ -1,7 +1,7 @@
 - Feature Name: `public_private_dependencies`
 - Start Date: 2017-04-03
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: https://github.com/rust-lang/rfcs/pull/1977
+- Rust Issue: https://github.com/rust-lang/rust/issues/44663
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
This RFC introduces the concept of a public/private separation of crate dependencies to aid the ecosystem to explicitly deal with dependencies that themselves become part of the public API of a crate.

This is work in progress.

[Rendered](https://github.com/mitsuhiko/rfcs/blob/public-private-dependencies/text/0000-public-private-dependencies.md)