### PR TITLE
Cross refs for allocator APIs

### DIFF
--- a/text/1183-swap-out-jemalloc.md
+++ b/text/1183-swap-out-jemalloc.md
@@ -10,6 +10,8 @@ different allocator to be used by default in Rust programs. Additionally, also
 switch the default allocator for dynamic libraries and static libraries to using
 the system malloc instead of jemalloc.
 
+*Note:* this RFC has been superseded by [RFC 1974][].
+
 # Motivation
 
 Note that this issue was [discussed quite a bit][babysteps] in the past, and
@@ -233,3 +235,9 @@ enable us to direct LLVM allocations to jemalloc, which would be quite nice!
 
 Should BSD-like systems use Rust's jemalloc by default? Many of them have
 jemalloc as the system allocator and even the special APIs we use from jemalloc.
+
+# Updates since being accepted
+
+*Note:* this RFC has been superseded by [RFC 1974][].
+
+[RFC 1974]: https://github.com/rust-lang/rfcs/blob/master/text/1974-global-allocators.md

--- a/text/1398-kinds-of-allocators.md
+++ b/text/1398-kinds-of-allocators.md
@@ -1227,6 +1227,13 @@ few motivating examples that *are* clearly feasible and useful.
 * Removed uses of `NonZero`. Made `Layout` able to represent zero-sized layouts.
   A given `Allocator` may or may not support zero-sized layouts.
 
+* Various other API revisions were made during development of
+  [PR 42313][], "allocator integration". See the [nightly API docs][]
+  rather than using RFC document as a sole reference.
+
+[PR 42313]: https://github.com/rust-lang/rust/pull/42313
+[nightly API docs]: https://doc.rust-lang.org/nightly/alloc/allocator/trait.Alloc.html
+
 # Appendices
 
 ## Bibliography


### PR DESCRIPTION
Add link connecting the old "swap-out-jemalloc" RFC to the new global allocator RFC.

As a drive-by, point out in the Allocator trait RFC that the actual API changed over development.