### PR TITLE
"Guide-level" and "Reference-level" explanations to replace how we teach and detailed design sections

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -52,4 +52,6 @@ Why should we *not* do this?
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-What parts of the design are still TBD?
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC tha could be addressed in the future independently of the solution that comes out of this RFC?

--- a/0000-template.md
+++ b/0000-template.md
@@ -13,27 +13,28 @@ One para explanation of the feature.
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
-# Detailed design
-[design]: #detailed-design
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
-with the language to understand, and for somebody familiar with the compiler to implement.
-This should get into specifics and corner-cases, and include examples of how the feature is used.
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
 
-# How We Teach This
-[how-we-teach-this]: #how-we-teach-this
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 
-What names and terminology work best for these concepts and why?
-How is this idea best presented—as a continuation of existing Rust patterns, or as a wholly new one?
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
-Would the acceptance of this proposal change how Rust is taught to new users at any level?
-How should this feature be introduced and taught to existing Rust users?
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
 
-What additions or changes to the Rust Reference, _The Rust Programming Language_, and/or _Rust by Example_ does it entail?
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
 
-What would an outline of a new section in the book look like? What should the reader be able to understand by the end of the section in the book?
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
 
-What's an example that would show off this feature?
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/0000-template.md
+++ b/0000-template.md
@@ -22,6 +22,7 @@ Explain the proposal as if it was already included in the language and you were 
 - Explaining the feature largely in terms of examples.
 - Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
 
 For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 

--- a/0000-template.md
+++ b/0000-template.md
@@ -42,10 +42,12 @@ The section should return to the examples given in the previous section, and exp
 
 Why should we *not* do this?
 
-# Alternatives
+# Rationale and Alternatives
 [alternatives]: #alternatives
 
-What other designs have been considered? What is the impact of not doing this?
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
 
 # Unresolved questions
 [unresolved]: #unresolved-questions


### PR DESCRIPTION
r? @aturon 
Switch to "Guide-level" and "Reference-level" explanations

As proposed by aturon <3

These sections replace the "Detailed design" and "How do we teach this?"
sections, and switch their order.

Instead of describing how we would teach a change as a result of a
proposal, the "Guide-level explanation" section will actually attempt to
teach the reader the feature, in a lightweight way.

The guide-level explanation appears first in order to help RFC writers
keep Rust users in the front of their minds, and in order to help RFC
readers understand how an RFC will affect them sooner in the RFC. This
will hopefully make the RFC process more accessible to people who are
Rust users but not compiler or language design experts.