### PR TITLE
Make RangeInclusive just a two-field struct (amend 1192)

### DIFF
--- a/text/1192-inclusive-ranges.md
+++ b/text/1192-inclusive-ranges.md
@@ -41,8 +41,7 @@ Writing `a...b` in an expression desugars to
 expression desugars to `std::ops::RangeToInclusive { end: b }`.
 
 `RangeInclusive` implements the standard traits (`Clone`, `Debug`
-etc.), and implements `Iterator`. The `Empty` variant is to allow the
-`Iterator` implementation to work without hacks (see Alternatives).
+etc.), and implements `Iterator`.
 
 The use of `...` in a pattern remains as testing for inclusion
 within that range, *not* a struct match.


### PR DESCRIPTION
Rationale overview:

1. Having the variants make trying to use a RangeInclusive unergonomic.
   For example, `fn clamp(self, range: RangeInclusive<Self>)` is forced
   to deal with the `Empty` case.
2. The variants don't actually provide any offsetting safety or additional
   performance, since everything is pub so it's totally possible for a
   "`NonEmpty`" range to contain no elements.
3. This makes it more consistent with (half-open) `Range`.
4. The extra flag/variant is not actually needed in order to make it
   iterable, even using the existing Step trait.  And supposing a more
   cut-down trait, generating `a, b` such that `!(a <= b)` is easier
   than other fundamental requirements of safe range iterability.

Posting this here after discussion on the inclusive ranges tracking issue: https://github.com/rust-lang/rust/issues/28237

A branch with this change implemented: https://github.com/rust-lang/rust/compare/master...scottmcm:rangeinclusive-struct?expand=1

[Edit] Rendered: https://github.com/scottmcm/rfcs/blob/simpler-rangeinclusive/text/1192-inclusive-ranges.md
