### PR TITLE
Automatically Usable External Crates

### DIFF
--- a/text/0000-no-more-extern-crate.md
+++ b/text/0000-no-more-extern-crate.md
@@ -1,0 +1,103 @@
+- Feature Name: infer-extern-crate
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Infer `extern crate` declarations from the arguments passed to `rustc`.
+With this change, projects using Cargo will no longer have to specify
+`extern crate`: adding dependencies to `Cargo.toml` will result in the
+module being automatically imported.
+
+# Motivation
+[motivation]: #motivation
+
+One of the principles of Rust is that using external crates should be as
+easy and natural as using the standard library.
+This allows the standard library to be kept small, and allows mature, standard
+solutions to be developed by the community.
+
+Currently, however, external crates must be specified twice: once in a build
+system such as Cargo and again in the source code using `extern crate`.
+When external dependencies are conditional (`cfg`) upon feature flags or the
+target platform, the conditional logic must appear in both `Cargo.toml` and
+the `extern crate` declarations.
+
+This duplication causes unnecessary effort and results in one more opportunity
+for mistakes when working with conditionally-enabled dependencies.
+
+# Guide-Level Explanation
+[guide]: #guide
+
+When you add a dependency to your `Cargo.toml`, it is immediately usable within
+the source of your crate:
+
+```toml
+# Cargo.toml:
+name = "my_crate"
+version = "0.1.0"
+authors = ["Me" <me@mail.com>]
+
+[dependencies]
+rand = "0.3"
+```
+
+```rust
+// src/main.rs:
+
+fn main() {
+    println!"A random character: {}", rand::random::<char>());
+}
+```
+
+# Reference-Level Explanation
+[reference]: #reference
+
+External crates are passed to the rust compiler using the `-L` or `-l` flags.
+When an external crate is specified this way, an `extern crate name_of_crate;`
+declaration will be added to the current crate root.
+
+However, for backwards-compatibility with legacy `extern crate` syntax, no
+automatic import will occur if an `extern crate` declaration for the same
+external dependency appears anywhere within the crate.
+
+Additionally, items such as modules, types, or functions that conflict with
+the names of implicitly imported crates will cause the implicit `extern crate`
+declaration to be removed.
+Note that this is different from the current behavior of the
+implicitly-imported `std` module.
+Currently, creating a root-level item named `std` results in a name conflict
+error. For consistency with other crates, this error will be removed.
+Creating a root-level item named `std` will prevent `std` from being included,
+and will trigger a warning.
+
+It will still be necessary to use the `extern crate` syntax when using
+`#[macro_use]` to import macros from a crate. This is necessary in order to
+prevent macros from being automatically brought into scope and changing the
+behavior of existing code.
+
+# Alternatives
+[alternatives]: #alternatives
+
+- Don't do this.
+- Specify external dependencies using only `extern crate`, rather than only
+`Cargo.toml`, by using `extern crate foo = "0.2";` or similar. This would
+require either `Cargo` or `rustc` to first scan the source before determining
+the build dependencies of the existing code, a system which requires fairly
+tight coupling between a build system and `rustc`, and which would almost
+certainly interact poorly with third-party build systems.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+- What interactions does this have with future procedural macros?
+- Should we lint/warn on local items shadowing implicitly imported crates?
+It seems like a useful warning, but it's also a potential
+backwards-compatibility hazard for crates which previously depended on a
+crate, didn't import it with `extern crate`, and had a root-level item with
+an overlapping name (although this seems like an extreme edge case).
+- How can we prevent having to use `extern crate` whenever we need to import
+a macro? In a future "macros 2.0" world it may be possible to import macros
+using some other syntax, which could resolve this issue.

--- a/text/0000-no-more-extern-crate.md
+++ b/text/0000-no-more-extern-crate.md
@@ -7,11 +7,11 @@
 [summary]: #summary
 
 This RFC reduces redundant boilerplate when including external crates.
-`extern crate` declarations will be inferred from the arguments passed to
-`rustc`.
-With this change, projects using Cargo will no longer have to specify
-`extern crate`: adding dependencies to `Cargo.toml` will result in the
-module being automatically imported.
+`extern crate` declarations will be inferred from the arguments passed to `rustc`.
+With this change, projects using Cargo
+(or other build systems using the same mechanism)
+will no longer have to specify `extern crate`:
+dependencies added to `Cargo.toml` will be automatically imported.
 Projects which require more flexibility can still use manual `extern crate`
 and will be unaffected by this RFC.
 
@@ -64,22 +64,27 @@ fn main() {
 # Reference-Level Explanation
 [reference]: #reference
 
-External crates are passed to the rust compiler using the
+External crates can be passed to the rust compiler using the
 `--extern CRATE_NAME=PATH` flag.
 For example, `cargo build`-ing a crate `my_crate` with a dependency on `rand`
 results in a call to rustc that looks something like
 `rustc --crate-name mycrate src/main.rs --extern rand=/path/to/librand.rlib ...`.
 
-When an external crate is specified this way, an `extern crate name_of_crate;`
-declaration will be added to the current crate root
-(note: this behavior won't occur when including a library using the `-l`
-or `-L` flags).
+When an external crate is specified this way,
+the crate will automatically brought into scope as if an
+`extern crate name_of_crate;`
+declaration had been added to the current crate root.
+This behavior won't occur when including a library using the `-l`
+or `-L` flags.
 
-However, for backwards-compatibility with legacy `extern crate` syntax, no
-automatic import will occur if an `extern crate` declaration for the same
+We will continue to support the current `extern crate` syntax,
+both for backwards compatibility and to enable users who want to use manual
+`extern crate` in order to have more fine grained control-- say, if they wanted
+to import an external crate only inside an inner module.
+No automatic import will occur if an `extern crate` declaration for the same
 external dependency appears anywhere within the crate.
 For example, if `rand = "0.3"` is listed as a dependency in Cargo.toml
-and `extern crate rand;` appears somwhere in the crate being compiled,
+and `extern crate rand;` appears somewhere in the crate being compiled,
 then no implicit `extern crate rand;` will be added.
 If Cargo.toml were to also list another dependency, `log = "0.3"`, and no
 `extern crate log;` appears in the crate being compiled,

--- a/text/0000-no-more-extern-crate.md
+++ b/text/0000-no-more-extern-crate.md
@@ -154,4 +154,4 @@ an overlapping name (although this seems like an extreme edge case).
 - `extern crate foo` has linking side effects even if `foo` isn't visibly
 used from Rust source. After this change, `use foo;` would have similar
 effects. This seems potentially undesirable-- what's the right way of handling
-crates which are brough in only for their side effects?
+crates which are brought in only for their side effects?

--- a/text/0000-no-more-extern-crate.md
+++ b/text/0000-no-more-extern-crate.md
@@ -43,7 +43,7 @@ and
 When you add a dependency to your `Cargo.toml`, it is immediately usable within
 the source of your crate:
 
-```toml
+```
 # Cargo.toml:
 name = "my_crate"
 version = "0.1.0"

--- a/text/0000-no-more-extern-crate.md
+++ b/text/0000-no-more-extern-crate.md
@@ -122,14 +122,23 @@ will be added to the `Cargo.toml` format.
 Users who want to use the `rand` crate but call it `random` instead can now
 write `rand = { version = "0.3", alias = "random" }`.
 
-When compiling, an external crate is only included if it is used
+When compiling, an external crate is only linked if it is used
 (through either `extern crate`, `use`, or absolute paths).
-This prevents unnecessary inclusion of crates when compiling crates with
-both `lib` and `bin` targets, or which bring in a large number of possible
-dependencies (such as
-[the current Rust Playground](https://users.rust-lang.org/t/the-official-rust-playground-now-has-the-top-100-crates-available/11817)).
-It also prevents `no_std` crates from accidentally including `std`-using
-crates.
+This prevents unused crates from being linked, which is helpful in a number of
+scenarios:
+- Some crates have both `lib` and `bin` targets and want to avoid linking both
+`bin` and `lib` dependencies.
+- `no_std` crates need a way to avoid accidentally linking `std`-using crates.
+- Other crates have a large number of possible dependencies (such as
+[the current Rust Playground](https://users.rust-lang.org/t/the-official-rust-playground-now-has-the-top-100-crates-available/11817)),
+and want to avoid linking all of them.
+
+In order to prevent linking of unused crates,
+after macro expansion has occurred, the compiler will resolve
+`use`, `extern crate`, and absolute paths looking for a reference to external
+crates or items within them. Crates which are unreferenced in these paths
+will not be linked.
+
 
 # Alternatives
 [alternatives]: #alternatives


### PR DESCRIPTION
This RFC reduces redundant boilerplate when including external crates. With this change, projects using Cargo (or other build systems using the same mechanism) will no longer have to specify extern crate: dependencies added to Cargo.toml will be automatically useable. We continue to support extern crate for backwards compatibility with the option of phasing it out in future Rust epochs.

[Rendered](https://github.com/cramertj/rfcs/blob/extern-crate/text/0000-no-more-extern-crate.md)