### PR TITLE
impl-only-use

### DIFF
--- a/text/0000-impl-only-use.md
+++ b/text/0000-impl-only-use.md
@@ -49,7 +49,7 @@ struct Zoo { // wait, what happens here?
 
 fn main() {
   let x = "foo";
-  let y = x.zoo(); // won’t compile because `zoo::Zoo` not in scope
+  let y = x.zoo();
 }
 ```
 
@@ -57,7 +57,7 @@ However, you can see that we’ll hit a problem here, because we define an ambig
 two solutions:
 
 - Change the name of the `struct` to something else.
-- Qualified the `use`.
+- Qualify the `use`.
 
 The problem is that if we qualify the `use`, what name do we give the trait? We’re not even
 referring to it directly.
@@ -118,7 +118,7 @@ extern crate my_crate as _;
 
 This RFC tries to solve a very specific problem (when you *must* alias a trait use). It’s just a
 nit to make the syntax more *“rust-ish”* (it’s very easy to think such a thing would work given the
-way `_` works pretty much everywhere else.
+way `_` works pretty much everywhere else).
 
 # Rationale and alternatives
 [alternatives]: #alternatives

--- a/text/0000-impl-only-use.md
+++ b/text/0000-impl-only-use.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-The `use … (… as …)` syntax can now accept a wildcard `_` as alias to a trait to only import the
+The `use …::{… as …}` syntax can now accept `_` as alias to a trait to only import the
 implementations of such a trait.
 
 # Motivation
@@ -88,7 +88,30 @@ The `_` means that you “don’t care about the name rustc will use for that qu
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-To be defined.
+`use Trait as _` needs to desugar into `use Trait as SomeGenSym`. With this scheme, global imports
+and exports can work properly with such items, i.e. import / re-export them.
+
+```rust
+mod m {
+  pub use Trait as _;
+
+  // `Trait` is in scope
+}
+
+use m::*;
+
+// `Trait` is in scope too
+```
+
+In the case where the symbol is not a *trait*, it works the exact same way. However, a warning must
+be emitted by the compiler to state the unused import (as types don’t have `impl`!).
+
+In the same way, it’s possible to use the same mechanism with `extern crate` for linking-only
+crates:
+
+```rust
+extern crate my_crate as _;
+```
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/2166-impl-only-use.md
+++ b/text/2166-impl-only-use.md
@@ -1,7 +1,7 @@
 - Feature Name: impl-only-use
 - Start Date: 2017-10-01
-- RFC PR:
-- Rust Issue:
+- RFC PR: https://github.com/rust-lang/rfcs/pull/2166
+- Rust Issue: https://github.com/rust-lang/rust/issues/48216
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
This RFC gives Rust the syntax:

```rust
use foo::FooTrait as _;
```

Here, `_` means that we want to import the `FooTrait` trait’s impls but
not the trait symbol directly, because we might declare the same symbol
in the module issuing the `use`.

---

[Rendered](https://github.com/phaazon/rfcs/blob/impl-only-use/text/0000-impl-only-use.md)