### PR TITLE
Fill in some blanks in RFC 1574 header

### DIFF
--- a/text/1574-more-api-documentation-conventions.md
+++ b/text/1574-more-api-documentation-conventions.md
@@ -1,7 +1,7 @@
 - Feature Name: More API Documentation Conventions
 - Start Date: 2016-03-31
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: https://github.com/rust-lang/rfcs/pull/1574
+- Rust Issue: N/A
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
Some fields were unintentionally left blank