### PR TITLE
Add external doc attribute to rustc

### DIFF
--- a/text/0000-external-doc-attribute.md
+++ b/text/0000-external-doc-attribute.md
@@ -152,7 +152,7 @@ making this feature useless if it creates ergonomic overhead like this.
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
-`#[external_doc("path", "type")]` is an extension of the current
+`#[doc(include = "file_path")]` is an extension of the current
 `#[doc = "doc"]` attribute by allowing documentation to exist outside of the
 source code. This isn't entirely hard to grasp if one is familiar with
 attributes but if not then this syntax vs a `///` or `//!` type of comment

--- a/text/0000-external-doc-attribute.md
+++ b/text/0000-external-doc-attribute.md
@@ -1,3 +1,14 @@
+<!---
+Copyright <year> The Rust Project Developers. See the COPYRIGHT
+file at the top-level directory of this distribution.
+
+Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+<LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+option. This file may not be copied, modified, or distributed
+except according to those terms.
+-->
+
 - Feature Name: external_doc
 - Start Date: 2017-04-26
 - RFC PR: (leave this empty)

--- a/text/0000-external-doc-attribute.md
+++ b/text/0000-external-doc-attribute.md
@@ -59,7 +59,7 @@ This is a markdown file that gets imported to Rust as a Doc comment.
 And code like this:
 
 ```rust
-#[external_doc("docs/example.md", "line")]
+#[doc(include = "docs/example.md")]
 fn my_func() {
   // Hidden implementation
 }
@@ -77,18 +77,16 @@ fn my_func() {
 
 Which `rustdoc` should be able to figure out and use for documentation.
 
-If the flag is changed from `line` to `mod` the file is then imported as
-a module comment for the file (or module) the attribute exists in.
-Using the previous markdown file we would have this code:
+If the code is written like this:
 
 ```rust
-#[external_doc("docs/example.md", "mod")]
+#![doc(include = "docs/example.md")]
 fn my_func() {
   // Hidden implementation
 }
 ```
 
-Expand to this at compile time:
+It should expand out to this at compile time:
 
 ```rust
 //! # I'm an example
@@ -102,7 +100,7 @@ In the case of this code:
 
 ```rust
 mod example {
-    #[external_doc("docs/example.md", "mod")]
+    #![doc(include = "docs/example.md")]
     fn my_func() {
       // Hidden implementation
     }
@@ -131,10 +129,10 @@ ignored by the compiler except for having the proper lines for error messages.
 For example if we have this:
 
 ```rust
-#[external_doc("docs/example.md", "line")] // Line 1
-f my_func() {                              // Line 2
-  // Hidden implementation                 // Line 3
-}                                          // Line 4
+#[doc(include = "docs/example.md")] // Line 1
+f my_func() {                       // Line 2
+  // Hidden implementation          // Line 3
+}                                   // Line 4
 ```
 
 Then we would have a syntax error on line 2, however the doc comment comes
@@ -167,11 +165,9 @@ as it is something that provides convenience but is not a necessary thing to
 learn to use Rust. It should be taught to existing users by updating
 documentation to show it in use and to include in in the Rust Programming
 Language book to teach new users. Currently the newest version of The Rust
-Programming Language does not include doc comments as part of it. This would
-need to be expanded to explain how doc comments work in general and this new
-syntax as well by showing that users can include docs from external sources.
-The Rust Reference comments section would need to updated to include this new
-syntax as well.
+Programming Language book has a section for [doc comments](https://doc.rust-lang.org/nightly/book/second-edition/ch14-02-publishing-to-crates-io.html#documentation-comments) that will need to be expanded
+to show how users can include docs from external sources. The Rust Reference
+comments section would need to updated to include this new syntax as well.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-external-doc-attribute.md
+++ b/text/0000-external-doc-attribute.md
@@ -135,8 +135,8 @@ not being relative to `src`.
 
 ## Missing Files or Incorrect Paths
 If a file given to `include` is missing then this should trigger a compilation
-as the given file was supposed to put into the code but for some reason or other
-it is not there.
+error as the given file was supposed to be put into the code but for some reason
+or other it is not there.
 
 ## Line Numbers When Errors Occur
 As with all macros being expanded this brings up the question of line numbers


### PR DESCRIPTION
This RFC proposes an addition to be able to pull in documentation for items from
an external source at compile time, rather than requiring them to be in the
source code itself.

[Rendered](https://github.com/mgattozzi/rfcs/blob/external-doc-attribute/text/0000-external-doc-attribute.md)