### PR TITLE
RFC: Allow Irrefutable Patterns in if-let and while-let statements

### DIFF
--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -1,0 +1,54 @@
+- Feature Name: allow_if_let_irrefutables
+- Start Date: 2017-07-27
+- RFC PR:
+- Rust Issue:
+
+# Summary
+[summary]: #summary
+
+Currently when using an if let statement and an irrefutable pattern (read always match) is used the compiler complains with an `E0162: irrefutable if-let pattern`.
+
+# Motivation
+[motivation]: #motivation
+
+The use cases for this is in the creation of macros where patterns are allowed because to support the `_` patterns the code has to be rewritten to be both much larger and include a compiler allow.
+The expected outcome is for irrefutable patterns to be compiled to a tautology and have the if block accept it as if it was `if true { }`.
+To support this, currently you must do something roughly the following, which seems to counteract the benefit of having if-let and while-let in the spec.
+
+```rust
+if let $p = $val {
+    $b
+}
+```
+Cannot be used, so the original match must be. The `allow` is forced so that the warning does not appear to the user of it since `_` won't be matched if `$p` is irrefutable.
+
+```rust
+#[allow(unreachable_patterns)]
+match $val {
+    $p => { $b; },
+    _ => ()
+}
+```
+
+
+# Detailed design
+[design]: #detailed-design
+
+1. Remove the error from `irrefutable if-let pattern`. Allow it to compile as a tautology.
+2. Remove the error from `irrefutable while-let pattern`. Allow it to compile as a tautology (maybe a loop).
+
+# How We Teach This
+[how-we-teach-this]: #how-we-teach-this
+
+This can be taught by changing the second version of (`The Book`)[https://doc.rust-lang.org/book/second-edition/ch18-02-refutability.html] to not explicitly say that it is not allowed.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+It allows programmers to manually write the line `if let _ = expr { } else { }` which is generally obfuscating and not desirable. However, a different RFC should solve this.
+
+# Alternatives
+[alternatives]: #alternatives
+
+# Unresolved questions
+[unresolved]: #unresolved-questions

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -7,12 +7,12 @@
 [summary]: #summary
 
 Currently when using an if let statement and an irrefutable pattern (read always match) is used the compiler complains with an `E0162: irrefutable if-let pattern`.
-The current state breaks macros who want to accept patterns generically and this RFC proposes changing this error to an error-by-default which is allowed to be disabled by such macros.
+The current state breaks macros who want to accept patterns generically and this RFC proposes changing this error to an error-by-default lint which is allowed to be disabled by such macros.
 
 # Motivation
 [motivation]: #motivation
 
-The use cases for this is in the creation of macros where patterns are allowed because to support the `_` patterns the code has to be rewritten to be both much larger and include an \[#allow\] statement.
+The use cases for this is in the creation of macros where patterns are allowed because to support the `_` patterns the code has to be rewritten to be both much larger and include an \[#allow\] statement for a lint that does not seem to be related to the problem.
 The expected outcome is for irrefutable patterns to be compiled to a tautology and have the if block accept it as if it was `if true { }`.
 To support this, currently you must do something roughly the following, which seems to counteract the benefit of having if-let and while-let in the spec.
 
@@ -23,13 +23,13 @@ match $val {
     _ => ()
 }
 ```
+The following cannot be used, so the previous must be. An `#[allow(irrefutable_let_pattern)]` is used so that the error-by-default lint does not appear to the user.
 
 ```rust
 if let $p = $val {
     $b
 }
 ```
-Cannot be used, so the original match must be. The `allow` is forced so that the warning does not appear to the user of it since `_` won't be matched if `$p` is irrefutable.
 
 # Detailed design
 [design]: #detailed-design

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -50,5 +50,8 @@ It allows programmers to manually write the line `if let _ = expr { } else { }` 
 # Alternatives
 [alternatives]: #alternatives
 
+* The trivial alternative: Do nothing. As your motivation explains, this only matters for macros anyways plus there already is an acceptable workaround (match). Code that needs this frequently can just package this workaround in its own macro and be done.
+* Turn the error into a lint that errors by default. Unreachable match arms are usually wrong except in some macros and that's why you can disable the warning there with #[allow(unreachable_patterns)]. The same goes for irrefutable if/while-let patterns, so it only seems natural to apply a similar solution. This also means that `#[allow]` statements need to be allowed.
+
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -12,7 +12,7 @@ The current state breaks macros who want to accept patterns generically and this
 # Motivation
 [motivation]: #motivation
 
-The use cases for this is in the creation of macros where patterns are allowed because to support the `_` patterns the code has to be rewritten to be both much larger and include a compiler allow.
+The use cases for this is in the creation of macros where patterns are allowed because to support the `_` patterns the code has to be rewritten to be both much larger and include an \[#allow\] statement.
 The expected outcome is for irrefutable patterns to be compiled to a tautology and have the if block accept it as if it was `if true { }`.
 To support this, currently you must do something roughly the following, which seems to counteract the benefit of having if-let and while-let in the spec.
 

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -60,7 +60,7 @@ macro_rules! check_five {
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
-This can be taught by changing the second version of (`The Book`)[https://doc.rust-lang.org/book/second-edition/ch18-02-refutability.html] to not explicitly say that it is not allowed.
+This can be taught by changing the second version of [The Book](https://doc.rust-lang.org/book/second-edition/ch18-02-refutability.html) to not explicitly say that it is not allowed.
 Adding that it is a lint that can be disabled.
 
 # Drawbacks

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -17,13 +17,6 @@ The expected outcome is for irrefutable patterns to be compiled to a tautology a
 To support this, currently you must do something roughly the following, which seems to counteract the benefit of having if-let and while-let in the spec.
 
 ```rust
-if let $p = $val {
-    $b
-}
-```
-Cannot be used, so the original match must be. The `allow` is forced so that the warning does not appear to the user of it since `_` won't be matched if `$p` is irrefutable.
-
-```rust
 #[allow(unreachable_patterns)]
 match $val {
     $p => { $b; },
@@ -31,6 +24,12 @@ match $val {
 }
 ```
 
+```rust
+if let $p = $val {
+    $b
+}
+```
+Cannot be used, so the original match must be. The `allow` is forced so that the warning does not appear to the user of it since `_` won't be matched if `$p` is irrefutable.
 
 # Detailed design
 [design]: #detailed-design
@@ -67,9 +66,9 @@ Adding that it is a lint that can be disabled.
 # Drawbacks
 [drawbacks]: #drawbacks
 
-It allows programmers to manually write the line `if let _ = expr { } else { }` which is generally obfuscating and not desirable. However, this will not be explicitly allowed with the `#[allow]`.
+It allows programmers to manually write the line `if let _ = expr { } else { }` which is generally obfuscating and not desirable. However, this will only be allowed with an explicit `#[allow(irrefutable_let_pattern)]`.
 
-# Alternatives
+# Alternatives4
 [alternatives]: #alternatives
 
 * The trivial alternative: Do nothing. As your motivation explains, this only matters for macros anyways plus there already is an acceptable workaround (match). Code that needs this frequently can just package this workaround in its own macro and be done.

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -7,6 +7,7 @@
 [summary]: #summary
 
 Currently when using an if let statement and an irrefutable pattern (read always match) is used the compiler complains with an `E0162: irrefutable if-let pattern`.
+The current state breaks macros who want to accept patterns generically and this RFC proposes changing this error to an error-by-default which is allowed to be disabled by such macros.
 
 # Motivation
 [motivation]: #motivation
@@ -35,6 +36,27 @@ match $val {
 [design]: #detailed-design
 
 1. Change the compiler error `irrefutable if-let-pattern` and similar patterns to an `error-by-default` lint that can be disabled by an `#[allow]` statement
+2. Proposed lint name: `irrefutable-let-pattern`
+
+Code Example (explicit):
+```rust
+#[allow(irrefutable-let-pattern)]
+if let _ = 'a' {
+    println!("Hello World");
+}
+```
+
+Code Example (implicit):
+```rust
+macro_rules! check_five {
+    ($p:pat) => {{
+        #[allow(irrefutable-let-pattern)]
+        if let $p = 5 {
+            println!("Pattern matches five");
+        }
+    }};
+}
+```
 
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -34,24 +34,23 @@ match $val {
 # Detailed design
 [design]: #detailed-design
 
-1. Remove the error from `irrefutable if-let pattern`. Allow it to compile as a tautology.
-2. Remove the error from `irrefutable while-let pattern`. Allow it to compile as a tautology (maybe a loop).
+1. Change the compiler error `irrefutable if-let-pattern` and similar patterns to an `error-by-default` lint that can be disabled by an `#[allow]` statement
 
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
 This can be taught by changing the second version of (`The Book`)[https://doc.rust-lang.org/book/second-edition/ch18-02-refutability.html] to not explicitly say that it is not allowed.
+Adding that it is a lint that can be disabled.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-It allows programmers to manually write the line `if let _ = expr { } else { }` which is generally obfuscating and not desirable. However, a different RFC should solve this.
+It allows programmers to manually write the line `if let _ = expr { } else { }` which is generally obfuscating and not desirable. However, this will not be explicitly allowed with the `#[allow]`.
 
 # Alternatives
 [alternatives]: #alternatives
 
 * The trivial alternative: Do nothing. As your motivation explains, this only matters for macros anyways plus there already is an acceptable workaround (match). Code that needs this frequently can just package this workaround in its own macro and be done.
-* Turn the error into a lint that errors by default. Unreachable match arms are usually wrong except in some macros and that's why you can disable the warning there with #[allow(unreachable_patterns)]. The same goes for irrefutable if/while-let patterns, so it only seems natural to apply a similar solution. This also means that `#[allow]` statements need to be allowed.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -68,7 +68,7 @@ Adding that it is a lint that can be disabled.
 
 It allows programmers to manually write the line `if let _ = expr { } else { }` which is generally obfuscating and not desirable. However, this will only be allowed with an explicit `#[allow(irrefutable_let_pattern)]`.
 
-# Alternatives4
+# Alternatives
 [alternatives]: #alternatives
 
 * The trivial alternative: Do nothing. As your motivation explains, this only matters for macros anyways plus there already is an acceptable workaround (match). Code that needs this frequently can just package this workaround in its own macro and be done.

--- a/text/0000-allow-if-let-irrefutables.md
+++ b/text/0000-allow-if-let-irrefutables.md
@@ -36,11 +36,11 @@ match $val {
 [design]: #detailed-design
 
 1. Change the compiler error `irrefutable if-let-pattern` and similar patterns to an `error-by-default` lint that can be disabled by an `#[allow]` statement
-2. Proposed lint name: `irrefutable-let-pattern`
+2. Proposed lint name: `irrefutable_let_pattern`
 
 Code Example (explicit):
 ```rust
-#[allow(irrefutable-let-pattern)]
+#[allow(irrefutable_let_pattern)]
 if let _ = 'a' {
     println!("Hello World");
 }
@@ -50,7 +50,7 @@ Code Example (implicit):
 ```rust
 macro_rules! check_five {
     ($p:pat) => {{
-        #[allow(irrefutable-let-pattern)]
+        #[allow(irrefutable_let_pattern)]
         if let $p = 5 {
             println!("Pattern matches five");
         }

--- a/text/2086-allow-if-let-irrefutables.md
+++ b/text/2086-allow-if-let-irrefutables.md
@@ -1,7 +1,7 @@
 - Feature Name: allow_if_let_irrefutables
 - Start Date: 2017-07-27
-- RFC PR:
-- Rust Issue:
+- RFC PR: https://github.com/rust-lang/rfcs/pull/2086
+- Rust Issue: https://github.com/rust-lang/rust/issues/44495
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
This is an RFC for allowing irrefutable patterns in if-let and while-let statements

**Edit**: [Rendered](https://github.com/Nokel81/rfcs/blob/allow_irrefutable-ifwhile-let/text/0000-allow-if-let-irrefutables.md)