### PR TITLE
Broken links for core team

### DIFF
--- a/text/0002-rfc-process.md
+++ b/text/0002-rfc-process.md
@@ -118,5 +118,5 @@ As an alternative alternative, we could adopt an even stricter RFC process than 
    informal RFC process?
 3. Should we retain rejected RFCs in the archive?
 
-[core team]: https://github.com/mozilla/rust/wiki/Note-core-team
+[core team]: https://www.rust-lang.org/en-US/team.html
 [PEP]: http://legacy.python.org/dev/peps/pep-0001/


### PR DESCRIPTION
The mozilla/rust repository is a redirect to rust-lang and rust-lang has no wiki.  The best link I could find for the core team was on www.rust-lang.org