### PR TITLE
Support defining C-compatible variadic functions in Rust

### DIFF
--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -65,7 +65,7 @@ To access the arguments, Rust provides the following public interfaces in
 ```rust
 /// The argument list of a C-compatible variadic function, corresponding to the
 /// underlying C `va_list`. Opaque.
-pub struct VaList<'a>;
+pub extern type VaList<'a>;
 
 impl<'a> VaList<'a> {
     /// Extract the next argument from the argument list. T must have a type
@@ -75,6 +75,9 @@ impl<'a> VaList<'a> {
 
 impl<'a> Clone for VaList<'a>;
 ```
+
+`VaList` may become a language item (`#[lang="VaList"]`) to attach the
+appropriate compiler handling.
 
 The type returned from `VaList::arg` must have a type usable in an `extern "C"`
 FFI interface; the compiler allows all the same types returned from

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -65,7 +65,7 @@ To access the arguments, Rust provides the following public interfaces in
 ```rust
 /// The argument list of a C-compatible variadic function, corresponding to the
 /// underlying C `va_list`. Opaque.
-pub extern type VaList<'a>;
+pub struct VaList<'a> { /* fields omitted */ }
 
 impl<'a> VaList<'a> {
     /// Extract the next argument from the argument list. T must have a type

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -102,10 +102,11 @@ consist of aliases for the underlying Rust types, making it unnecessary for
 `libc` to provide additional implementations of the `VaArg` trait. Nothing
 outside of `core` should define any implementation of `VaArg`.
 
-Note that extracting an argument from a `VaList` follows the platform-specific
-rules for argument passing and promotion. In particular, many platforms promote
-any argument smaller than a C `int` to an `int`. On such platforms, extracting
-the corresponding type will extract an `int` and convert appropriately.
+Note that extracting an argument from a `VaList` follows the C rules for
+argument passing and promotion. In particular, C code will promote any argument
+smaller than a C `int` to an `int`, and promote `float` to `double`. Thus,
+Rust's argument extractions for the corresponding types will extract an `int`
+or `double` as appropriate, and convert appropriately.
 
 Like the underlying platform `va_list` structure in C, `VaList` has an opaque,
 platform-specific representation.

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -76,9 +76,6 @@ impl<'a> VaList<'a> {
 impl<'a> Clone for VaList<'a>;
 ```
 
-`VaList` may become a language item (`#[lang="VaList"]`) to attach the
-appropriate compiler handling.
-
 The type returned from `VaList::arg` must have a type usable in an `extern "C"`
 FFI interface; the compiler allows all the same types returned from
 `VaList::arg` that it allows in the function signature of an `extern "C"`
@@ -177,6 +174,9 @@ ensure that a call to `va_end` occurs exactly once on every `VaList` at an
 appropriate time, similar to drop semantics. (This may occur via an
 implementation of `Drop`, but this must take into account the semantics of
 passing a `VaList` to or from an `extern "C"` function.)
+
+`VaList` may become a language item (`#[lang="VaList"]`) to attach the
+appropriate compiler handling.
 
 The compiler may need to handle the type `VaList` specially, in order to
 provide the desired drop semantics at FFI boundaries. In particular, some

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -191,7 +191,15 @@ original `VaList` as well as any clones of it. For instance, passing a `VaList`
 to a `vprintf` function as declared in this RFC semantically passes ownership
 of that `VaList`, and prevents calling the `arg` function again in the caller,
 but it remains the caller's responsibility to call `va_end`, so the compiler
-needs to insert the appropriate drop glue at the FFI boundary.
+needs to insert the appropriate drop glue at the FFI boundary. Conversely,
+functions accepting a `VaList` argument must not drop it themselves, since the
+caller will drop it instead.
+
+The C standard requires that the call to `va_end` for a `va_list` occur in the
+same function as the matching `va_start` or `va_copy` for that `va_list`. Some
+C implementations do not enforce this requirement, allowing for functions that
+call `va_end` on a passed-in `va_list` that they did not create. This RFC does
+not define a means of implementing or calling non-standard functions like these.
 
 Note that on some platforms, these LLVM intrinsics do not fully implement the
 necessary functionality, expecting the invoker of the intrinsic to provide

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -174,9 +174,9 @@ use std::intrinsics::{VaArg, VaList};
 #[no_mangle]
 pub unsafe extern "C" fn func(fixed: u32, ...) {
     let args = VaList::start();
-    let x: u8 = args::arg();
-    let y: u16 = args::arg();
-    let z: u32 = args::arg();
+    let x: u8 = args.arg();
+    let y: u16 = args.arg();
+    let z: u32 = args.arg();
     println!("{} {} {} {}", fixed, x, y, z);
 }
 ```

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -76,10 +76,10 @@ impl<'a> VaList<'a> {
 impl<'a> Clone for VaList<'a>;
 ```
 
-The type returned from `VaList::arg` must have a type usable in an FFI
-interface: `i8`, `i16`, `i32`, `i64`, `isize`, `u8`, `u16`, `u32`, `u64`,
-`usize`, `f32`, `f64`, `*const _`, `*mut _`, a `#[repr(C)]` struct or union, or
-a non-value-carrying enum with a `repr`-specified discriminant type.
+The type returned from `VaList::arg` must have a type usable in an `extern "C"`
+FFI interface; the compiler allows all the same types returned from
+`VaList::arg` that it allows in the function signature of an `extern "C"`
+function.
 
 All of the corresponding C integer and float types defined in the `libc` crate
 consist of aliases for the underlying Rust types, so `VaList::arg` can also

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -95,13 +95,16 @@ impl VaArg for i16;
 impl VaArg for i32;
 impl VaArg for i64;
 impl VaArg for isize;
+
 impl VaArg for u8;
 impl VaArg for u16;
 impl VaArg for u32;
 impl VaArg for u64;
 impl VaArg for usize;
+
 impl VaArg for f32;
 impl VaArg for f64;
+
 impl<T> VaArg for *const T;
 impl<T> VaArg for *mut T;
 ```
@@ -113,24 +116,34 @@ the raw C types corresponding to the Rust integer and float types above:
 impl VaArg for c_char;
 impl VaArg for c_schar;
 impl VaArg for c_uchar;
+
 impl VaArg for c_short;
-impl VaArg for c_int;
-impl VaArg for c_long;
-impl VaArg for c_longlong;
 impl VaArg for c_ushort;
+
+impl VaArg for c_int;
 impl VaArg for c_uint;
+
+impl VaArg for c_long;
 impl VaArg for c_ulong;
+
+impl VaArg for c_longlong;
 impl VaArg for c_ulonglong;
+
 impl VaArg for c_float;
 impl VaArg for c_double;
+
 impl VaArg for int8_t;
 impl VaArg for int16_t;
 impl VaArg for int32_t;
 impl VaArg for int64_t;
+
 impl VaArg for uint8_t;
 impl VaArg for uint16_t;
 impl VaArg for uint32_t;
 impl VaArg for uint64_t;
+
+impl VaArg for size_t;
+impl VaArg for ssize_t;
 ```
 
 Note that extracting an argument from a `VaList` follows the platform-specific

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -105,10 +105,12 @@ instance, the `libc` crate could define the `va_list` variants of `printf` as
 follows:
 
 ```rust
-pub unsafe extern "C" fn vprintf(format: *const c_char, ap: VaList) -> c_int;
-pub unsafe extern "C" fn vfprintf(stream: *mut FILE, format: *const c_char, ap: VaList) -> c_int;
-pub unsafe extern "C" fn vsprintf(s: *mut c_char, format: *const c_char, ap: VaList) -> c_int;
-pub unsafe extern "C" fn vsnprintf(s: *mut c_char, n: size_t, format: *const c_char, ap: VaList) -> c_int;
+extern "C" {
+    pub unsafe fn vprintf(format: *const c_char, ap: VaList) -> c_int;
+    pub unsafe fn vfprintf(stream: *mut FILE, format: *const c_char, ap: VaList) -> c_int;
+    pub unsafe fn vsprintf(s: *mut c_char, format: *const c_char, ap: VaList) -> c_int;
+    pub unsafe fn vsnprintf(s: *mut c_char, n: size_t, format: *const c_char, ap: VaList) -> c_int;
+}
 ```
 
 Note that, per the C semantics, after passing `VaList` to these functions, the

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -212,25 +212,16 @@ ever allowing the `VaList` structure to outlive it. However, if we can provide
 an appropriate compile-time lifetime check, doing would make it easier to
 correctly write the appropriate unsafe code.
 
-Rather than defining a `VaList::start` function, we could require specifying a
-name along with the `...`:
+Rather than naming the argument in the variadic function signature, we could
+provide a `VaList::start` function to return one. This would also allow calling
+`start` more than once. However, this would complicate the lifetime handling
+required to ensure that the `VaList` does not outlive the call to the variadic
+function.
 
-```rust
-pub unsafe extern "C" fn func(fixed: u32, ...args) {
-    // implementation
-}
-```
-
-This might simplify the provision of an appropriate lifetime, and would avoid
-the need to provide a `VaList::start` function and only allow calling it from
-within a variadic function.
-
-However, such an approach would not expose any means of calling `va_start`
-multiple times in the same variadic function. Note that doing so has a
-different semantic than calling `va_copy`, as calling `va_start` again iterates
-over the arguments from the beginning rather than the current point. Given that
-this mechanism exists for the sole purpose of interoperability with C, more
-closely matching the underlying C interface seems appropriate.
+We could use several alternative syntaxes to declare the argument in the
+signature, including `...args`, or listing the `VaList` or `VaList<'a>` type
+explicitly. The latter, however, would require care to ensure that code could
+not reference or alias the lifetime.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -50,10 +50,11 @@ pub unsafe extern "C" fn func(arg: T, arg2: T2, mut args: ...) {
 
 The use of `...` as the type of `args` at the end of the argument list declares
 the function as variadic. This must appear as the last argument of the
-function.  The function must use `extern "C"`, and must use `unsafe`. To expose
-such a function as a symbol for C code to call directly, the function may want
-to use `#[no_mangle]` as well; however, Rust code may also pass the function to
-C code expecting a function pointer to a variadic function.
+function, and the function must have at least one argument before it. The
+function must use `extern "C"`, and must use `unsafe`. To expose such a
+function as a symbol for C code to call directly, the function may want to use
+`#[no_mangle]` as well; however, Rust code may also pass the function to C code
+expecting a function pointer to a variadic function.
 
 The `args` named in the function declaration has the type
 `core::intrinsics::VaList<'a>`, where the compiler supplies a lifetime `'a`

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -252,3 +252,14 @@ corresponding variadic function.
 Currently, Rust does not allow passing a closure to C code expecting a pointer
 to an `extern "C"` function. If this becomes possible in the future, then
 variadic closures would become useful, and we should add them at that time.
+
+This RFC only supports the platform's native `"C"` ABI, not any other ABI. Code
+may wish to define variadic functions for another ABI, and potentially more
+than one such ABI in the same program. However, such support should not
+complicate the common case. LLVM has extremely limited support for this, for
+only a specific pair of platforms (supporting the Windows ABI on platforms that
+use the System V ABI), with no generalized support in the underlying
+intrinsics. The LLVM intrinsics only support using the ABI of the containing
+function. Given the current state of the ecosystem, this RFC only proposes
+supporting the native `"C"` ABI for now. Doing so will not prevent the
+introduction of support for non-native ABIs in the future.

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -161,6 +161,18 @@ A variadic function may pass the `VaList` to another function. However, it may
 not return the `VaList` or otherwise allow it to outlive that call to the
 variadic function.
 
+A function declared with `extern "C"` may accept a `VaList` parameter,
+corresponding to a `va_list` parameter in the corresponding C function. For
+instance, the `libc` crate could define the `va_list` variants of `printf` as
+follows:
+
+```rust
+pub unsafe extern "C" fn vprintf(format: *const c_char, ap: VaList) -> c_int;
+pub unsafe extern "C" fn vfprintf(stream: *mut FILE, format: *const c_char, ap: VaList) -> c_int;
+pub unsafe extern "C" fn vsprintf(s: *mut c_char, format: *const c_char, ap: VaList) -> c_int;
+pub unsafe extern "C" fn vsnprintf(s: *mut c_char, n: size_t, format: *const c_char, ap: VaList) -> c_int;
+```
+
 Defining a variadic function, or calling any of these new functions, requires a
 feature-gate, `c_variadic`.
 

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -77,25 +77,25 @@ impl<'a> Clone for VaList<'a>;
 impl<'a> Drop for VaList<'a>;
 
 /// The type of arguments extractable from VaList
-trait VaArg;
+unsafe trait VaArg;
 
-impl VaArg for i8;
-impl VaArg for i16;
-impl VaArg for i32;
-impl VaArg for i64;
-impl VaArg for isize;
+unsafe impl VaArg for i8;
+unsafe impl VaArg for i16;
+unsafe impl VaArg for i32;
+unsafe impl VaArg for i64;
+unsafe impl VaArg for isize;
 
-impl VaArg for u8;
-impl VaArg for u16;
-impl VaArg for u32;
-impl VaArg for u64;
-impl VaArg for usize;
+unsafe impl VaArg for u8;
+unsafe impl VaArg for u16;
+unsafe impl VaArg for u32;
+unsafe impl VaArg for u64;
+unsafe impl VaArg for usize;
 
-impl VaArg for f32;
-impl VaArg for f64;
+unsafe impl VaArg for f32;
+unsafe impl VaArg for f64;
 
-impl<T> VaArg for *const T;
-impl<T> VaArg for *mut T;
+unsafe impl<T> VaArg for *const T;
+unsafe impl<T> VaArg for *mut T;
 ```
 
 All of the corresponding C integer and float types defined in the `libc` crate

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -70,7 +70,7 @@ impl<'a> VaList<'a> {
     pub unsafe fn start() -> VaList<'a>;
 
     /// Extract the next argument from the argument list.
-    pub unsafe fn<T: VaArg> arg(&mut self) -> T;
+    pub unsafe fn arg<T: VaArg>(&mut self) -> T;
 }
 
 impl<'a> Clone for VaList<'a>;

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -54,17 +54,6 @@ such a function as a symbol for C code to call directly, the function may want
 to use `#[no_mangle]` as well; however, Rust code may also pass the function to
 C code expecting a function pointer to a variadic function.
 
-Unsafe Rust code can also define a variadic closure:
-
-```rust
-let closure = |arg, arg2, ...| {
-    // implementation
-};
-```
-
-Rust code may pass a variadic closure to C code expecting a pointer to a
-variadic function.
-
 To access the arguments, Rust provides the following public interfaces in
 `core::intrinsics` (also available via `std::intrinsics`):
 
@@ -285,3 +274,7 @@ closely matching the underlying C interface seems appropriate.
 When implementing this feature, we will need to determine whether the compiler
 can provide an appropriate lifetime that prevents a `VaList` from outliving its
 corresponding variadic function.
+
+Currently, Rust does not allow passing a closure to C code expecting a pointer
+to an `extern "C"` function. If this becomes possible in the future, then
+variadic closures would become useful, and we should add them at that time.

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -98,42 +98,10 @@ impl<T> VaArg for *const T;
 impl<T> VaArg for *mut T;
 ```
 
-The `libc` crate additionally provides implementations of the `VaArg` trait for
-the raw C types corresponding to the Rust integer and float types above:
-
-```rust
-impl VaArg for c_char;
-impl VaArg for c_schar;
-impl VaArg for c_uchar;
-
-impl VaArg for c_short;
-impl VaArg for c_ushort;
-
-impl VaArg for c_int;
-impl VaArg for c_uint;
-
-impl VaArg for c_long;
-impl VaArg for c_ulong;
-
-impl VaArg for c_longlong;
-impl VaArg for c_ulonglong;
-
-impl VaArg for c_float;
-impl VaArg for c_double;
-
-impl VaArg for int8_t;
-impl VaArg for int16_t;
-impl VaArg for int32_t;
-impl VaArg for int64_t;
-
-impl VaArg for uint8_t;
-impl VaArg for uint16_t;
-impl VaArg for uint32_t;
-impl VaArg for uint64_t;
-
-impl VaArg for size_t;
-impl VaArg for ssize_t;
-```
+All of the corresponding C integer and float types defined in the `libc` crate
+consist of aliases for the underlying Rust types, making it unnecessary for
+`libc` to provide additional implementations of the `VaArg` trait. Nothing
+outside of `core` should define any implementation of `VaArg`.
 
 Note that extracting an argument from a `VaList` follows the platform-specific
 rules for argument passing and promotion. In particular, many platforms promote

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -43,7 +43,7 @@ mechanism.
 Such a declaration looks like this:
 
 ```rust
-pub unsafe extern "C" fn func(arg: T, arg2: T2, args: ...) {
+pub unsafe extern "C" fn func(arg: T, arg2: T2, mut args: ...) {
     // implementation
 }
 ```
@@ -137,7 +137,7 @@ Sample Rust code exposing a variadic function:
 use std::intrinsics::VaArg;
 
 #[no_mangle]
-pub unsafe extern "C" fn func(fixed: u32, args: ...) {
+pub unsafe extern "C" fn func(fixed: u32, mut args: ...) {
     let x: u8 = args.arg();
     let y: u16 = args.arg();
     let z: u32 = args.arg();

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -1,0 +1,262 @@
+- Feature Name: variadic
+- Start Date: 2017-08-21
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Support defining C-compatible variadic functions in Rust, via new intrinsics.
+Rust currently supports declaring external variadic functions and calling them
+from unsafe code, but does not support writing such functions directly in Rust.
+Adding such support will allow Rust to replace a larger variety of C libraries,
+avoid requiring C stubs and error-prone reimplementation of platform-specific
+code, improve incremental translation of C codebases to Rust, and allow
+implementation of variadic callbacks.
+
+# Motivation
+[motivation]: #motivation
+
+Rust can currently call any possible C interface, and export *almost* any
+interface for C to call. Variadic functions represent one of the last remaining
+gaps in the latter. Currently, providing a variadic function callable from C
+requires writing a stub function in C, linking that function into the Rust
+program, and arranging for that stub to subsequently call into Rust.
+Furthermore, even with the arguments packaged into a `va_list` structure by C
+code, extracting arguments from that structure requires exceptionally
+error-prone, platform-specific code, for which the crates.io ecosystem provides
+only partial solutions for a few target architectures.
+
+This RFC does not propose an interface intended for native Rust code to pass
+variable numbers of arguments to a native Rust function, nor an interface that
+provides any kind of type safety. This proposal exists primarily to allow Rust
+to provide interfaces callable from C code.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+C code allows declaring a function callable with a variable number of
+arguments, using an ellipsis (`...`) at the end of the argument list. For
+compatibility, unsafe Rust code may export a function compatible with this
+mechanism.
+
+Such a declaration looks like this:
+
+```rust
+pub unsafe extern "C" fn func(arg: T, arg2: T2, ...) {
+    // implementation
+}
+```
+
+The `...` at the end of the argument list declares the function as variadic.
+The function must use `extern "C"`, and must use `unsafe`. To expose
+such a function as a symbol for C code to call directly, the function may want
+to use `#[no_mangle]` as well; however, Rust code may also pass the function to
+C code expecting a function pointer to a variadic function.
+
+Unsafe Rust code can also define a variadic closure:
+
+```rust
+let closure = |arg, arg2, ...| {
+    // implementation
+};
+```
+
+Rust code may pass a variadic closure to C code expecting a pointer to a
+variadic function.
+
+To access the arguments, Rust provides the following public interfaces in
+`core::intrinsics` (also available via `std::intrinsics`):
+
+```rust
+/// The argument list of a C-compatible variadic function, corresponding to the
+/// underlying C `va_list`. Opaque.
+pub struct VaList<'a>;
+
+impl<'a> VaList<'a> {
+    /// Obtain the variable arguments of the current function. Produces a
+    /// compile-time error if called from a non-variadic function. The compiler
+    /// will supply the appropriate lifetime when called, and prevent that
+    /// lifetime from outliving the variadic function.
+    pub unsafe fn start() -> VaList<'a>;
+
+    /// Extract the next argument from the argument list.
+    pub unsafe fn<T: VaArg> arg(&mut self) -> T;
+}
+
+impl<'a> Clone for VaList<'a>;
+impl<'a> Drop for VaList<'a>;
+
+/// The type of arguments extractable from VaList
+trait VaArg;
+
+impl VaArg for i8;
+impl VaArg for i16;
+impl VaArg for i32;
+impl VaArg for i64;
+impl VaArg for isize;
+impl VaArg for u8;
+impl VaArg for u16;
+impl VaArg for u32;
+impl VaArg for u64;
+impl VaArg for usize;
+impl VaArg for f32;
+impl VaArg for f64;
+impl<T> VaArg for *const T;
+impl<T> VaArg for *mut T;
+```
+
+The `libc` crate additionally provides implementations of the `VaArg` trait for
+the raw C types corresponding to the Rust integer and float types above:
+
+```rust
+impl VaArg for c_char;
+impl VaArg for c_schar;
+impl VaArg for c_uchar;
+impl VaArg for c_short;
+impl VaArg for c_int;
+impl VaArg for c_long;
+impl VaArg for c_longlong;
+impl VaArg for c_ushort;
+impl VaArg for c_uint;
+impl VaArg for c_ulong;
+impl VaArg for c_ulonglong;
+impl VaArg for c_float;
+impl VaArg for c_double;
+impl VaArg for int8_t;
+impl VaArg for int16_t;
+impl VaArg for int32_t;
+impl VaArg for int64_t;
+impl VaArg for uint8_t;
+impl VaArg for uint16_t;
+impl VaArg for uint32_t;
+impl VaArg for uint64_t;
+```
+
+Note that extracting an argument from a `VaList` follows the platform-specific
+rules for argument passing and promotion. In particular, many platforms promote
+any argument smaller than a C `int` to an `int`. On such platforms, extracting
+the corresponding type will extract an `int` and convert appropriately.
+
+Like the underlying platform `va_list` structure in C, `VaList` has an opaque,
+platform-specific representation.
+
+A variadic function may call `VaList::start` more than once, and traverse the
+argument list more than once.
+
+A variadic function may pass the `VaList` to another function. However, it may
+not return the `VaList` or otherwise allow it to outlive that call to the
+variadic function.
+
+Defining a variadic function, or calling any of these new functions, requires a
+feature-gate, `c_variadic`.
+
+Sample Rust code exposing a variadic function:
+
+```rust
+#![feature(c_variadic)]
+use std::intrinsics::{VaArg, VaList};
+
+#[no_mangle]
+pub unsafe extern "C" fn func(fixed: u32, ...) {
+    let args = VaList::start();
+    let x: u8 = args::arg();
+    let y: u16 = args::arg();
+    let z: u32 = args::arg();
+    println!("{} {} {} {}", fixed, x, y, z);
+}
+```
+
+Sample C code calling that function:
+
+```c
+#include <stdint.h>
+
+void func(uint32_t fixed, ...);
+
+int main(void)
+{
+    uint8_t x = 10;
+    uint16_t y = 15;
+    uint32_t z = 20;
+    func(5, x, y, z);
+    return 0;
+}
+```
+
+Compiling and linking these two together will produce a program that prints:
+
+```text
+5 10 15 20
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+LLVM already provides a set of intrinsics, implementing `va_start`, `va_arg`,
+`va_end`, and `va_copy`. The implementation of `VaList::start` will call the
+`va_start` intrinsic. The implementation of `VaList::arg` will call `va_arg`.
+The implementation of `Clone` for `VaList` wil call `va_copy`. The
+implementation of `Drop` for `VaList` wil call `va_end`.
+
+This RFC intentionally does not specify the mechanism used to implement the
+`VaArg` trait, as the compiler may need to natively implement `VaList::arg`
+with appropriate understanding of platform-specific conventions. Code outside
+of `core`, `std`, and `libc` may not implement this trait for any other type.
+
+Note that on some platforms, these LLVM intrinsics do not fully implement the
+necessary functionality, expecting the invoker of the intrinsic to provide
+additional LLVM IR code. On such platforms, rustc will need to provide the
+appropriate additional code, just as clang does.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+This feature is highly unsafe, and requires carefully written code to extract
+the appropriate argument types provided by the caller, based on whatever
+arbitrary runtime information determines those types. However, in this regard,
+this feature provides no more unsafety than the equivalent C code, and in fact
+provides several additional safety mechanisms, such as automatic handling of
+type promotions, lifetimes, copies, and destruction.
+
+# Rationale and Alternatives
+[alternatives]: #alternatives
+
+This represents one of the few C-compatible interfaces that Rust does not
+provide. Currently, Rust code wishing to interoperate with C has no alternative
+to this mechanism, other than hand-written C stubs. This also limits the
+ability to incrementally translate C to Rust, or to bind to C interfaces that
+expect variadic callbacks.
+
+Rather than having the compiler invent an appropriate lifetime parameter, we
+could simply require the unsafe code implementing a variadic function to avoid
+ever allowing the `VaList` structure to outlive it. However, if we can provide
+an appropriate compile-time lifetime check, doing would make it easier to
+correctly write the appropriate unsafe code.
+
+Rather than defining a `VaList::start` function, we could require specifying a
+name along with the `...`:
+
+```rust
+pub unsafe extern "C" fn func(fixed: u32, ...args) {
+    // implementation
+}
+```
+
+This might simplify the provision of an appropriate lifetime, and would avoid
+the need to provide a `VaList::start` function and only allow calling it from
+within a variadic function.
+
+However, such an approach would not expose any means of calling `va_start`
+multiple times in the same variadic function. Note that doing so has a
+different semantic than calling `va_copy`, as calling `va_start` again iterates
+over the arguments from the beginning rather than the current point. Given that
+this mechanism exists for the sole purpose of interoperability with C, more
+closely matching the underlying C interface seems appropriate.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+When implementing this feature, we will need to determine whether the compiler
+can provide an appropriate lifetime that prevents a `VaList` from outliving its
+corresponding variadic function.

--- a/text/0000-variadic.md
+++ b/text/0000-variadic.md
@@ -172,10 +172,11 @@ Compiling and linking these two together will produce a program that prints:
 [reference-level-explanation]: #reference-level-explanation
 
 LLVM already provides a set of intrinsics, implementing `va_start`, `va_arg`,
-`va_end`, and `va_copy`. The implementation of `VaList::start` will call the
-`va_start` intrinsic. The implementation of `VaList::arg` will call `va_arg`.
-The implementation of `Clone` for `VaList` wil call `va_copy`. The
-implementation of `Drop` for `VaList` wil call `va_end`.
+`va_end`, and `va_copy`. The compiler will insert a call to the `va_start`
+intrinsic at the start of the function to provide the `VaList` argument (if
+used). The implementation of `VaList::arg` will call `va_arg`.  The
+implementation of `Clone` for `VaList` wil call `va_copy`. The implementation
+of `Drop` for `VaList` wil call `va_end`.
 
 This RFC intentionally does not specify the mechanism used to implement the
 `VaArg` trait, as the compiler may need to natively implement `VaList::arg`

--- a/text/2137-variadic.md
+++ b/text/2137-variadic.md
@@ -1,7 +1,7 @@
 - Feature Name: variadic
 - Start Date: 2017-08-21
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: https://github.com/rust-lang/rfcs/pull/2137
+- Rust Issue: https://github.com/rust-lang/rust/issues/44930
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
Support defining C-compatible variadic functions in Rust, via new intrinsics.
Rust currently supports declaring external variadic functions and calling them
from unsafe code, but does not support writing such functions directly in Rust.
Adding such support will allow Rust to replace a larger variety of C libraries,
avoid requiring C stubs and error-prone reimplementation of platform-specific
code, improve incremental translation of C codebases to Rust, and allow
implementation of variadic callbacks.

This RFC does not propose an interface intended for native Rust code to pass
variable numbers of arguments to a native Rust function, nor an interface that
provides any kind of type safety. This proposal exists primarily to allow Rust
to provide interfaces callable from C code.

[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/2137-variadic.md)