### PR TITLE
RFC: Quick dbg!(expr) macro

### DIFF
--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -475,6 +475,8 @@ Several names has been proposed for the macro. Some of the candidates were:
 + `show!`, inspired by Haskell. `show` was deemed less obvious than `dbg!`.
 + `peek!`, which was also deemed less obvious.
 + `DEBUG!`, which was deemed too screamy.
++ `qdbg!`, which was deemed to hurt searchability and learnability since it
+isn't prefixed with `d`(ebug).
 
 While it is unfortunate that `debug!` was unavailable, `dbg!` was deemed the
 next best thing, which is why it was picked as the name of the macro.

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -479,6 +479,17 @@ Several names has been proposed for the macro. Some of the candidates were:
 While it is unfortunate that `debug!` was unavailable, `dbg!` was deemed the
 next best thing, which is why it was picked as the name of the macro.
 
+## How do we teach this?
+
+Part of the [motivation][[for-aspiring-rustaceans]] for this macro was to delay
+the point at which aspiring rustaceans have to learn how formatting arguments
+work in the language. For this to be effective, the macro should be taught prior
+to teaching formatting arguments, but after teaching the user to write their
+first "hello world" and other uses of `println!("<string literal>")` which does
+not involve formatting arguments, which should first be taught when formatting
+is actually interesting, and not as a part of printing out the value of an
+expression.
+
 # Unresolved questions
 [unresolved]: #unresolved-questions
 

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -22,7 +22,9 @@ Delaying the need to explain formatting arguments in the statement `println!("{:
 
 By using `dbg!(expr);`, the burden of a common papercut: writing `println!("{:?}", expr);` every time you want to see the evaluted-to value of an expression, can be significantly reduced. The developer no longer has to remember the formatting args and has to type significantly less (12 characters to be exact).
 
-To increase the utility of the macro, it acts as a pass-through function on the expression by simply printing it and then yielding it. On release builds, the macro is the identity function - thus, the macro can be used in release builds while hurting performance while also helping to debug the program.
+To increase the utility of the macro, it acts as a pass-through function on the expression by simply printing it and then yielding it. On release builds, the
+macro is the identity function - thus, the macro can be used in release builds without hurting performance while allowing the debugging of the program in debug
+builds.
 
 Additionally, by allowing the user to pass in multiple expressions and label
 them, the utility is further augmented.

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -65,11 +65,13 @@ fn main() {
 The program will print the points to `STDERR` as:
 
 ```
-dbg(1:4) Point{x: 1, y: 2,} = Point {
+[DEBUGGING, src/main.rs:1:4]:
+=> Point{x: 1, y: 2,} = Point {
     x: 1,
     y: 2
 }
-dbg(7:4) p = Point {
+[DEBUGGING, src/main.rs:7:4]:
+=> p = Point {
     x: 4,
     y: 5
 }
@@ -88,13 +90,17 @@ fn main() {
 }
 ```
 
-This prints the following to `STDERR` as:
+This prints the following to `STDERR`:
 
 ```
-dbg(1:12) 1 + 2 = 3
-dbg(2:12) x + 1 = 4
-dbg(2:26) 3 = 3
-dbg(3:4) y = 7
+[DEBUGGING, src/main.rs:1:12]:
+=> 1 + 2 = 3
+[DEBUGGING, src/main.rs:2:12]:
+=> x + 1 = 4
+[DEBUGGING, src/main.rs:2:26]:
+=> 3 = 3
+[DEBUGGING, src/main.rs:3:4]:
+=> y = 7
 ```
 
 This way of using the macro will mostly benefit existing Rust programmers.
@@ -107,7 +113,7 @@ evaluate the expressions.
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The macro `dbg!` will be implemented as:
+The `dbg!` macro will be implemented as:
 
 ```rust
 macro_rules! dbg {
@@ -115,8 +121,8 @@ macro_rules! dbg {
         {
             let tmp = $val;
             if cfg!(debug_assertions) {
-                eprintln!("dbg({}:{}) {} = {:#?}",
-                    line!(), column!(), stringify!($val), tmp );
+                eprintln!("[DEBUGGING, {}:{}:{}]:\n=> {} = {:#?}",
+                    file!(), line!(), column!(), stringify!($val), tmp );
             }
             tmp
         }
@@ -130,9 +136,8 @@ an expression is simply the expression itself. In effect the result is applying
 the identity function on the expression, but the call will be inlined away such
 that the overhead is zero.
 
-The line number and column is included for increased utility when included in
-production quality code. The expression is also stringified, so that the
-developer can easily see the syntactic structure of the expression that
+The file name, line number and column is included for increased utility when included in production quality code. The expression is also stringified, so that
+the developer can easily see the syntactic structure of the expression that
 evaluted to the RHS of the equality.
 
 **NOTE:** The exact output format is not meant to be stabilized even when/if the
@@ -148,8 +153,7 @@ sufficiently ergonomic for both experienced rustaceans and newcomers.
 [alternatives]: #alternatives
 
 The formatting is informative, but could be formatted in other ways depending
-on what is valued. A more terse format could be used if `stringify!` or line and
-column numbers is not deemed beneficial, which this RFC argues it should.
+on what is valued. A more terse format could be used if `stringify!` or `file!()` line and column numbers is not deemed beneficial, which this RFC argues it should.
 
 The impact of not merging the RFC is that the papercut, if considered as such,
 remains.
@@ -160,8 +164,9 @@ remains.
 The format used by the macro should be resolved prior to merging.
 Some questions regarding the format are:
 
-1. Should the line number be included?
-2. Should the column number be included?
+1. Should the `file!()` be included?
+2. Should the line number be included?
+3. Should the column number be included?
 4. Should the `stringify!($val)` be included?
 
 Other questions, which should also be resolved prior to merging, are:

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -38,7 +38,26 @@ To increase the utility of the macro, it acts as a pass-through function on the
 expression by simply printing it and then yielding it. On release builds, the
 macro is the identity function - thus, the macro can be used in release builds
 without hurting performance while allowing the debugging of the program in debug
-builds.
+builds. To see why this is useful, consider starting off with:
+
+```rust
+let c = fun(a) + fun(b);
+let y = self.first().second();
+```
+
+Now you want to inspect what `fun(a)` and `fun(b)` is, but not go through the
+hassle of 1) saving `fun(a)` and `fun(b)` to a variable, 2) printing out the
+variable, 3) then finally use it in the expression as `let c = fa + fb;`.
+The same applies to inspecting the temporary state of `self.first()`. Instead of
+this hassle, you can simply do:
+
+```rust
+let c = dbg!(fun(a)) + dbg!(fun(b));
+let y = dbg!(self.first()).second();
+```
+
+This modification is considerably smaller and disturbs flow while
+developing code to a lesser degree.
 
 Additionally, by allowing the user to pass in multiple expressions and label
 them, the utility is further augmented.

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -175,3 +175,9 @@ Other questions, which should also be resolved prior to merging, are:
    the value of the expression?
 6. Should the macro act as the identity function on release modes?
    If the answer to this is yes, 5. must also be yes, i.e: 6. => 5.
+
+To be revisited once [`specialization`](https://github.com/rust-lang/rfcs/pull/1210)
+has been stabilized:
+
+7. Should expressions and values of non-`Debug` types be usable with this macro
+by using `std::intrinsics::type_name` for such types and the `Debug` impl for `T : Debug` types as done in version 0.1.2 of [`debugit` ](https://docs.rs/debugit/0.1.2/debugit/)? This depends on specialization.

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -490,7 +490,6 @@ Some questions regarding the format were:
 
 1. Should the `file!()` be included?
 2. Should the line number be included?
-3. Should the column number be included?
 4. Should the `stringify!($val)` be included?
 
 Other questions, which should also be resolved prior to merging, were:
@@ -504,6 +503,20 @@ Other questions, which should also be resolved prior to merging, were:
 They have all been answered in the affirmative.
 
 ## Currently unresolved
+
+Some questions regarding the format are:
+
+3. Should the column number be included?
+
+It is more likely than not that no more than one `dbg!(...)` will occur. If it
+does, it will most likely be when dealing with binary operators such as with:
+`dbg!(x) + dbg!(y) + dbg!(z)`, or with several arguments to a function/method
+call. However, since the macro prints out `stringify!(expr)`, which in the case
+of the additions would result in: `x = <val>, y = <val>, z = <val>`, the user
+can clearly see which expression on the line that generated the value. The only
+exception to this is if the same expression is used multiple times and crucically
+has side effects altering the value between calls. This scenario is probably
+very uncommon.
 
 [`specialization`]: https://github.com/rust-lang/rfcs/pull/1210
 

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -68,6 +68,19 @@ While the `log` crate offers a lot of utility, it first has to be used with
 `extern crate log;`. A logger then has to be set up before expressions can be
 logged. It is therefore not suitable for introducing newcommers to the language.
 
+## Not useful as a crate
+
+This RFC is for quick and dirty debugging and has to be in the standard library
+to be useful. Why? Because while the utility provided by the `dbg!` macro is
+necessary, it is unlikely that a developer, and that includes the author of
+the RFC, would take a dependency on a crate that just provides the macro. The
+hassle of constantly re-adding such a crate temporarily would also be greater
+than just using `println!("{:#?}", expr);` in a majority of cases. But using
+`println!` is still a paper cut. Furthermore, `dbg!` is unlikely to ever be a
+crate that you can `extern crate` for in the Rust playground, so the macro
+can't be used to quickly help users on `#rust` and other venues, which is one
+of the goals of the macro.
+
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -1,0 +1,172 @@
+- Feature Name: quick_debug_macro
+- Start Date: 2017-10-13
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Adds a macro `dbg!(expr)` for quick and dirty `Debug`:ing of an expression to the terminal. The macro evaluates the expression, prints it to `STDERR`, and finally yields `expr`. On release builds, the macro is the identity function and has no side effects. The macro is added to the prelude of the standard library.
+
+# Motivation
+[motivation]: #motivation
+
+The motivation to add this new `dbg!` macro is two-fold.
+
+## For aspiring rustaceans
+
+One of the often asked questions is how to print out variables to the terminal.
+Delaying the need to explain formatting arguments in the statement `println!("{:?}", expr);` can help aspiring rustaceans to quickly learn the language. With `dbg!(expr);` there is no longer such need, which can be delayed until the developer actually cares about the format of the output and not just what value the expression evaluates to.
+
+## For experienced developers
+
+By using `dbg!(expr);`, the burden of a common papercut: writing `println!("{:?}", expr);` every time you want to see the evaluted-to value of an expression, can be significantly reduced. The developer no longer has to remember the formatting args and has to type significantly less (12 characters to be exact).
+
+The shortness is also beneficial when asking `rustbot` on #rust@irc.mozilla.org to evaluate and print an expression.
+
+To increase the utility of the macro, it acts as a pass-through function on the expression by simply printing it and then yielding it. On release builds, the macro is the identity function - thus, the macro can be used in release builds while hurting performance while also helping to debug the program.
+
+## Why not use the `log` crate?
+
+While the `log` crate offers a lot of utility, it first has to be used with `extern crate log;`. A logger then has to be set up before expressions can be logged. It is therefore not suitable for introducing newcommers to the language.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## On debug builds:
+
+First, some preliminaries:
+
+```rust
+#[derive(Debug)] // The type of expr in dbg!(expr) must be Debug.
+struct Point {
+    x: usize,
+    y: usize,
+}
+```
+
+With the following example (which most newcomers will benefit from):
+
+```rust
+fn main() {
+    dbg!(Point {
+        x: 1,
+        y: 2,
+    });
+
+    let p = Point {
+        x: 4,
+        y: 5,
+    };
+    dbg!(p);
+}
+```
+
+The program will print the points to `STDERR` as:
+
+```
+dbg(1:4) Point{x: 1, y: 2,} = Point {
+    x: 1,
+    y: 2
+}
+dbg(7:4) p = Point {
+    x: 4,
+    y: 5
+}
+```
+
+Here, `7:4` is the line and the column.
+
+You may also save the debugged value to a variable or use it in an expression
+since the debugging is pass-through:
+
+```rust
+fn main() {
+    let x = dbg!(1 + 2);
+    let y = dbg!(x + 1) + dbg!(3);
+    dbg!(y);
+}
+```
+
+This prints the following to `STDERR` as:
+
+```
+dbg(1:12) 1 + 2 = 3
+dbg(2:12) x + 1 = 4
+dbg(2:26) 3 = 3
+dbg(3:4) y = 7
+```
+
+This way of using the macro will mostly benefit existing Rust programmers.
+
+## On release builds:
+
+The same examples above will print nothing to `STDERR` and will instead simply
+evaluate the expressions.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The macro `dbg!` will be implemented as:
+
+```rust
+macro_rules! dbg {
+    ($val: expr) => {
+        {
+            let tmp = $val;
+            if cfg!(debug_assertions) {
+                eprintln!("dbg({}:{}) {} = {:#?}",
+                    line!(), column!(), stringify!($val), tmp );
+            }
+            tmp
+        }
+    }
+}
+```
+
+Branching on `cfg!(debug_assertions)` means that if the program is built as a
+release build, nothing will be printed, and the result of using the macro on
+an expression is simply the expression itself. In effect the result is applying
+the identity function on the expression, but the call will be inlined away such
+that the overhead is zero.
+
+The line number and column is included for increased utility when included in
+production quality code. The expression is also stringified, so that the
+developer can easily see the syntactic structure of the expression that
+evaluted to the RHS of the equality.
+
+**NOTE:** The exact output format is not meant to be stabilized even when/if the
+macro is stabilized.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+It could be considered bloat, and `println!("{:#?}", expr)` might be
+sufficiently ergonomic for both experienced rustaceans and newcomers.
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+The formatting is informative, but could be formatted in other ways depending
+on what is valued. A more terse format could be used if `stringify!` or line and
+column numbers is not deemed beneficial, which this RFC argues it should.
+
+The impact of not merging the RFC is that the papercut, if considered as such,
+remains.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+The format used by the macro should be resolved prior to merging.
+Some questions regarding the format are:
+
+1. Should the line number be included?
+2. Should the column number be included?
+4. Should the `stringify!($val)` be included?
+
+Other questions, which should also be resolved prior to merging, are:
+5. Should the macro be pass-through with respect to the expression?
+   In other words: should the value of applying the macro to the expression be
+   the value of the expression?
+6. Should the macro act as the identity function on release modes?
+   If the answer to this is yes, 5. must also be yes, i.e: 6. => 5.

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -443,6 +443,52 @@ explanation and the example implementation that it locks `STDERR` once and uses
 a buffered writer for efficiency and concistency when dealing with multiple
 threads that write out to `STDERR` concurrently.
 
+On release builds, this macro reduces to:
+
+```rust
+// For #[allow(unused_parens)]:
+#![feature(stmt_expr_attributes)]
+
+#[macro_export]
+macro_rules! dbg {
+    // ...
+    // With label:
+    ($labf: expr => $valf: expr $(, $lab: expr => $val: expr)*) => {
+        #[allow(unused_parens)] // requires: #![feature(stmt_expr_attributes)]
+        {
+            let ret = (
+                {
+                    let tmp = $valf;
+                    tmp
+                }
+                $(, {
+                    {
+                        let tmp = $val;
+                        tmp
+                    }
+                } )*
+            );
+            ret
+        }
+    };
+}
+```
+
+which further reduces to the following, which clearly shows that the invocation
+is nothing more than the identity on the tuple passed:
+
+```rust
+#[macro_export]
+macro_rules! dbg {
+    // ...
+
+    // With label:
+    ($($lab: expr => $val: expr)+) => {{
+        ( $($val),* )
+    }};
+}
+```
+
 # Drawbacks
 [drawbacks]: #drawbacks
 

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -22,8 +22,6 @@ Delaying the need to explain formatting arguments in the statement `println!("{:
 
 By using `dbg!(expr);`, the burden of a common papercut: writing `println!("{:?}", expr);` every time you want to see the evaluted-to value of an expression, can be significantly reduced. The developer no longer has to remember the formatting args and has to type significantly less (12 characters to be exact).
 
-The shortness is also beneficial when asking `playbot-mini` on #rust@irc.mozilla.org to evaluate and print an expression.
-
 To increase the utility of the macro, it acts as a pass-through function on the expression by simply printing it and then yielding it. On release builds, the macro is the identity function - thus, the macro can be used in release builds while hurting performance while also helping to debug the program.
 
 ## Why not use the `log` crate?

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -529,7 +529,49 @@ of the additions would result in: `x = <val>, y = <val>, z = <val>`, the user
 can clearly see which expression on the line that generated the value. The only
 exception to this is if the same expression is used multiple times and crucically
 has side effects altering the value between calls. This scenario is probably
-very uncommon.
+very uncommon. However, the `column!()` isn't very visually disturbing since
+it uses horizontal screen real-estate but not vertical real-estate, which
+may still be a good reason to keep it.
+
+8. Should a trailing newline be added after each `dbg!(exprs...)`? The result
+of answer in the affirmative would be to change the following example:
+
+```
+[DEBUGGING, src/main.rs:85:18]:
+=> a = 1
+[DEBUGGING, src/main.rs:86:25]:
+=> a = 1, b = 2
+[DEBUGGING, src/main.rs:87:30]:
+=> a = 1, b = 2, a + b = 3
+```
+
+into:
+
+```
+[DEBUGGING, src/main.rs:85:18]:
+=> a = 1
+
+[DEBUGGING, src/main.rs:86:25]:
+=> a = 1, b = 2
+
+[DEBUGGING, src/main.rs:87:30]:
+=> a = 1, b = 2, a + b = 3
+```
+
+This may, to many readers, look considerably more readable thanks to visual
+association of a particular set of values with the `DEBUGGING` header and make
+the users own `println!(..)` and `eprintln!(..)` calls stand out more due to the
+absence of the header.
+
+A counter argument to this is that users with IDEs or vertically short terminals
+may have as little as `25%` of vertical screen space allocated for the program's
+output with the rest belonging to the actual code editor. To these users, lines
+are too precious to waste in this manner since scrolling may require the use of
+the mouse or switching of keyboard input focus.
+
+However, it is more unlikely that a user will see the information they are
+looking for in a small window without scrolling. Here, searchability is aided by
+grouping which is visually pleasing to process.
 
 [`specialization`]: https://github.com/rust-lang/rfcs/pull/1210
 

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -22,7 +22,7 @@ Delaying the need to explain formatting arguments in the statement `println!("{:
 
 By using `dbg!(expr);`, the burden of a common papercut: writing `println!("{:?}", expr);` every time you want to see the evaluted-to value of an expression, can be significantly reduced. The developer no longer has to remember the formatting args and has to type significantly less (12 characters to be exact).
 
-The shortness is also beneficial when asking `rustbot` on #rust@irc.mozilla.org to evaluate and print an expression.
+The shortness is also beneficial when asking `playbot-mini` on #rust@irc.mozilla.org to evaluate and print an expression.
 
 To increase the utility of the macro, it acts as a pass-through function on the expression by simply printing it and then yielding it. On release builds, the macro is the identity function - thus, the macro can be used in release builds while hurting performance while also helping to debug the program.
 

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -49,21 +49,6 @@ While the `log` crate offers a lot of utility, it first has to be used with
 `extern crate log;`. A logger then has to be set up before expressions can be
 logged. It is therefore not suitable for introducing newcommers to the language.
 
-## Bikeshed: The name of the macro
-
-Several names has been proposed for the macro. Some of the candidates were:
-
-+ `debug!`, which was the original name. This was however already used by the
-`log` crate.
-+ `d!`, which was deemded to be too short to be informative and convey intent.
-+ `dump!`, which was confused with stack traces.
-+ `show!`, inspired by Haskell. `show` was deemed less obvious than `dbg!`.
-+ `peek!`, which was also deemed less obvious.
-+ `DEBUG!`, which was deemed too screamy.
-
-While it is unfortunate that `debug!` was unavailable, `dbg!` was deemed the
-next best thing, which is why it was picked as the name of the macro.
-
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
@@ -478,6 +463,21 @@ header via an env var strikes a good balance.
 
 The impact of not merging the RFC is that the papercut, if considered as such,
 remains.
+
+## Bikeshed: The name of the macro
+
+Several names has been proposed for the macro. Some of the candidates were:
+
++ `debug!`, which was the original name. This was however already used by the
+`log` crate.
++ `d!`, which was deemded to be too short to be informative and convey intent.
++ `dump!`, which was confused with stack traces.
++ `show!`, inspired by Haskell. `show` was deemed less obvious than `dbg!`.
++ `peek!`, which was also deemed less obvious.
++ `DEBUG!`, which was deemed too screamy.
+
+While it is unfortunate that `debug!` was unavailable, `dbg!` was deemed the
+next best thing, which is why it was picked as the name of the macro.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -28,6 +28,21 @@ To increase the utility of the macro, it acts as a pass-through function on the 
 
 While the `log` crate offers a lot of utility, it first has to be used with `extern crate log;`. A logger then has to be set up before expressions can be logged. It is therefore not suitable for introducing newcommers to the language.
 
+## Bikeshed: The name of the macro
+
+Several names has been proposed for the macro. Some of the candidates were:
+
++ `debug!`, which was the original name. This was however already used by the `log`
+crate.
++ `d!`, which was deemded to be too short to be informative and convey intent.
++ `dump!`, which was confused with stack traces.
++ `show!`, inspired by Haskell. `show` was deemed less obvious than `dbg!`.
++ `peek!`, which was also deemed less obvious.
++ `DEBUG!`, which was deemed too screamy.
+
+While it is unfortunate that `debug!` was unavailable, `dbg!` was deemed the
+next best thing, which is why it was picked as the name of the macro.
+
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
@@ -103,6 +118,24 @@ This prints the following to `STDERR`:
 
 This way of using the macro will mostly benefit existing Rust programmers.
 
+Optionally, the default formatting used by the macro can be changed by
+passing in a format as a second argument as done in:
+
+```rust
+fn main() {
+    let p = dbg!(Point { x: 4, y: 5 }, "{:?}");
+}
+```
+
+This prints the following to `STDERR`:
+
+```
+Point { x: 4, y: 5 }
+```
+
+In this case, the main advantage of `dbg` over `println` in this case is that
+the value of the expression is passed back to the "caller" of the macro.
+
 ## On release builds:
 
 The same examples above will print nothing to `STDERR` and will instead simply
@@ -120,7 +153,16 @@ macro_rules! dbg {
             let tmp = $val;
             if cfg!(debug_assertions) {
                 eprintln!("[DEBUGGING, {}:{}:{}]:\n=> {} = {:#?}",
-                    file!(), line!(), column!(), stringify!($val), tmp );
+                    file!(), line!(), column!(), stringify!($val), tmp);
+            }
+            tmp
+        }
+    };
+    ($val: expr, $fmt: expr) => {
+        {
+            let tmp = $val;
+            if cfg!(debug_assertions) {
+                eprintln!($fmt, tmp);
             }
             tmp
         }
@@ -140,6 +182,8 @@ evaluted to the RHS of the equality.
 
 **NOTE:** The exact output format is not meant to be stabilized even when/if the
 macro is stabilized.
+
+By passing in a format as the second optional argument to the macro, the way the value is printed can be changed. This is done in `($val: expr, $fmt: expr)`.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -223,7 +223,7 @@ example, the following is printed to `STDERR`:
 }
 ```
 
-The ways of using the macro in illustrated in later (not the first) examples
+The ways of using the macro as illustrated in later (not the first) examples
 will mostly benefit existing Rust programmers.
 
 ### Move semantics

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Adds a macro `dbg!(expr)` for quick and dirty `Debug`:ing of an expression to the terminal. The macro evaluates the expression, prints it to `STDERR`, and finally yields `expr`. On release builds, the macro is the identity function and has no side effects. The macro is added to the prelude of the standard library.
+Adds a macro `dbg!(expr1 [, expr2, .., exprN])` for quick and dirty `Debug`:ing of expressions to the terminal. The macro evaluates expressions, prints it to `STDERR`, and finally yields a flat tuple of `(expr1 [, expr2, .. exprN])`. On release builds, the macro is the identity function and has no side effects. The macro is added to the prelude of the standard library.
 
 # Motivation
 [motivation]: #motivation
@@ -23,6 +23,9 @@ Delaying the need to explain formatting arguments in the statement `println!("{:
 By using `dbg!(expr);`, the burden of a common papercut: writing `println!("{:?}", expr);` every time you want to see the evaluted-to value of an expression, can be significantly reduced. The developer no longer has to remember the formatting args and has to type significantly less (12 characters to be exact).
 
 To increase the utility of the macro, it acts as a pass-through function on the expression by simply printing it and then yielding it. On release builds, the macro is the identity function - thus, the macro can be used in release builds while hurting performance while also helping to debug the program.
+
+Additionally, by allowing the user to pass in multiple expressions and label
+them, the utility is further augmented.
 
 ## Why not use the `log` crate?
 
@@ -46,7 +49,7 @@ next best thing, which is why it was picked as the name of the macro.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-## On debug builds:
+## On debug builds
 
 First, some preliminaries:
 
@@ -58,7 +61,7 @@ struct Point {
 }
 ```
 
-With the following example (which most newcomers will benefit from):
+With the following example, which most newcomers will benefit from:
 
 ```rust
 fn main() {
@@ -93,7 +96,7 @@ The program will print the points to `STDERR` as:
 Here, `7:4` is the line and the column.
 
 You may also save the debugged value to a variable or use it in an expression
-since the debugging is pass-through:
+since the debugging is pass-through. This is seen in the following example:
 
 ```rust
 fn main() {
@@ -116,27 +119,79 @@ This prints the following to `STDERR`:
 => y = 7
 ```
 
-This way of using the macro will mostly benefit existing Rust programmers.
-
-Optionally, the default formatting used by the macro can be changed by
-passing in a format as a second argument as done in:
-
+More expressions may be debugged in one invocation of the macro, as seen in the following example:
 ```rust
 fn main() {
-    let p = dbg!(Point { x: 4, y: 5 }, "{:?}");
+    let a = 1;
+    let b = 2;
+    let _ : u32 = dbg!(a);
+    let _ : (u32, u32) = dbg!(a, b);
+    let _ : (u32, u32, u32) = dbg!(a, b, a + b);
+
+    let p = Point { x: 4, y: 5 };
+    let q = Point { x: 2, y: 1 };
+    let qp : (&Point, &Point) = dbg!(&p, &q);
 }
 ```
 
-This prints the following to `STDERR`:
+As seen in the example, the type of the expression `dbg!(expr)` is the type of `expr`. For `dbg!(expr1, expr2 [, .., exprN])` the type is that of the tuple `(expr1, expr2 [, .., exprN])`.
 
+The example above prints the following to `STDERR`:
 ```
-Point { x: 4, y: 5 }
+[DEBUGGING, src/main.rs:3:18]:
+=> a = 1
+[DEBUGGING, src/main.rs:4:25]:
+=> a = 1, b = 2
+[DEBUGGING, src/main.rs:5:30]:
+=> a = 1, b = 2, a + b = 3
+[DEBUGGING, src/main.rs:9:31]:
+=> &p = Point {
+    x: 4,
+    y: 5
+}, &q = Point {
+    x: 2,
+    y: 1
+}
 ```
 
-In this case, the main advantage of `dbg` over `println` in this case is that
-the value of the expression is passed back to the "caller" of the macro.
+Furthermore, instead of using `stringify!` on the expressions, which is done by default, the user may provide labels, as done in:
 
-## On release builds:
+```rust
+fn main() {
+    let w = 1;
+    let h = 2;
+    dbg!("width" => w, "height" => h, "area" => w * h);
+
+    let p = Point { x: 4, y: 5 };
+    let q = Point { x: 2, y: 1 };
+    dbg!("first point" => &p, "second point" => &p);
+}
+```
+
+This allows the user to provide more descriptive names if necessary. With this example, the following is printed to `STDERR`:
+```
+[DEBUGGING, src/main.rs:2:4]:
+=> "width" = 1, "height" = 2, "area" = 2
+[DEBUGGING, src/main.rs:7:4]:
+=> "first point" = Point {
+    x: 4,
+    y: 5
+}, "second point" = Point {
+    x: 2,
+    y: 1
+}
+```
+
+The ways of using the macro used in later (not the first) examples will mostly benefit existing Rust programmers.
+
+### Omitting the source location
+
+Those developers who feel the source location header is overly verbose may
+choose to opt-out by setting the environment variable `RUST_DBG_NO_LOCATION` to
+`"0"`. This is a one-time setup cost the developer has to make for all current
+and future Rust projects.
+
+## On release builds
 
 The same examples above will print nothing to `STDERR` and will instead simply
 evaluate the expressions.
@@ -144,46 +199,204 @@ evaluate the expressions.
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The `dbg!` macro will be implemented as:
+The macro is called `dbg` and accepts either a non-empty comma-separated or
+comma-terminated list of `expr`, or a non-empty list of `label => expr` which
+is also separated or terminated with commas.
 
+The terminated versions are defined as:
+
+1. `($($val: expr),+,) => { dbg!( $($val),+ ) };`
+2. `($($lab: expr => $val: expr),+,) => { dbg!( $($lab => $val),+ ) };`
+
+The separated versions accept the following:
+
+1. `($($val: expr),+)`
+2. `($($lab: expr => $val: expr),+)`
+
+The macro only prints something if `cfg!(debug_assertions)` holds, meaning that
+if the program is built as a release build, nothing will be printed, and the result of using the macro on an expressions or expressions is simply the expression
+itself or a flat tuple of the expressions themselves. In effect the result is applying the identity function on the expression(s), but the call will be inlined away such that the overhead is zero.
+
+## The type of `dbg!(expressions)`
+
+"Applying" `dbg` on a non-empty list of expressions `expr1 [, expr2 [, .., exprN])` gives back an expression of the following type and value:
+
++ List of size 1, `dbg!(expr)`: The type is the type of `expr` and the value is
+the value of `expr`.
+
++ Otherwise, `dbg!(expr1, expr2 [, expr3, .., exprN])`: The type is the type
+of the tuple `(expr1, expr2 [, expr3, .., exprN])` which is the value.
+
+## Schematic/step-wise explanation
+
+1. Assume `let p = option_env!("RUST_DBG_NO_LOCATION").map_or_else(|| true, |s| s == "0");`. If `p` holds, the file name (given by `file!()`), line number (`line!()`) and column (`column!()`) is included in the print out for increased utility when the macro is used in non-trivial code. This is wrapped by `[DEBUGGING, <location>]:` as in:
 ```rust
-macro_rules! dbg {
-    ($val: expr) => {
-        {
-            let tmp = $val;
-            if cfg!(debug_assertions) {
-                eprintln!("[DEBUGGING, {}:{}:{}]:\n=> {} = {:#?}",
-                    file!(), line!(), column!(), stringify!($val), tmp);
-            }
-            tmp
-        }
-    };
-    ($val: expr, $fmt: expr) => {
-        {
-            let tmp = $val;
-            if cfg!(debug_assertions) {
-                eprintln!($fmt, tmp);
-            }
-            tmp
-        }
-    }
-}
+eprintln!("[DEBUGGING, {}:{}:{}]:", file!(), line!(), column!());
 ```
+If `p` does not hold, this step prints nothing.
 
-Branching on `cfg!(debug_assertions)` means that if the program is built as a
-release build, nothing will be printed, and the result of using the macro on
-an expression is simply the expression itself. In effect the result is applying
-the identity function on the expression, but the call will be inlined away such
-that the overhead is zero.
+2. An arrow is then printed on the next line: `eprint!("=> ");`.
 
-The file name, line number and column is included for increased utility when included in non-trivial code. The expression is also stringified, so that
-the developer can easily see the syntactic structure of the expression that
-evaluted to the RHS of the equality.
+3. + For `($($val: expr),+)`
+
+For each `$val` (the expression), the following is printed, comma separated:
+The value of the expression is presented on the right hand side (RHS) of an equality sign `=` while the result of `stringify!(expr)` is presented on the
+left hand side (LHS). This is done so that the developer easily can see the syntactic structure of the expression that evaluted to RHS.
+
+In other words, the following: `eprint!("{} = {:#?}", stringify!($lab), tmp);`.
+
+3. + For `($($lab: expr => $val: expr),+)`:
+
+For each `$lab => $val` (the label and expression), the following is printed,
+comma separated: The value of the expression is presented on RHS of an equality sign `=` while the label is presented on LHS.
+
+In other words, the following: `eprint!("{} = {:#?}", stringify!($lab), tmp);`.
+
+**NOTE:** The label is only guaranteed when it is a string slice literal.
 
 **NOTE:** The exact output format is not meant to be stabilized even when/if the
 macro is stabilized.
 
-By passing in a format as the second optional argument to the macro, the way the value is printed can be changed. This is done in `($val: expr, $fmt: expr)`.
+## Example implementation
+
+The `dbg!` macro is semantically (with the notable detail that the helper macros and any non-`pub` `fn`s must be inlined in the actual implementation):
+
+```rust
+macro_rules! cfg_dbg {
+    ($($x:tt)+) => {
+        if cfg!(debug_assertions) { $($x)* }
+    };
+}
+
+fn dbg_with_location() -> bool {
+    option_env!("RUST_DBG_NO_LOCATION").map_or_else(|| true, |s| s == "0")
+}
+
+macro_rules! dbg_header {
+    ($expr: expr) => {{
+        cfg_dbg! {
+            if dbg_with_location() {
+                eprintln!("[DEBUGGING, {}:{}:{}]:", file!(), line!(), column!());
+            }
+            eprint!("=> ");
+        }
+        let ret = $expr;
+        cfg_dbg! { eprintln!(""); }
+        ret
+    }};
+}
+
+macro_rules! dbg_comma {
+    ($valf: expr) => { $valf };
+    ($valf: expr, $($val: expr),+) => {
+        ( $valf, $({ cfg_dbg! { eprint!(", "); } $val}),+ )
+    }
+}
+
+macro_rules! dbg_term {
+    ($val: expr) => { dbg_term!($val => $val) };
+    ($lab: expr => $val: expr) => {{
+        let tmp = $val;
+        cfg_dbg! { eprint!("{} = {:#?}", stringify!($lab), tmp); }
+        tmp
+    }};
+}
+
+#[macro_export]
+macro_rules! dbg {
+    ($($val: expr),+,) => {
+        dbg!( $($val),+ )
+    };
+    ($($lab: expr => $val: expr),+,) => {
+        dbg!( $($lab => $val),+ )
+    };
+    ($($val: expr),+) => {
+        dbg_header!(dbg_comma!($(dbg_term!($val)),+))
+    };
+    ($($lab: expr => $val: expr),+) => {
+        dbg_header!(dbg_comma!($(dbg_term!($lab => $val)),+))
+    };
+}
+```
+
+## Exact implementation
+
+The exact implementation is given by:
+
+```rust
+// For #[allow(unused_parens)]:
+#![feature(stmt_expr_attributes)]
+
+#[macro_export]
+macro_rules! dbg {
+    // Handle trailing comma:
+    ($($val: expr),+,) => {
+        dbg!( $($val),+ )
+    };
+    ($($lab: expr => $val: expr),+,) => {
+        dbg!( $($lab => $val),+ )
+    };
+    // Without label, use source of $val as label:
+    ($($val: expr),+) => {
+        dbg!($($val => $val),+)
+    };
+    // With label:
+    ($labf: expr => $valf: expr $(, $lab: expr => $val: expr)*) => {
+        #[allow(unused_parens)] // requires: #![feature(stmt_expr_attributes)]
+        {
+            if cfg!(debug_assertions) {
+                // Print out source location unless silenced by setting
+                // the env var RUST_DBG_NO_LOCATION != 0.
+                let p = option_env!("RUST_DBG_NO_LOCATION")
+                            .map_or_else(|| true, |s| s == "0");
+                if p {
+                    eprintln!("[DEBUGGING, {}:{}:{}]:",
+                        file!(), line!(), column!());
+                }
+                // Print out arrow (on a new line):
+                eprint!("=> ");
+            }
+
+            // Foreach label and expression:
+            // 1. Evaluate each expression to value,
+            // 2. Print out $lab = value
+            // Separate with comma.
+            let ret = (
+                {
+                    // Evaluate, tmp is value:
+                    let tmp = $valf;
+                    // Print out $lab = tmp:
+                    if cfg!(debug_assertions) {
+                        eprint!("{} = {:#?}", stringify!($labf), tmp);
+                    }
+                    // Yield tmp:
+                    tmp
+                }
+                $(, {
+                    // Comma separator:
+                    if cfg!(debug_assertions) { eprint!(", "); }
+                    {
+                        // Evaluate, tmp is value:
+                        let tmp = $val;
+                        // Print out $lab = tmp:
+                        if cfg!(debug_assertions) {
+                            eprint!("{} = {:#?}", stringify!($lab), tmp);
+                        }
+                        // Yield tmp:
+                        tmp
+                    }
+                } )*
+            );
+
+            // Newline:
+            if cfg!(debug_assertions) { eprintln!(""); }
+
+            // Return the expression:
+            ret
+        }
+    };
+}
+```
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -195,7 +408,8 @@ sufficiently ergonomic for both experienced rustaceans and newcomers.
 [alternatives]: #alternatives
 
 The formatting is informative, but could be formatted in other ways depending
-on what is valued. A more terse format could be used if `stringify!` or `file!()` line and column numbers is not deemed beneficial, which this RFC argues it should.
+on what is valued. A more terse format could be used if `stringify!` or `file!()`, line and column numbers is not deemed beneficial, which this RFC argues it should.
+The RFC argues that the possibility of opting out to this header via an env var strikes a good balance.
 
 The impact of not merging the RFC is that the papercut, if considered as such,
 remains.
@@ -204,19 +418,27 @@ remains.
 [unresolved]: #unresolved-questions
 
 The format used by the macro should be resolved prior to merging.
-Some questions regarding the format are:
+
+## Formerly unresolved
+
+Some questions regarding the format were:
 
 1. Should the `file!()` be included?
 2. Should the line number be included?
 3. Should the column number be included?
 4. Should the `stringify!($val)` be included?
 
-Other questions, which should also be resolved prior to merging, are:
+Other questions, which should also be resolved prior to merging, were:
+
 5. Should the macro be pass-through with respect to the expression?
    In other words: should the value of applying the macro to the expression be
    the value of the expression?
 6. Should the macro act as the identity function on release modes?
    If the answer to this is yes, 5. must also be yes, i.e: 6. => 5.
+
+They have all been answered in the affirmative.
+
+## Currently unresolved
 
 To be revisited once [`specialization`](https://github.com/rust-lang/rfcs/pull/1210)
 has been stabilized:

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -6,7 +6,11 @@
 # Summary
 [summary]: #summary
 
-Adds a macro `dbg!(expr1 [, expr2, .., exprN])` for quick and dirty `Debug`:ing of expressions to the terminal. The macro evaluates expressions, prints it to `STDERR`, and finally yields a flat tuple of `(expr1 [, expr2, .. exprN])`. On release builds, the macro is the identity function and has no side effects. The macro is added to the prelude of the standard library.
+Adds a macro `dbg!(expr1 [, expr2, .., exprN])` for quick and dirty `Debug`:ing
+of expressions to the terminal. The macro evaluates expressions, prints it to
+`STDERR`, and finally yields a flat tuple of `(expr1 [, expr2, .. exprN])`.
+On release builds, the macro is the identity function and has no side effects.
+The macro is added to the prelude of the standard library.
 
 # Motivation
 [motivation]: #motivation
@@ -14,16 +18,26 @@ Adds a macro `dbg!(expr1 [, expr2, .., exprN])` for quick and dirty `Debug`:ing 
 The motivation to add this new `dbg!` macro is two-fold.
 
 ## For aspiring rustaceans
+[for-aspiring-rustaceans]: #for-aspiring-rustaceans
 
 One of the often asked questions is how to print out variables to the terminal.
-Delaying the need to explain formatting arguments in the statement `println!("{:?}", expr);` can help aspiring rustaceans to quickly learn the language. With `dbg!(expr);` there is no longer such need, which can be delayed until the developer actually cares about the format of the output and not just what value the expression evaluates to.
+Delaying the need to explain formatting arguments in the statement
+`println!("{:?}", expr);` can help aspiring rustaceans to quickly learn the
+language. With `dbg!(expr);` there is no longer such need, which can be delayed
+until the developer actually cares about the format of the output and not just
+what value the expression evaluates to.
 
 ## For experienced developers
 
-By using `dbg!(expr);`, the burden of a common papercut: writing `println!("{:?}", expr);` every time you want to see the evaluted-to value of an expression, can be significantly reduced. The developer no longer has to remember the formatting args and has to type significantly less (12 characters to be exact).
+By using `dbg!(expr);`, the burden of a common papercut: writing
+`println!("{:?}", expr);` every time you want to see the evaluted-to value of an
+expression, can be significantly reduced. The developer no longer has to remember
+the formatting args and has to type significantly less (12 characters to be exact).
 
-To increase the utility of the macro, it acts as a pass-through function on the expression by simply printing it and then yielding it. On release builds, the
-macro is the identity function - thus, the macro can be used in release builds without hurting performance while allowing the debugging of the program in debug
+To increase the utility of the macro, it acts as a pass-through function on the
+expression by simply printing it and then yielding it. On release builds, the
+macro is the identity function - thus, the macro can be used in release builds
+without hurting performance while allowing the debugging of the program in debug
 builds.
 
 Additionally, by allowing the user to pass in multiple expressions and label
@@ -31,14 +45,16 @@ them, the utility is further augmented.
 
 ## Why not use the `log` crate?
 
-While the `log` crate offers a lot of utility, it first has to be used with `extern crate log;`. A logger then has to be set up before expressions can be logged. It is therefore not suitable for introducing newcommers to the language.
+While the `log` crate offers a lot of utility, it first has to be used with
+`extern crate log;`. A logger then has to be set up before expressions can be
+logged. It is therefore not suitable for introducing newcommers to the language.
 
 ## Bikeshed: The name of the macro
 
 Several names has been proposed for the macro. Some of the candidates were:
 
-+ `debug!`, which was the original name. This was however already used by the `log`
-crate.
++ `debug!`, which was the original name. This was however already used by the
+`log` crate.
 + `d!`, which was deemded to be too short to be informative and convey intent.
 + `dump!`, which was confused with stack traces.
 + `show!`, inspired by Haskell. `show` was deemed less obvious than `dbg!`.
@@ -121,7 +137,8 @@ This prints the following to `STDERR`:
 => y = 7
 ```
 
-More expressions may be debugged in one invocation of the macro, as seen in the following example:
+More expressions may be debugged in one invocation of the macro, as seen in the
+following example:
 ```rust
 fn main() {
     let a = 1;
@@ -136,7 +153,9 @@ fn main() {
 }
 ```
 
-As seen in the example, the type of the expression `dbg!(expr)` is the type of `expr`. For `dbg!(expr1, expr2 [, .., exprN])` the type is that of the tuple `(expr1, expr2 [, .., exprN])`.
+As seen in the example, the type of the expression `dbg!(expr)` is the type of
+`expr`. For `dbg!(expr1, expr2 [, .., exprN])` the type is that of the tuple
+`(expr1, expr2 [, .., exprN])`.
 
 The example above prints the following to `STDERR`:
 ```
@@ -156,7 +175,8 @@ The example above prints the following to `STDERR`:
 }
 ```
 
-Furthermore, instead of using `stringify!` on the expressions, which is done by default, the user may provide labels, as done in:
+Furthermore, instead of using `stringify!` on the expressions, which is done by
+default, the user may provide labels, as done in:
 
 ```rust
 fn main() {
@@ -170,7 +190,8 @@ fn main() {
 }
 ```
 
-This allows the user to provide more descriptive names if necessary. With this example, the following is printed to `STDERR`:
+This allows the user to provide more descriptive names if necessary. With this
+example, the following is printed to `STDERR`:
 ```
 [DEBUGGING, src/main.rs:2:4]:
 => "width" = 1, "height" = 2, "area" = 2
@@ -184,7 +205,8 @@ This allows the user to provide more descriptive names if necessary. With this e
 }
 ```
 
-The ways of using the macro used in later (not the first) examples will mostly benefit existing Rust programmers.
+The ways of using the macro used in later (not the first) examples will mostly
+benefit existing Rust programmers.
 
 ### Omitting the source location
 
@@ -216,12 +238,17 @@ The separated versions accept the following:
 2. `($($lab: expr => $val: expr),+)`
 
 The macro only prints something if `cfg!(debug_assertions)` holds, meaning that
-if the program is built as a release build, nothing will be printed, and the result of using the macro on an expressions or expressions is simply the expression
-itself or a flat tuple of the expressions themselves. In effect the result is applying the identity function on the expression(s), but the call will be inlined away such that the overhead is zero.
+if the program is built as a release build, nothing will be printed, and the
+result of using the macro on an expressions or expressions is simply the
+expression itself or a flat tuple of the expressions themselves. In effect the
+result is applying the identity function on the expression(s), but the call will
+be inlined away such that the overhead is zero.
 
 ## The type of `dbg!(expressions)`
 
-"Applying" `dbg` on a non-empty list of expressions `expr1 [, expr2 [, .., exprN])` gives back an expression of the following type and value:
+"Applying" `dbg` on a non-empty list of expressions
+`expr1 [, expr2 [, .., exprN])` gives back an expression of the following type
+and value:
 
 + List of size 1, `dbg!(expr)`: The type is the type of `expr` and the value is
 the value of `expr`.
@@ -231,10 +258,17 @@ of the tuple `(expr1, expr2 [, expr3, .., exprN])` which is the value.
 
 ## Schematic/step-wise explanation
 
-1. Assume `let p = option_env!("RUST_DBG_NO_LOCATION").map_or_else(|| true, |s| s == "0");`. If `p` holds, the file name (given by `file!()`), line number (`line!()`) and column (`column!()`) is included in the print out for increased utility when the macro is used in non-trivial code. This is wrapped by `[DEBUGGING, <location>]:` as in:
+1. Assume
+`let p = option_env!("RUST_DBG_NO_LOCATION").map_or(true, |s| s == "0");`.
+If `p` holds, the file name (given by `file!()`), line number (`line!()`) and
+column (`column!()`) is included in the print out for increased utility when the
+macro is used in non-trivial code. This is wrapped by `[DEBUGGING, <location>]:`
+as in:
+
 ```rust
 eprintln!("[DEBUGGING, {}:{}:{}]:", file!(), line!(), column!());
 ```
+
 If `p` does not hold, this step prints nothing.
 
 2. An arrow is then printed on the next line: `eprint!("=> ");`.
@@ -242,26 +276,30 @@ If `p` does not hold, this step prints nothing.
 3. + For `($($val: expr),+)`
 
 For each `$val` (the expression), the following is printed, comma separated:
-The value of the expression is presented on the right hand side (RHS) of an equality sign `=` while the result of `stringify!(expr)` is presented on the
-left hand side (LHS). This is done so that the developer easily can see the syntactic structure of the expression that evaluted to RHS.
+The value of the expression is presented on the right hand side (RHS) of an
+equality sign `=` while the result of `stringify!(expr)` is presented on the
+left hand side (LHS). This is done so that the developer easily can see the
+syntactic structure of the expression that evaluted to RHS.
 
 In other words, the following: `eprint!("{} = {:#?}", stringify!($lab), tmp);`.
 
 3. + For `($($lab: expr => $val: expr),+)`:
 
 For each `$lab => $val` (the label and expression), the following is printed,
-comma separated: The value of the expression is presented on RHS of an equality sign `=` while the label is presented on LHS.
+comma separated: The value of the expression is presented on RHS of an equality
+sign `=` while the label is presented on LHS.
 
 In other words, the following: `eprint!("{} = {:#?}", stringify!($lab), tmp);`.
 
-**NOTE:** The label is only guaranteed when it is a string slice literal.
+**NOTE:** The label is only guaranteed to work when it is a string slice literal.
 
 **NOTE:** The exact output format is not meant to be stabilized even when/if the
 macro is stabilized.
 
 ## Example implementation
 
-The `dbg!` macro is semantically (with the notable detail that the helper macros and any non-`pub` `fn`s must be inlined in the actual implementation):
+The `dbg!` macro is semantically (with the notable detail that the helper macros
+and any non-`pub` `fn`s must be inlined in the actual implementation):
 
 ```rust
 macro_rules! cfg_dbg {
@@ -410,8 +448,10 @@ sufficiently ergonomic for both experienced rustaceans and newcomers.
 [alternatives]: #alternatives
 
 The formatting is informative, but could be formatted in other ways depending
-on what is valued. A more terse format could be used if `stringify!` or `file!()`, line and column numbers is not deemed beneficial, which this RFC argues it should.
-The RFC argues that the possibility of opting out to this header via an env var strikes a good balance.
+on what is valued. A more terse format could be used if `stringify!` or
+`file!()`, line and column numbers is not deemed beneficial, which this RFC
+argues it should. The RFC argues that the possibility of opting out to this
+header via an env var strikes a good balance.
 
 The impact of not merging the RFC is that the papercut, if considered as such,
 remains.
@@ -442,8 +482,14 @@ They have all been answered in the affirmative.
 
 ## Currently unresolved
 
-To be revisited once [`specialization`](https://github.com/rust-lang/rfcs/pull/1210)
+[`specialization`]: https://github.com/rust-lang/rfcs/pull/1210
+
+To be revisited once [`specialization`]
 has been stabilized:
 
+[`debugit`]: https://docs.rs/debugit/0.1.2/debugit/
+
 7. Should expressions and values of non-`Debug` types be usable with this macro
-by using `std::intrinsics::type_name` for such types and the `Debug` impl for `T : Debug` types as done in version 0.1.2 of [`debugit` ](https://docs.rs/debugit/0.1.2/debugit/)? This depends on specialization.
+by using `std::intrinsics::type_name` for such types and the `Debug` impl for
+`T : Debug` types as done in version 0.1.2 of [`debugit`]? This depends on
+specialization.

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -375,17 +375,14 @@ macro_rules! dbg {
             // 2. to ensure that the printed message is not interleaved, which
             // would disturb the readability of the output, by other messages to
             // STDERR.
+            #[cfg(debug_assertions)]
             use ::std::io::Write;
             #[cfg(debug_assertions)]
             let stderr = ::std::io::stderr();
             #[cfg(debug_assertions)]
             let mut err = ::std::io::BufWriter::new(stderr.lock());
 
-            // RELEASE: satisfy the type system with a Writer that's never used.
-            #[cfg(not(debug_assertions))]
-            let mut err = ::std::io::sink();
-
-            if cfg!(debug_assertions) {
+            #[cfg(debug_assertions)] {
                 // Print out source location unless silenced:
                 let p = option_env!("RUST_DBG_NO_LOCATION")
                             .map_or(true, |s| s == "0");
@@ -405,7 +402,7 @@ macro_rules! dbg {
                     // Evaluate, tmp is value:
                     let tmp = $valf;
                     // Print out $lab = tmp:
-                    if cfg!(debug_assertions) {
+                    #[cfg(debug_assertions)] {
                         write!(&mut err, "{} = {:#?}", stringify!($labf), tmp)
                             .unwrap();
                     }
@@ -414,14 +411,14 @@ macro_rules! dbg {
                 }
                 $(, {
                     // Comma separator:
-                    if cfg!(debug_assertions) {
+                    #[cfg(debug_assertions)] {
                         write!(&mut err, ", ").unwrap();
                     }
                     {
                         // Evaluate, tmp is value:
                         let tmp = $val;
                         // Print out $lab = tmp:
-                        if cfg!(debug_assertions) {
+                        #[cfg(debug_assertions)] {
                             write!(&mut err, "{} = {:#?}", stringify!($lab), tmp)
                                 .unwrap();
                         }
@@ -432,7 +429,7 @@ macro_rules! dbg {
             );
 
             // Newline:
-            if cfg!(debug_assertions) { writeln!(&mut err, "").unwrap(); }
+            #[cfg(debug_assertions)] { writeln!(&mut err, "").unwrap(); }
 
             // Return the expression:
             ret

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -483,7 +483,7 @@ macro_rules! dbg {
     // ...
 
     // With label:
-    ($($lab: expr => $val: expr)+) => {{
+    ($($lab: expr => $val: expr),+) => {{
         ( $($val),* )
     }};
 }
@@ -526,7 +526,7 @@ next best thing, which is why it was picked as the name of the macro.
 
 ## How do we teach this?
 
-Part of the [motivation][[for-aspiring-rustaceans]] for this macro was to delay
+Part of the [motivation][for-aspiring-rustaceans] for this macro was to delay
 the point at which aspiring rustaceans have to learn how formatting arguments
 work in the language. For this to be effective, the macro should be taught prior
 to teaching formatting arguments, but after teaching the user to write their

--- a/text/0000-quick-debug-macro.md
+++ b/text/0000-quick-debug-macro.md
@@ -136,7 +136,7 @@ an expression is simply the expression itself. In effect the result is applying
 the identity function on the expression, but the call will be inlined away such
 that the overhead is zero.
 
-The file name, line number and column is included for increased utility when included in production quality code. The expression is also stringified, so that
+The file name, line number and column is included for increased utility when included in non-trivial code. The expression is also stringified, so that
 the developer can easily see the syntactic structure of the expression that
 evaluted to the RHS of the equality.
 


### PR DESCRIPTION
Adds a macro `dbg!(expr1 [, expr2, .., exprN])` for quick and dirty `Debug`:ing of expressions to the terminal. The macro evaluates expressions, prints it to `STDERR`, and finally yields a flat tuple of `(expr1 [, expr2, .. exprN])`. On release builds, the macro is the identity function and has no side effects. The macro is added to the prelude of the standard library.

[Rendered.](https://github.com/Centril/rfcs/blob/rfc/quick-debug-macro/text/0000-quick-debug-macro.md)

### Acknowledgements & ping

@scottmcm, @mbrubeck, @sdleffler, @setharnold