### PR TITLE
Markdown style link for mdbook

### DIFF
--- a/text/0192-bounds-on-object-and-generic-types.md
+++ b/text/0192-bounds-on-object-and-generic-types.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-08-06
-- RFC PR: https://github.com/rust-lang/rfcs/pull/192
-- Rust Issue: https://github.com/rust-lang/rust/issues/16462
+- RFC PR: [rust-lang/rfcs#192](https://github.com/rust-lang/rfcs/pull/192)
+- Rust Issue: [rust-lang/rust#16462](https://github.com/rust-lang/rust/issues/16462)
 
 # Summary
 

--- a/text/0202-subslice-syntax-change.md
+++ b/text/0202-subslice-syntax-change.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-08-15
-- RFC PR: https://github.com/rust-lang/rfcs/pull/202
-- Rust Issue: https://github.com/rust-lang/rust/issues/16967
+- RFC PR: [rust-lang/rfcs#202](https://github.com/rust-lang/rfcs/pull/202)
+- Rust Issue: [rust-lang/rust#16967](https://github.com/rust-lang/rust/issues/16967)
 
 # Summary
 

--- a/text/0212-restore-int-fallback.md
+++ b/text/0212-restore-int-fallback.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-09-03
-- RFC PR: https://github.com/rust-lang/rfcs/pull/212
-- Rust Issue: https://github.com/rust-lang/rust/issues/16968
+- RFC PR: [rust-lang/rfcs#212](https://github.com/rust-lang/rfcs/pull/212)
+- Rust Issue: [rust-lang/rust#16968](https://github.com/rust-lang/rust/issues/16968)
 
 # Summary
 

--- a/text/0213-defaulted-type-params.md
+++ b/text/0213-defaulted-type-params.md
@@ -1,6 +1,6 @@
 - Start Date: 2015-02-04
-- RFC PR: https://github.com/rust-lang/rfcs/pull/213
-- Rust Issue: https://github.com/rust-lang/rust/issues/21939
+- RFC PR: [rust-lang/rfcs#213](https://github.com/rust-lang/rfcs/pull/213)
+- Rust Issue: [rust-lang/rust#21939](https://github.com/rust-lang/rust/issues/21939)
 
 # Summary
 

--- a/text/0214-while-let.md
+++ b/text/0214-while-let.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-08-27
-- RFC PR: https://github.com/rust-lang/rfcs/pull/214
-- Rust Issue: https://github.com/rust-lang/rust/issues/17687
+- RFC PR: [rust-lang/rfcs#214](https://github.com/rust-lang/rfcs/pull/214)
+- Rust Issue: [rust-lang/rust#17687](https://github.com/rust-lang/rust/issues/17687)
 
 # Summary
 

--- a/text/0230-remove-runtime.md
+++ b/text/0230-remove-runtime.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-09-16
-- RFC PR: https://github.com/rust-lang/rfcs/pull/230
-- Rust Issue: https://github.com/rust-lang/rust/issues/17325
+- RFC PR: [rust-lang/rfcs#230](https://github.com/rust-lang/rfcs/pull/230)
+- Rust Issue: [rust-lang/rust#17325](https://github.com/rust-lang/rust/issues/17325)
 
 # Summary
 

--- a/text/0256-remove-refcounting-gc-of-t.md
+++ b/text/0256-remove-refcounting-gc-of-t.md
@@ -1,5 +1,5 @@
 - Start Date: 2014-09-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/256
+- RFC PR: [rust-lang/rfcs#256](https://github.com/rust-lang/rfcs/pull/256)
 - Rust Issue: https://github.com/rust-lang/rfcs/pull/256
 
 # Summary

--- a/text/0326-restrict-xXX-to-ascii.md
+++ b/text/0326-restrict-xXX-to-ascii.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-09-26
 - RFC PR: 326
-- Rust Issue: https://github.com/rust-lang/rust/issues/18062
+- Rust Issue: [rust-lang/rust#18062](https://github.com/rust-lang/rust/issues/18062)
 
 # Summary
 

--- a/text/0341-remove-virtual-structs.md
+++ b/text/0341-remove-virtual-structs.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-09-30
-- RFC PR: https://github.com/rust-lang/rfcs/pull/341
-- Rust Issue: https://github.com/rust-lang/rust/issues/17861
+- RFC PR: [rust-lang/rfcs#341](https://github.com/rust-lang/rfcs/pull/341)
+- Rust Issue: [rust-lang/rust#17861](https://github.com/rust-lang/rust/issues/17861)
 
 # Summary
 

--- a/text/0342-keywords.md
+++ b/text/0342-keywords.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-10-07
-- RFC PR: https://github.com/rust-lang/rfcs/pull/342
-- Rust Issue: https://github.com/rust-lang/rust/issues/17862
+- RFC PR: [rust-lang/rfcs#342](https://github.com/rust-lang/rfcs/pull/342)
+- Rust Issue: [rust-lang/rust#17862](https://github.com/rust-lang/rust/issues/17862)
 
 # Summary
 

--- a/text/0446-es6-unicode-escapes.md
+++ b/text/0446-es6-unicode-escapes.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-11-05
-- RFC PR: https://github.com/rust-lang/rfcs/pull/446
-- Rust Issue: https://github.com/rust-lang/rust/issues/19739
+- RFC PR: [rust-lang/rfcs#446](https://github.com/rust-lang/rfcs/pull/446)
+- Rust Issue: [rust-lang/rust#19739](https://github.com/rust-lang/rust/issues/19739)
 
 # Summary
 

--- a/text/0447-no-unused-impl-parameters.md
+++ b/text/0447-no-unused-impl-parameters.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-11-06
-- RFC PR: https://github.com/rust-lang/rfcs/pull/447
-- Rust Issue: https://github.com/rust-lang/rust/issues/20598
+- RFC PR: [rust-lang/rfcs#447](https://github.com/rust-lang/rfcs/pull/447)
+- Rust Issue: [rust-lang/rust#20598](https://github.com/rust-lang/rust/issues/20598)
 
 # Summary
 

--- a/text/0458-send-improvements.md
+++ b/text/0458-send-improvements.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-11-10
-- RFC PR: https://github.com/rust-lang/rfcs/pull/458
-- Rust Issue: https://github.com/rust-lang/rust/issues/22251
+- RFC PR: [rust-lang/rfcs#458](https://github.com/rust-lang/rfcs/pull/458)
+- Rust Issue: [rust-lang/rust#22251](https://github.com/rust-lang/rust/issues/22251)
 
 # Summary
 

--- a/text/0461-tls-overhaul.md
+++ b/text/0461-tls-overhaul.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-11-11
-- RFC PR: https://github.com/rust-lang/rfcs/pull/461
-- Rust Issue: https://github.com/rust-lang/rust/issues/19175
+- RFC PR: [rust-lang/rfcs#461](https://github.com/rust-lang/rfcs/pull/461)
+- Rust Issue: [rust-lang/rust#19175](https://github.com/rust-lang/rust/issues/19175)
 
 # Summary
 

--- a/text/0486-std-ascii-reform.md
+++ b/text/0486-std-ascii-reform.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-11-27
-- RFC PR: https://github.com/rust-lang/rfcs/pull/486
-- Rust Issue: https://github.com/rust-lang/rust/issues/19908
+- RFC PR: [rust-lang/rfcs#486](https://github.com/rust-lang/rfcs/pull/486)
+- Rust Issue: [rust-lang/rust#19908](https://github.com/rust-lang/rust/issues/19908)
 
 # Summary
 

--- a/text/0494-c_str-and-c_vec-stability.md
+++ b/text/0494-c_str-and-c_vec-stability.md
@@ -1,6 +1,6 @@
 - Start Date: 2015-01-02
-- RFC PR: https://github.com/rust-lang/rfcs/pull/494
-- Rust Issue: https://github.com/rust-lang/rust/issues/20444
+- RFC PR: [rust-lang/rfcs#494](https://github.com/rust-lang/rfcs/pull/494)
+- Rust Issue: [rust-lang/rust#20444](https://github.com/rust-lang/rust/issues/20444)
 
 # Summary
 

--- a/text/0501-consistent_no_prelude_attributes.md
+++ b/text/0501-consistent_no_prelude_attributes.md
@@ -1,6 +1,6 @@
 - Start Date: (2014-12-06)
-- RFC PR: https://github.com/rust-lang/rfcs/pull/501
-- Rust Issue: https://github.com/rust-lang/rust/issues/20561
+- RFC PR: [rust-lang/rfcs#501](https://github.com/rust-lang/rfcs/pull/501)
+- Rust Issue: [rust-lang/rust#20561](https://github.com/rust-lang/rust/issues/20561)
 
 # Summary
 

--- a/text/0503-prelude-stabilization.md
+++ b/text/0503-prelude-stabilization.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-12-20
-- RFC PR: https://github.com/rust-lang/rfcs/pull/503
-- Rust Issue: https://github.com/rust-lang/rust/issues/20068
+- RFC PR: [rust-lang/rfcs#503](https://github.com/rust-lang/rfcs/pull/503)
+- Rust Issue: [rust-lang/rust#20068](https://github.com/rust-lang/rust/issues/20068)
 
 # Summary
 

--- a/text/0504-show-stabilization.md
+++ b/text/0504-show-stabilization.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-12-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/504
-- Rust Issue: https://github.com/rust-lang/rust/issues/20013
+- RFC PR: [rust-lang/rfcs#504](https://github.com/rust-lang/rfcs/pull/504)
+- Rust Issue: [rust-lang/rust#20013](https://github.com/rust-lang/rust/issues/20013)
 
 # Summary
 

--- a/text/0509-collections-reform-part-2.md
+++ b/text/0509-collections-reform-part-2.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-12-18
-- RFC PR: https://github.com/rust-lang/rfcs/pull/509
-- Rust Issue: https://github.com/rust-lang/rust/issues/19986
+- RFC PR: [rust-lang/rfcs#509](https://github.com/rust-lang/rfcs/pull/509)
+- Rust Issue: [rust-lang/rust#19986](https://github.com/rust-lang/rust/issues/19986)
 
 # Summary
 

--- a/text/0526-fmt-text-writer.md
+++ b/text/0526-fmt-text-writer.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-12-30
-- RFC PR: https://github.com/rust-lang/rfcs/pull/526
-- Rust Issue: https://github.com/rust-lang/rust/issues/20352
+- RFC PR: [rust-lang/rfcs#526](https://github.com/rust-lang/rfcs/pull/526)
+- Rust Issue: [rust-lang/rust#20352](https://github.com/rust-lang/rust/issues/20352)
 
 # Summary
 

--- a/text/0528-string-patterns.md
+++ b/text/0528-string-patterns.md
@@ -1,6 +1,6 @@
 - Start Date: 2015-02-17
-- RFC PR: https://github.com/rust-lang/rfcs/pull/528
-- Rust Issue: https://github.com/rust-lang/rust/issues/22477
+- RFC PR: [rust-lang/rfcs#528](https://github.com/rust-lang/rfcs/pull/528)
+- Rust Issue: [rust-lang/rust#22477](https://github.com/rust-lang/rust/issues/22477)
 
 # Summary
 

--- a/text/0580-rename-collections.md
+++ b/text/0580-rename-collections.md
@@ -1,6 +1,6 @@
 - Start Date: 2015-01-13
-- RFC PR: https://github.com/rust-lang/rfcs/pull/580
-- Rust Issue: https://github.com/rust-lang/rust/issues/22479
+- RFC PR: [rust-lang/rfcs#580](https://github.com/rust-lang/rfcs/pull/580)
+- Rust Issue: [rust-lang/rust#22479](https://github.com/rust-lang/rust/issues/22479)
 
 # Summary
 

--- a/text/0592-c-str-deref.md
+++ b/text/0592-c-str-deref.md
@@ -1,6 +1,6 @@
 - Start Date: 2015-01-17
-- RFC PR: https://github.com/rust-lang/rfcs/pull/592
-- Rust Issue: https://github.com/rust-lang/rust/issues/22469
+- RFC PR: [rust-lang/rfcs#592](https://github.com/rust-lang/rfcs/pull/592)
+- Rust Issue: [rust-lang/rust#22469](https://github.com/rust-lang/rust/issues/22469)
 
 # Summary
 

--- a/text/0599-default-object-bound.md
+++ b/text/0599-default-object-bound.md
@@ -1,6 +1,6 @@
 - Start Date: 2015-02-12
-- RFC PR: https://github.com/rust-lang/rfcs/pull/599
-- Rust Issue: https://github.com/rust-lang/rust/issues/22211
+- RFC PR: [rust-lang/rfcs#599](https://github.com/rust-lang/rfcs/pull/599)
+- Rust Issue: [rust-lang/rust#22211](https://github.com/rust-lang/rust/issues/22211)
 
 # Summary
 

--- a/text/0736-privacy-respecting-fru.md
+++ b/text/0736-privacy-respecting-fru.md
@@ -1,6 +1,6 @@
 - Start Date: 2015-01-26
-- RFC PR: https://github.com/rust-lang/rfcs/pull/736
-- Rust Issue: https://github.com/rust-lang/rust/issues/21407
+- RFC PR: [rust-lang/rfcs#736](https://github.com/rust-lang/rfcs/pull/736)
+- Rust Issue: [rust-lang/rust#21407](https://github.com/rust-lang/rust/issues/21407)
 
 # Summary
 

--- a/text/0738-variance.md
+++ b/text/0738-variance.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-12-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/738
-- Rust Issue: https://github.com/rust-lang/rust/issues/22212
+- RFC PR: [rust-lang/rfcs#738](https://github.com/rust-lang/rfcs/pull/738)
+- Rust Issue: [rust-lang/rust#22212](https://github.com/rust-lang/rust/issues/22212)
 
 # Summary
 

--- a/text/0771-std-iter-once.md
+++ b/text/0771-std-iter-once.md
@@ -1,6 +1,6 @@
 - Start Date: 2015-1-30
-- RFC PR: https://github.com/rust-lang/rfcs/pull/771
-- Rust Issue: https://github.com/rust-lang/rust/issues/24443
+- RFC PR: [rust-lang/rfcs#771](https://github.com/rust-lang/rfcs/pull/771)
+- Rust Issue: [rust-lang/rust#24443](https://github.com/rust-lang/rust/issues/24443)
 
 # Summary
 

--- a/text/0823-hash-simplification.md
+++ b/text/0823-hash-simplification.md
@@ -1,7 +1,7 @@
 - Feature Name: hash
 - Start Date: 2015-02-17
-- RFC PR: https://github.com/rust-lang/rfcs/pull/823
-- Rust Issue: https://github.com/rust-lang/rust/issues/22467
+- RFC PR: [rust-lang/rfcs#823](https://github.com/rust-lang/rfcs/pull/823)
+- Rust Issue: [rust-lang/rust#22467](https://github.com/rust-lang/rust/issues/22467)
 
 # Summary
 

--- a/text/0832-from-elem-with-love.md
+++ b/text/0832-from-elem-with-love.md
@@ -1,7 +1,7 @@
 - Feature Name: direct to stable, because it modifies a stable macro
 - Start Date: 2015-02-11
-- RFC PR: https://github.com/rust-lang/rfcs/pull/832
-- Rust Issue: https://github.com/rust-lang/rust/issues/22414
+- RFC PR: [rust-lang/rfcs#832](https://github.com/rust-lang/rfcs/pull/832)
+- Rust Issue: [rust-lang/rust#22414](https://github.com/rust-lang/rust/issues/22414)
 
 # Summary
 

--- a/text/0840-no-panic-in-c-string.md
+++ b/text/0840-no-panic-in-c-string.md
@@ -1,7 +1,7 @@
 - Feature Name: non_panicky_cstring
 - Start Date: 2015-02-13
-- RFC PR: https://github.com/rust-lang/rfcs/pull/840
-- Rust Issue: https://github.com/rust-lang/rust/issues/22470
+- RFC PR: [rust-lang/rfcs#840](https://github.com/rust-lang/rfcs/pull/840)
+- Rust Issue: [rust-lang/rust#22470](https://github.com/rust-lang/rust/issues/22470)
 
 # Summary
 

--- a/text/0909-move-thread-local-to-std-thread.md
+++ b/text/0909-move-thread-local-to-std-thread.md
@@ -1,7 +1,7 @@
 - Feature Name: N/A
 - Start Date: 2015-02-25
-- RFC PR: https://github.com/rust-lang/rfcs/pull/909
-- Rust Issue: https://github.com/rust-lang/rust/issues/23547
+- RFC PR: [rust-lang/rfcs#909](https://github.com/rust-lang/rfcs/pull/909)
+- Rust Issue: [rust-lang/rust#23547](https://github.com/rust-lang/rust/issues/23547)
 
 # Summary
 

--- a/text/0921-entry_v3.md
+++ b/text/0921-entry_v3.md
@@ -1,7 +1,7 @@
 - Feature Name: entry_v3
 - Start Date: 2015-03-01
-- RFC PR: https://github.com/rust-lang/rfcs/pull/921
-- Rust Issue: https://github.com/rust-lang/rust/issues/23508
+- RFC PR: [rust-lang/rfcs#921](https://github.com/rust-lang/rfcs/pull/921)
+- Rust Issue: [rust-lang/rust#23508](https://github.com/rust-lang/rust/issues/23508)
 
 # Summary
 

--- a/text/0979-align-splitn-with-other-languages.md
+++ b/text/0979-align-splitn-with-other-languages.md
@@ -1,7 +1,7 @@
 - Feature Name: n/a
 - Start Date: 2015-03-15
-- RFC PR: https://github.com/rust-lang/rfcs/pull/979
-- Rust Issue: https://github.com/rust-lang/rust/issues/23911
+- RFC PR: [rust-lang/rfcs#979](https://github.com/rust-lang/rfcs/pull/979)
+- Rust Issue: [rust-lang/rust#23911](https://github.com/rust-lang/rust/issues/23911)
 
 # Summary
 

--- a/text/0980-read-exact.md
+++ b/text/0980-read-exact.md
@@ -1,7 +1,7 @@
 - Feature Name: read_exact
 - Start Date: 2015-03-15
-- RFC PR: https://github.com/rust-lang/rfcs/pull/980
-- Rust Issue: https://github.com/rust-lang/rust/issues/27585
+- RFC PR: [rust-lang/rfcs#980](https://github.com/rust-lang/rfcs/pull/980)
+- Rust Issue: [rust-lang/rust#27585](https://github.com/rust-lang/rust/issues/27585)
 
 # Summary
 

--- a/text/1011-process.exit.md
+++ b/text/1011-process.exit.md
@@ -1,6 +1,6 @@
 - Feature Name: exit
 - Start Date: 2015-03-24
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1011
+- RFC PR: [rust-lang/rfcs#1011](https://github.com/rust-lang/rfcs/pull/1011)
 - Rust Issue: (leave this empty)
 
 # Summary

--- a/text/1040-duration-reform.md
+++ b/text/1040-duration-reform.md
@@ -1,7 +1,7 @@
 - Feature Name: duration
 - Start Date: 2015-03-24
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1040
-- Rust Issue: https://github.com/rust-lang/rust/issues/24874
+- RFC PR: [rust-lang/rfcs#1040](https://github.com/rust-lang/rfcs/pull/1040)
+- Rust Issue: [rust-lang/rust#24874](https://github.com/rust-lang/rust/issues/24874)
 
 # Summary
 

--- a/text/1044-io-fs-2.1.md
+++ b/text/1044-io-fs-2.1.md
@@ -1,7 +1,7 @@
 - Feature Name: `fs2`
 - Start Date: 2015-04-04
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1044
-- Rust Issue: https://github.com/rust-lang/rust/issues/24796
+- RFC PR: [rust-lang/rfcs#1044](https://github.com/rust-lang/rfcs/pull/1044)
+- Rust Issue: [rust-lang/rust#24796](https://github.com/rust-lang/rust/issues/24796)
 
 # Summary
 

--- a/text/1066-safe-mem-forget.md
+++ b/text/1066-safe-mem-forget.md
@@ -1,7 +1,7 @@
 - Feature Name: N/A
 - Start Date: 2015-04-15
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1066
-- Rust Issue: https://github.com/rust-lang/rust/issues/25186
+- RFC PR: [rust-lang/rfcs#1066](https://github.com/rust-lang/rfcs/pull/1066)
+- Rust Issue: [rust-lang/rust#25186](https://github.com/rust-lang/rust/issues/25186)
 
 # Summary
 

--- a/text/1096-remove-static-assert.md
+++ b/text/1096-remove-static-assert.md
@@ -1,6 +1,6 @@
 - Feature Name: remove-static-assert
 - Start Date: 2015-04-28        
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1096
+- RFC PR: [rust-lang/rfcs#1096](https://github.com/rust-lang/rfcs/pull/1096)
 - Rust Issue: https://github.com/rust-lang/rust/pull/24910
 
 # Summary

--- a/text/1156-adjust-default-object-bounds.md
+++ b/text/1156-adjust-default-object-bounds.md
@@ -1,7 +1,7 @@
 - Feature Name: N/A
 - Start Date: 2015-06-4
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1156
-- Rust Issue: https://github.com/rust-lang/rust/issues/26438
+- RFC PR: [rust-lang/rfcs#1156](https://github.com/rust-lang/rfcs/pull/1156)
+- Rust Issue: [rust-lang/rust#26438](https://github.com/rust-lang/rust/issues/26438)
 
 # Summary
 

--- a/text/1184-stabilize-no_std.md
+++ b/text/1184-stabilize-no_std.md
@@ -1,7 +1,7 @@
 - Feature Name: N/A
 - Start Date: 2015-06-26
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1184
-- Rust Issue: https://github.com/rust-lang/rust/issues/27394
+- RFC PR: [rust-lang/rfcs#1184](https://github.com/rust-lang/rfcs/pull/1184)
+- Rust Issue: [rust-lang/rust#27394](https://github.com/rust-lang/rust/issues/27394)
 
 # Summary
 

--- a/text/1199-simd-infrastructure.md
+++ b/text/1199-simd-infrastructure.md
@@ -1,7 +1,7 @@
 - Feature Name: repr_simd, platform_intrinsics, cfg_target_feature
 - Start Date: 2015-06-02
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1199
-- Rust Issue: https://github.com/rust-lang/rust/issues/27731
+- RFC PR: [rust-lang/rfcs#1199](https://github.com/rust-lang/rfcs/pull/1199)
+- Rust Issue: [rust-lang/rust#27731](https://github.com/rust-lang/rust/issues/27731)
 
 # Summary
 

--- a/text/1201-naked-fns.md
+++ b/text/1201-naked-fns.md
@@ -1,7 +1,7 @@
 - Feature Name: `naked_fns`
 - Start Date: 2015-07-10
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1201
-- Rust Issue: https://github.com/rust-lang/rust/issues/32408
+- RFC PR: [rust-lang/rfcs#1201](https://github.com/rust-lang/rfcs/pull/1201)
+- Rust Issue: [rust-lang/rust#32408](https://github.com/rust-lang/rust/issues/32408)
 
 # Summary
 

--- a/text/1216-bang-type.md
+++ b/text/1216-bang-type.md
@@ -1,7 +1,7 @@
 - Feature Name: bang_type
 - Start Date: 2015-07-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1216
-- Rust Issue: https://github.com/rust-lang/rust/issues/35121
+- RFC PR: [rust-lang/rfcs#1216](https://github.com/rust-lang/rfcs/pull/1216)
+- Rust Issue: [rust-lang/rust#35121](https://github.com/rust-lang/rust/issues/35121)
 
 # Summary
 

--- a/text/1228-placement-left-arrow.md
+++ b/text/1228-placement-left-arrow.md
@@ -1,7 +1,7 @@
 - Feature Name: place_left_arrow_syntax
 - Start Date: 2015-07-28
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1228
-- Rust Issue: https://github.com/rust-lang/rust/issues/27779
+- RFC PR: [rust-lang/rfcs#1228](https://github.com/rust-lang/rfcs/pull/1228)
+- Rust Issue: [rust-lang/rust#27779](https://github.com/rust-lang/rust/issues/27779)
 
 # Summary
 

--- a/text/1238-nonparametric-dropck.md
+++ b/text/1238-nonparametric-dropck.md
@@ -1,7 +1,7 @@
 - Feature Name: dropck_parametricity
 - Start Date: 2015-08-05
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1238/
-- Rust Issue: https://github.com/rust-lang/rust/issues/28498
+- RFC PR: [rust-lang/rfcs#1238](https://github.com/rust-lang/rfcs/pull/1238)/
+- Rust Issue: [rust-lang/rust#28498](https://github.com/rust-lang/rust/issues/28498)
 
 # Summary
 

--- a/text/1240-repr-packed-unsafe-ref.md
+++ b/text/1240-repr-packed-unsafe-ref.md
@@ -1,7 +1,7 @@
 - Feature Name: NA
 - Start Date: 2015-08-06
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1240
-- Rust Issue: https://github.com/rust-lang/rust/issues/27060
+- RFC PR: [rust-lang/rfcs#1240](https://github.com/rust-lang/rfcs/pull/1240)
+- Rust Issue: [rust-lang/rust#27060](https://github.com/rust-lang/rust/issues/27060)
 
 # Summary
 

--- a/text/1260-main-reexport.md
+++ b/text/1260-main-reexport.md
@@ -1,7 +1,7 @@
 - Feature Name: main_reexport
 - Start Date: 2015-08-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1260
-- Rust Issue: https://github.com/rust-lang/rust/issues/28937
+- RFC PR: [rust-lang/rfcs#1260](https://github.com/rust-lang/rfcs/pull/1260)
+- Rust Issue: [rust-lang/rust#28937](https://github.com/rust-lang/rust/issues/28937)
 
 # Summary
 

--- a/text/1268-allow-overlapping-impls-on-marker-traits.md
+++ b/text/1268-allow-overlapping-impls-on-marker-traits.md
@@ -1,7 +1,7 @@
 - Feature Name: Allow overlapping impls for marker traits
 - Start Date: 2015-09-02
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1268
-- Rust Issue: https://github.com/rust-lang/rust/issues/29864
+- RFC PR: [rust-lang/rfcs#1268](https://github.com/rust-lang/rfcs/pull/1268)
+- Rust Issue: [rust-lang/rust#29864](https://github.com/rust-lang/rust/issues/29864)
 
 # Summary
 

--- a/text/1300-intrinsic-semantics.md
+++ b/text/1300-intrinsic-semantics.md
@@ -1,6 +1,6 @@
 - Feature Name: intrinsic-semantics
 - Start Date: 2015-09-29
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1300
+- RFC PR: [rust-lang/rfcs#1300](https://github.com/rust-lang/rfcs/pull/1300)
 - Rust Issue: N/A
 
 # Summary

--- a/text/1358-repr-align.md
+++ b/text/1358-repr-align.md
@@ -1,7 +1,7 @@
 - Feature Name: `repr_align`
 - Start Date: 2015-11-09
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1358
-- Rust Issue: https://github.com/rust-lang/rust/issues/33626
+- RFC PR: [rust-lang/rfcs#1358](https://github.com/rust-lang/rfcs/pull/1358)
+- Rust Issue: [rust-lang/rust#33626](https://github.com/rust-lang/rust/issues/33626)
 
 # Summary
 [summary]: #summary

--- a/text/1398-kinds-of-allocators.md
+++ b/text/1398-kinds-of-allocators.md
@@ -1,7 +1,7 @@
 - Feature Name: allocator_api
 - Start Date: 2015-12-01
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1398
-- Rust Issue: https://github.com/rust-lang/rust/issues/32838
+- RFC PR: [rust-lang/rfcs#1398](https://github.com/rust-lang/rfcs/pull/1398)
+- Rust Issue: [rust-lang/rust#32838](https://github.com/rust-lang/rust/issues/32838)
 
 # Summary
 [summary]: #summary

--- a/text/1422-pub-restricted.md
+++ b/text/1422-pub-restricted.md
@@ -1,7 +1,7 @@
 - Feature Name: pub_restricted
 - Start Date: 2015-12-18
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1422
-- Rust Issue: https://github.com/rust-lang/rust/issues/32409
+- RFC PR: [rust-lang/rfcs#1422](https://github.com/rust-lang/rfcs/pull/1422)
+- Rust Issue: [rust-lang/rust#32409](https://github.com/rust-lang/rust/issues/32409)
 
 # Summary
 [summary]: #summary

--- a/text/1444-union.md
+++ b/text/1444-union.md
@@ -1,7 +1,7 @@
 - Feature Name: `union`
 - Start Date: 2015-12-29
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1444
-- Rust Issue: https://github.com/rust-lang/rust/issues/32836
+- RFC PR: [rust-lang/rfcs#1444](https://github.com/rust-lang/rfcs/pull/1444)
+- Rust Issue: [rust-lang/rust#32836](https://github.com/rust-lang/rust/issues/32836)
 
 # Summary
 [summary]: #summary

--- a/text/1492-dotdot-in-patterns.md
+++ b/text/1492-dotdot-in-patterns.md
@@ -1,6 +1,6 @@
 - Feature Name: dotdot_in_patterns
 - Start Date: 2016-02-06
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1492
+- RFC PR: [rust-lang/rfcs#1492](https://github.com/rust-lang/rfcs/pull/1492)
 - Rust Issue: (leave this empty)
 
 # Summary

--- a/text/1504-int128.md
+++ b/text/1504-int128.md
@@ -1,7 +1,7 @@
 - Feature Name: int128
 - Start Date: 21-02-2016
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1504
-- Rust Issue: https://github.com/rust-lang/rust/issues/35118
+- RFC PR: [rust-lang/rfcs#1504](https://github.com/rust-lang/rfcs/pull/1504)
+- Rust Issue: [rust-lang/rust#35118](https://github.com/rust-lang/rust/issues/35118)
 
 # Summary
 [summary]: #summary

--- a/text/1506-adt-kinds.md
+++ b/text/1506-adt-kinds.md
@@ -1,7 +1,7 @@
 - Feature Name: clarified_adt_kinds
 - Start Date: 2016-02-07
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1506
-- Rust Issue: https://github.com/rust-lang/rust/issues/35626
+- RFC PR: [rust-lang/rfcs#1506](https://github.com/rust-lang/rfcs/pull/1506)
+- Rust Issue: [rust-lang/rust#35626](https://github.com/rust-lang/rust/issues/35626)
 
 # Summary
 [summary]: #summary

--- a/text/1513-less-unwinding.md
+++ b/text/1513-less-unwinding.md
@@ -1,7 +1,7 @@
 - Feature Name: `panic_runtime`
 - Start Date: 2016-02-25
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1513
-- Rust Issue: https://github.com/rust-lang/rust/issues/32837
+- RFC PR: [rust-lang/rfcs#1513](https://github.com/rust-lang/rfcs/pull/1513)
+- Rust Issue: [rust-lang/rust#32837](https://github.com/rust-lang/rust/issues/32837)
 
 # Summary
 [summary]: #summary

--- a/text/1522-conservative-impl-trait.md
+++ b/text/1522-conservative-impl-trait.md
@@ -1,7 +1,7 @@
 - Feature Name: conservative_impl_trait
 - Start Date: 2016-01-31
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1522
-- Rust Issue: https://github.com/rust-lang/rust/issues/34511
+- RFC PR: [rust-lang/rfcs#1522](https://github.com/rust-lang/rfcs/pull/1522)
+- Rust Issue: [rust-lang/rust#34511](https://github.com/rust-lang/rust/issues/34511)
 
 # Summary
 [summary]: #summary

--- a/text/1548-global-asm.md
+++ b/text/1548-global-asm.md
@@ -1,7 +1,7 @@
 - Feature Name: global_asm
 - Start Date: 2016-03-18
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1548
-- Rust Issue: https://github.com/rust-lang/rust/issues/35119
+- RFC PR: [rust-lang/rfcs#1548](https://github.com/rust-lang/rfcs/pull/1548)
+- Rust Issue: [rust-lang/rust#35119](https://github.com/rust-lang/rust/issues/35119)
 
 # Summary
 [summary]: #summary

--- a/text/1559-attributes-with-literals.md
+++ b/text/1559-attributes-with-literals.md
@@ -1,7 +1,7 @@
 - Feature Name: attributes_with_literals
 - Start Date: 2016-03-28
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1559
-- Rust Issue: https://github.com/rust-lang/rust/issues/34981
+- RFC PR: [rust-lang/rfcs#1559](https://github.com/rust-lang/rfcs/pull/1559)
+- Rust Issue: [rust-lang/rust#34981](https://github.com/rust-lang/rust/issues/34981)
 
 # Summary
 [summary]: #summary

--- a/text/1560-name-resolution.md
+++ b/text/1560-name-resolution.md
@@ -1,7 +1,7 @@
 - Feature Name: item_like_imports
 - Start Date: 2016-02-09
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1560
-- Rust Issue: https://github.com/rust-lang/rust/issues/35120
+- RFC PR: [rust-lang/rfcs#1560](https://github.com/rust-lang/rfcs/pull/1560)
+- Rust Issue: [rust-lang/rust#35120](https://github.com/rust-lang/rust/issues/35120)
 
 # Summary
 [summary]: #summary

--- a/text/1561-macro-naming.md
+++ b/text/1561-macro-naming.md
@@ -1,7 +1,7 @@
 - Feature Name: N/A (part of other unstable features)
 - Start Date: 2016-02-11
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1561
-- Rust Issue: https://github.com/rust-lang/rust/issues/35896
+- RFC PR: [rust-lang/rfcs#1561](https://github.com/rust-lang/rfcs/pull/1561)
+- Rust Issue: [rust-lang/rust#35896](https://github.com/rust-lang/rust/issues/35896)
 
 # Summary
 [summary]: #summary

--- a/text/1566-proc-macros.md
+++ b/text/1566-proc-macros.md
@@ -1,7 +1,7 @@
 - Feature Name: procedural_macros
 - Start Date: 2016-02-15
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1566
-- Rust Issue: https://github.com/rust-lang/rust/issues/38356
+- RFC PR: [rust-lang/rfcs#1566](https://github.com/rust-lang/rfcs/pull/1566)
+- Rust Issue: [rust-lang/rust#38356](https://github.com/rust-lang/rust/issues/38356)
 
 # Summary
 [summary]: #summary

--- a/text/1574-more-api-documentation-conventions.md
+++ b/text/1574-more-api-documentation-conventions.md
@@ -1,6 +1,6 @@
 - Feature Name: More API Documentation Conventions
 - Start Date: 2016-03-31
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1574
+- RFC PR: [rust-lang/rfcs#1574](https://github.com/rust-lang/rfcs/pull/1574)
 - Rust Issue: N/A
 
 # Summary

--- a/text/1576-macros-literal-matcher.md
+++ b/text/1576-macros-literal-matcher.md
@@ -1,7 +1,7 @@
 - Feature Name: macros-literal-match
 - Start Date: 2016-04-08
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1576
-- Rust Issue: https://github.com/rust-lang/rust/issues/35625
+- RFC PR: [rust-lang/rfcs#1576](https://github.com/rust-lang/rfcs/pull/1576)
+- Rust Issue: [rust-lang/rust#35625](https://github.com/rust-lang/rust/issues/35625)
 
 # Summary
 

--- a/text/1589-rustc-bug-fix-procedure.md
+++ b/text/1589-rustc-bug-fix-procedure.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2016-04-22
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1589
+- RFC PR: [rust-lang/rfcs#1589](https://github.com/rust-lang/rfcs/pull/1589)
 - Rust Issue: N/A
 
 # Summary

--- a/text/1590-macro-lifetimes.md
+++ b/text/1590-macro-lifetimes.md
@@ -1,7 +1,7 @@
 - Feature Name: Allow `lifetime` specifiers to be passed to macros
 - Start Date: 2016-04-22
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1590
-- Rust Issue: https://github.com/rust-lang/rust/issues/34303
+- RFC PR: [rust-lang/rfcs#1590](https://github.com/rust-lang/rfcs/pull/1590)
+- Rust Issue: [rust-lang/rust#34303](https://github.com/rust-lang/rust/issues/34303)
 
 # Summary
 [summary]: #summary

--- a/text/1607-style-rfcs.md
+++ b/text/1607-style-rfcs.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2016-04-21
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1607
+- RFC PR: [rust-lang/rfcs#1607](https://github.com/rust-lang/rfcs/pull/1607)
 - Rust Issue: N/A
 
 

--- a/text/1623-static.md
+++ b/text/1623-static.md
@@ -1,7 +1,7 @@
 - Feature Name: static_lifetime_in_statics
 - Start Date: 2016-05-20
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1623
-- Rust Issue: https://github.com/rust-lang/rust/issues/35897
+- RFC PR: [rust-lang/rfcs#1623](https://github.com/rust-lang/rfcs/pull/1623)
+- Rust Issue: [rust-lang/rust#35897](https://github.com/rust-lang/rust/issues/35897)
 
 # Summary
 [summary]: #summary

--- a/text/1624-loop-break-value.md
+++ b/text/1624-loop-break-value.md
@@ -1,7 +1,7 @@
 - Feature Name: loop_break_value
 - Start Date: 2016-05-20
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1624
-- Rust Issue: https://github.com/rust-lang/rust/issues/37339
+- RFC PR: [rust-lang/rfcs#1624](https://github.com/rust-lang/rfcs/pull/1624)
+- Rust Issue: [rust-lang/rust#37339](https://github.com/rust-lang/rust/issues/37339)
 
 # Summary
 [summary]: #summary

--- a/text/1636-document_all_features.md
+++ b/text/1636-document_all_features.md
@@ -1,6 +1,6 @@
 - Feature Name: document_all_features
 - Start Date: 2016-06-03
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1636
+- RFC PR: [rust-lang/rfcs#1636](https://github.com/rust-lang/rfcs/pull/1636)
 - Rust Issue: https://github.com/rust-lang-nursery/reference/issues/9
 
 

--- a/text/1643-memory-model-strike-team.md
+++ b/text/1643-memory-model-strike-team.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2016-06-07
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1643
+- RFC PR: [rust-lang/rfcs#1643](https://github.com/rust-lang/rfcs/pull/1643)
 - Rust Issue: N/A
 
 # Summary

--- a/text/1651-movecell.md
+++ b/text/1651-movecell.md
@@ -1,7 +1,7 @@
 - Feature Name: move_cell
 - Start Date: 2016-06-15
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1651
-- Rust Issue: https://github.com/rust-lang/rust/issues/39264
+- RFC PR: [rust-lang/rfcs#1651](https://github.com/rust-lang/rfcs/pull/1651)
+- Rust Issue: [rust-lang/rust#39264](https://github.com/rust-lang/rust/issues/39264)
 
 # Summary
 [summary]: #summary

--- a/text/1681-macros-1.1.md
+++ b/text/1681-macros-1.1.md
@@ -1,7 +1,7 @@
 - Feature Name: `rustc_macros`
 - Start Date: 2016-07-14
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1681
-- Rust Issue: https://github.com/rust-lang/rust/issues/35900
+- RFC PR: [rust-lang/rfcs#1681](https://github.com/rust-lang/rfcs/pull/1681)
+- Rust Issue: [rust-lang/rust#35900](https://github.com/rust-lang/rust/issues/35900)
 
 # Summary
 [summary]: #summary

--- a/text/1682-field-init-shorthand.md
+++ b/text/1682-field-init-shorthand.md
@@ -1,7 +1,7 @@
 - Feature Name: field-init-shorthand
 - Start Date: 2016-07-18
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1682
-- Rust Issue: https://github.com/rust-lang/rust/issues/37340
+- RFC PR: [rust-lang/rfcs#1682](https://github.com/rust-lang/rfcs/pull/1682)
+- Rust Issue: [rust-lang/rust#37340](https://github.com/rust-lang/rust/issues/37340)
 
 # Summary
 [summary]: #summary

--- a/text/1683-docs-team.md
+++ b/text/1683-docs-team.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2016-07-21
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1683
+- RFC PR: [rust-lang/rfcs#1683](https://github.com/rust-lang/rfcs/pull/1683)
 - Rust Issue: N/A
 
 # Summary

--- a/text/1685-deprecate-anonymous-parameters.md
+++ b/text/1685-deprecate-anonymous-parameters.md
@@ -1,7 +1,7 @@
 - Feature Name: deprecate_anonymous_parameters
 - Start Date: 2016-07-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1685
-- Rust Issue: https://github.com/rust-lang/rust/issues/41686
+- RFC PR: [rust-lang/rfcs#1685](https://github.com/rust-lang/rfcs/pull/1685)
+- Rust Issue: [rust-lang/rust#41686](https://github.com/rust-lang/rust/issues/41686)
 
 # Summary
 [summary]: #summary

--- a/text/1696-discriminant.md
+++ b/text/1696-discriminant.md
@@ -1,6 +1,6 @@
 - Feature Name: discriminant
 - Start Date: 2016-08-01
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1696
+- RFC PR: [rust-lang/rfcs#1696](https://github.com/rust-lang/rfcs/pull/1696)
 - Rust Issue: [#24263](https://github.com/rust-lang/rust/pull/24263), [#34785](https://github.com/rust-lang/rust/pull/34785)
 
 # Summary

--- a/text/1758-repr-transparent.md
+++ b/text/1758-repr-transparent.md
@@ -1,6 +1,6 @@
 - Feature Name: `repr_transparent`
 - Start Date: 2016-09-26
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1758
+- RFC PR: [rust-lang/rfcs#1758](https://github.com/rust-lang/rfcs/pull/1758)
 - Rust Issue:https://github.com/rust-lang/rust/issues/43036
 
 # Summary

--- a/text/1774-roadmap-2017.md
+++ b/text/1774-roadmap-2017.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2016-10-04
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1774
+- RFC PR: [rust-lang/rfcs#1774](https://github.com/rust-lang/rfcs/pull/1774)
 - Rust Issue: N/A
 
 # Summary

--- a/text/1789-as-cell.md
+++ b/text/1789-as-cell.md
@@ -1,7 +1,7 @@
 - Feature Name: as_cell
 - Start Date: 2016-11-13
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1789
-- Rust Issue: https://github.com/rust-lang/rust/issues/43038
+- RFC PR: [rust-lang/rfcs#1789](https://github.com/rust-lang/rfcs/pull/1789)
+- Rust Issue: [rust-lang/rust#43038](https://github.com/rust-lang/rust/issues/43038)
 
 # Summary
 [summary]: #summary

--- a/text/1824-crates.io-default-ranking.md
+++ b/text/1824-crates.io-default-ranking.md
@@ -1,7 +1,7 @@
 - Feature Name: crates_io_default_ranking
 - Start Date: 2016-12-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1824
-- Rust Issue: https://github.com/rust-lang/rust/issues/41616
+- RFC PR: [rust-lang/rfcs#1824](https://github.com/rust-lang/rfcs/pull/1824)
+- Rust Issue: [rust-lang/rust#41616](https://github.com/rust-lang/rust/issues/41616)
 
 # Summary
 [summary]: #summary

--- a/text/1826-change-doc-default-urls.md
+++ b/text/1826-change-doc-default-urls.md
@@ -1,7 +1,7 @@
 - Feature Name: N/A
 - Start Date: 2016-12-22
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1826
-- Rust Issue: https://github.com/rust-lang/rust/issues/44687
+- RFC PR: [rust-lang/rfcs#1826](https://github.com/rust-lang/rfcs/pull/1826)
+- Rust Issue: [rust-lang/rust#44687](https://github.com/rust-lang/rust/issues/44687)
 
 # Summary
 [summary]: #summary

--- a/text/1828-rust-bookshelf.md
+++ b/text/1828-rust-bookshelf.md
@@ -1,7 +1,7 @@
 - Feature Name: N/A
 - Start Date: 2016-12-25
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1828
-- Rust Issue: https://github.com/rust-lang/rust/issues/39588
+- RFC PR: [rust-lang/rfcs#1828](https://github.com/rust-lang/rfcs/pull/1828)
+- Rust Issue: [rust-lang/rust#39588](https://github.com/rust-lang/rust/issues/39588)
 
 # Summary
 [summary]: #summary

--- a/text/1857-stabilize-drop-order.md
+++ b/text/1857-stabilize-drop-order.md
@@ -1,7 +1,7 @@
 - Feature Name: stable_drop_order
 - Start Date: 2017-01-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1857
-- Rust Issue: https://github.com/rust-lang/rust/issues/43034
+- RFC PR: [rust-lang/rfcs#1857](https://github.com/rust-lang/rfcs/pull/1857)
+- Rust Issue: [rust-lang/rust#43034](https://github.com/rust-lang/rust/issues/43034)
 
 # Summary
 [summary]: #summary

--- a/text/1861-extern-types.md
+++ b/text/1861-extern-types.md
@@ -1,7 +1,7 @@
 - Feature Name: extern_types
 - Start Date: 2017-01-18
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1861
-- Rust Issue: https://github.com/rust-lang/rust/issues/43467
+- RFC PR: [rust-lang/rfcs#1861](https://github.com/rust-lang/rfcs/pull/1861)
+- Rust Issue: [rust-lang/rust#43467](https://github.com/rust-lang/rust/issues/43467)
 
 # Summary
 [summary]: #summary

--- a/text/1866-more-readable-assert-eq.md
+++ b/text/1866-more-readable-assert-eq.md
@@ -1,7 +1,7 @@
 - Feature Name: more-readable-assert-eq
 - Start Date: 2017-01-23
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1866
-- Rust Issue: https://github.com/rust-lang/rust/issues/41615
+- RFC PR: [rust-lang/rfcs#1866](https://github.com/rust-lang/rfcs/pull/1866)
+- Rust Issue: [rust-lang/rust#41615](https://github.com/rust-lang/rust/issues/41615)
 
 
 # Summary

--- a/text/1868-portability-lint.md
+++ b/text/1868-portability-lint.md
@@ -1,7 +1,7 @@
 - Feature Name: nonportable
 - Start Date: 2016-11-15
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1868
-- Rust Issue: https://github.com/rust-lang/rust/issues/41619
+- RFC PR: [rust-lang/rfcs#1868](https://github.com/rust-lang/rfcs/pull/1868)
+- Rust Issue: [rust-lang/rust#41619](https://github.com/rust-lang/rust/issues/41619)
 
 # Summary
 [summary]: #summary

--- a/text/1925-optional-match-vert.md
+++ b/text/1925-optional-match-vert.md
@@ -1,7 +1,7 @@
 - Feature Name: `match_vert_prefix`
 - Start Date: 2017-02-23
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1925
-- Rust Issue: https://github.com/rust-lang/rust/issues/44101
+- RFC PR: [rust-lang/rfcs#1925](https://github.com/rust-lang/rfcs/pull/1925)
+- Rust Issue: [rust-lang/rust#44101](https://github.com/rust-lang/rust/issues/44101)
 
 # Summary
 [summary]: #summary

--- a/text/1937-ques-in-main.md
+++ b/text/1937-ques-in-main.md
@@ -1,7 +1,7 @@
 - Feature Name: ques_in_main
 - Start Date: 2017-02-22
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1937
-- Rust Issue: https://github.com/rust-lang/rust/issues/43301
+- RFC PR: [rust-lang/rfcs#1937](https://github.com/rust-lang/rfcs/pull/1937)
+- Rust Issue: [rust-lang/rust#43301](https://github.com/rust-lang/rust/issues/43301)
 
 # Summary
 [summary]: #summary

--- a/text/1940-must-use-functions.md
+++ b/text/1940-must-use-functions.md
@@ -1,7 +1,7 @@
 - Feature Name: none?
 - Start Date: 2015-02-18
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1940
-- Rust Issue: https://github.com/rust-lang/rust/issues/43302
+- RFC PR: [rust-lang/rfcs#1940](https://github.com/rust-lang/rfcs/pull/1940)
+- Rust Issue: [rust-lang/rust#43302](https://github.com/rust-lang/rust/issues/43302)
 
 # Summary
 

--- a/text/1946-intra-rustdoc-links.md
+++ b/text/1946-intra-rustdoc-links.md
@@ -1,7 +1,7 @@
 - Feature Name: `intra_rustdoc_links`
 - Start Date: 2017-03-06
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1946
-- Rust Issue: https://github.com/rust-lang/rust/issues/43466
+- RFC PR: [rust-lang/rfcs#1946](https://github.com/rust-lang/rfcs/pull/1946)
+- Rust Issue: [rust-lang/rust#43466](https://github.com/rust-lang/rust/issues/43466)
 
 # Summary
 [summary]: #summary

--- a/text/1951-expand-impl-trait.md
+++ b/text/1951-expand-impl-trait.md
@@ -1,7 +1,7 @@
 - Feature Name: expanded_impl_trait
 - Start Date: 2017-03-12
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1951
-- Rust Issue: https://github.com/rust-lang/rust/issues/42183
+- RFC PR: [rust-lang/rfcs#1951](https://github.com/rust-lang/rfcs/pull/1951)
+- Rust Issue: [rust-lang/rust#42183](https://github.com/rust-lang/rust/issues/42183)
 
 # Summary
 [summary]: #summary

--- a/text/1961-clamp.md
+++ b/text/1961-clamp.md
@@ -1,7 +1,7 @@
 - Feature Name: clamp functions
 - Start Date: 2017-03-26
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1961/
-- Rust Issue: https://github.com/rust-lang/rust/issues/44095
+- RFC PR: [rust-lang/rfcs#1961](https://github.com/rust-lang/rfcs/pull/1961)/
+- Rust Issue: [rust-lang/rust#44095](https://github.com/rust-lang/rust/issues/44095)
 
 # Summary
 [summary]: #summary

--- a/text/1977-public-private-dependencies.md
+++ b/text/1977-public-private-dependencies.md
@@ -1,7 +1,7 @@
 - Feature Name: `public_private_dependencies`
 - Start Date: 2017-04-03
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1977
-- Rust Issue: https://github.com/rust-lang/rust/issues/44663
+- RFC PR: [rust-lang/rfcs#1977](https://github.com/rust-lang/rfcs/pull/1977)
+- Rust Issue: [rust-lang/rust#44663](https://github.com/rust-lang/rust/issues/44663)
 
 # Summary
 [summary]: #summary

--- a/text/1983-nursery-deprecation.md
+++ b/text/1983-nursery-deprecation.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2017-04-26
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1983
+- RFC PR: [rust-lang/rfcs#1983](https://github.com/rust-lang/rfcs/pull/1983)
 - Rust Issue: N/A
 
 # Summary

--- a/text/1985-tiered-browser-support.md
+++ b/text/1985-tiered-browser-support.md
@@ -1,7 +1,7 @@
 - Feature Name: tiered_browser_support
 - Start Date: 2017-04-25
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1985
-- Rust Issue: https://github.com/rust-lang/rust/issues/43035
+- RFC PR: [rust-lang/rfcs#1985](https://github.com/rust-lang/rfcs/pull/1985)
+- Rust Issue: [rust-lang/rust#43035](https://github.com/rust-lang/rust/issues/43035)
 
 # Summary
 [summary]: #summary

--- a/text/1990-external-doc-attribute.md
+++ b/text/1990-external-doc-attribute.md
@@ -11,8 +11,8 @@ except according to those terms.
 
 - Feature Name: external_doc
 - Start Date: 2017-04-26
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1990
-- Rust Issue: https://github.com/rust-lang/rust/issues/44732
+- RFC PR: [rust-lang/rfcs#1990](https://github.com/rust-lang/rfcs/pull/1990)
+- Rust Issue: [rust-lang/rust#44732](https://github.com/rust-lang/rust/issues/44732)
 
 # Summary
 [summary]: #summary

--- a/text/2000-const-generics.md
+++ b/text/2000-const-generics.md
@@ -1,7 +1,7 @@
 - Feature Name: const_generics
 - Start Date: 2017-05-01
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2000
-- Rust Issue: https://github.com/rust-lang/rust/issues/44580
+- RFC PR: [rust-lang/rfcs#2000](https://github.com/rust-lang/rfcs/pull/2000)
+- Rust Issue: [rust-lang/rust#44580](https://github.com/rust-lang/rust/issues/44580)
 
 # Summary
 [summary]: #summary

--- a/text/2005-match-ergonomics.md
+++ b/text/2005-match-ergonomics.md
@@ -1,7 +1,7 @@
 - Feature Name: pattern-binding-modes
 - Start Date: 2016-08-12
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2005
-- Rust Issue: https://github.com/rust-lang/rust/issues/42640
+- RFC PR: [rust-lang/rfcs#2005](https://github.com/rust-lang/rfcs/pull/2005)
+- Rust Issue: [rust-lang/rust#42640](https://github.com/rust-lang/rust/issues/42640)
 
 # Summary
 [summary]: #summary

--- a/text/2008-non-exhaustive.md
+++ b/text/2008-non-exhaustive.md
@@ -1,7 +1,7 @@
 - Feature Name: non_exhaustive
 - Start Date: 2017-05-24
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2008
-- Rust Issue: https://github.com/rust-lang/rust/issues/44109
+- RFC PR: [rust-lang/rfcs#2008](https://github.com/rust-lang/rfcs/pull/2008)
+- Rust Issue: [rust-lang/rust#44109](https://github.com/rust-lang/rust/issues/44109)
 
 # Summary
 

--- a/text/2025-nested-method-calls.md
+++ b/text/2025-nested-method-calls.md
@@ -1,7 +1,7 @@
 - Feature Name: nested_method_call
 - Start Date: 2017-06-06
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2025
-- Rust Issue: https://github.com/rust-lang/rust/issues/44100
+- RFC PR: [rust-lang/rfcs#2025](https://github.com/rust-lang/rfcs/pull/2025)
+- Rust Issue: [rust-lang/rust#44100](https://github.com/rust-lang/rust/issues/44100)
 
 # Summary
 [summary]: #summary

--- a/text/2033-experimental-coroutines.md
+++ b/text/2033-experimental-coroutines.md
@@ -1,7 +1,7 @@
 - Feature Name: `coroutines`
 - Start Date: 2017-06-15
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2033
-- Rust Issue: https://github.com/rust-lang/rust/issues/43122
+- RFC PR: [rust-lang/rfcs#2033](https://github.com/rust-lang/rfcs/pull/2033)
+- Rust Issue: [rust-lang/rust#43122](https://github.com/rust-lang/rust/issues/43122)
 
 # Summary
 [summary]: #summary

--- a/text/2043-is-aligned-intrinsic.md
+++ b/text/2043-is-aligned-intrinsic.md
@@ -1,7 +1,7 @@
 - Feature Name: align_to_intrinsic
 - Start Date: 2017-06-20
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2043
-- Rust Issue: https://github.com/rust-lang/rust/issues/44488
+- RFC PR: [rust-lang/rfcs#2043](https://github.com/rust-lang/rfcs/pull/2043)
+- Rust Issue: [rust-lang/rust#44488](https://github.com/rust-lang/rust/issues/44488)
 
 # Summary
 [summary]: #summary

--- a/text/2044-license-rfcs.md
+++ b/text/2044-license-rfcs.md
@@ -1,7 +1,7 @@
 - Feature Name: license_rfcs
 - Start Date: 2017-06-26
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2044
-- Rust Issue: https://github.com/rust-lang/rust/issues/43461
+- RFC PR: [rust-lang/rfcs#2044](https://github.com/rust-lang/rfcs/pull/2044)
+- Rust Issue: [rust-lang/rust#43461](https://github.com/rust-lang/rust/issues/43461)
 
 # Summary
 [summary]: #summary

--- a/text/2052-epochs.md
+++ b/text/2052-epochs.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2017-06-26
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2052
+- RFC PR: [rust-lang/rfcs#2052](https://github.com/rust-lang/rfcs/pull/2052)
 - Rust Issue: N/A
 
 # Summary

--- a/text/2070-panic-implementation.md
+++ b/text/2070-panic-implementation.md
@@ -1,7 +1,7 @@
 - Feature Name: panic_implementation
 - Start Date: 2017-07-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2070
-- Rust Issue: https://github.com/rust-lang/rust/issues/44489
+- RFC PR: [rust-lang/rfcs#2070](https://github.com/rust-lang/rfcs/pull/2070)
+- Rust Issue: [rust-lang/rust#44489](https://github.com/rust-lang/rust/issues/44489)
 
 # Summary
 [summary]: #summary

--- a/text/2071-impl-trait-type-alias.md
+++ b/text/2071-impl-trait-type-alias.md
@@ -1,8 +1,8 @@
 - Feature Name: impl-trait-existential-types
 - Start Date: 2017-07-20
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2071
-- Rust Issue: https://github.com/rust-lang/rust/issues/44685 (existential types)
-- Rust Issue: https://github.com/rust-lang/rust/issues/44686 (impl Trait in const/static/let)
+- RFC PR: [rust-lang/rfcs#2071](https://github.com/rust-lang/rfcs/pull/2071)
+- Rust Issue: [rust-lang/rust#44685](https://github.com/rust-lang/rust/issues/44685) (existential types)
+- Rust Issue: [rust-lang/rust#44686](https://github.com/rust-lang/rust/issues/44686) (impl Trait in const/static/let)
 
 # Summary
 [summary]: #summary

--- a/text/2086-allow-if-let-irrefutables.md
+++ b/text/2086-allow-if-let-irrefutables.md
@@ -1,7 +1,7 @@
 - Feature Name: allow_if_let_irrefutables
 - Start Date: 2017-07-27
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2086
-- Rust Issue: https://github.com/rust-lang/rust/issues/44495
+- RFC PR: [rust-lang/rfcs#2086](https://github.com/rust-lang/rfcs/pull/2086)
+- Rust Issue: [rust-lang/rust#44495](https://github.com/rust-lang/rust/issues/44495)
 
 # Summary
 [summary]: #summary

--- a/text/2089-implied-bounds.md
+++ b/text/2089-implied-bounds.md
@@ -1,7 +1,7 @@
 - Feature Name: `implied_bounds`
 - Start Date: 2017-07-28
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2089
-- Rust Issue: https://github.com/rust-lang/rust/issues/44491
+- RFC PR: [rust-lang/rfcs#2089](https://github.com/rust-lang/rfcs/pull/2089)
+- Rust Issue: [rust-lang/rust#44491](https://github.com/rust-lang/rust/issues/44491)
 
 # Summary
 [summary]: #summary

--- a/text/2093-infer-outlives.md
+++ b/text/2093-infer-outlives.md
@@ -1,7 +1,7 @@
 - Feature Name: `infer_outlives`
 - Start Date: 2017-08-02
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2093
-- Rust Issue: https://github.com/rust-lang/rust/issues/44493
+- RFC PR: [rust-lang/rfcs#2093](https://github.com/rust-lang/rfcs/pull/2093)
+- Rust Issue: [rust-lang/rust#44493](https://github.com/rust-lang/rust/issues/44493)
 
 # Summary
 [summary]: #summary

--- a/text/2094-nll.md
+++ b/text/2094-nll.md
@@ -1,7 +1,7 @@
 - Feature Name: (fill me in with a unique ident, my_awesome_feature)
 - Start Date: 2017-08-02
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2094
-- Rust Issue: https://github.com/rust-lang/rust/issues/44928
+- RFC PR: [rust-lang/rfcs#2094](https://github.com/rust-lang/rfcs/pull/2094)
+- Rust Issue: [rust-lang/rust#44928](https://github.com/rust-lang/rust/issues/44928)
 
 # Summary
 [summary]: #summary

--- a/text/2103-tool-attributes.md
+++ b/text/2103-tool-attributes.md
@@ -1,7 +1,7 @@
 - Feature Name: tool_attributes, tool_lints
 - Start Date: 2016-09-22
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2103
-- Rust Issue: https://github.com/rust-lang/rust/issues/44690
+- RFC PR: [rust-lang/rfcs#2103](https://github.com/rust-lang/rfcs/pull/2103)
+- Rust Issue: [rust-lang/rust#44690](https://github.com/rust-lang/rust/issues/44690)
 
 
 # Summary

--- a/text/2113-dyn-trait-syntax.md
+++ b/text/2113-dyn-trait-syntax.md
@@ -1,7 +1,7 @@
 - Feature Name: dyn-trait-syntax
 - Start Date: 2017-08-17
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2113
-- Rust Issue: https://github.com/rust-lang/rust/issues/44662
+- RFC PR: [rust-lang/rfcs#2113](https://github.com/rust-lang/rfcs/pull/2113)
+- Rust Issue: [rust-lang/rust#44662](https://github.com/rust-lang/rust/issues/44662)
 
 # Summary
 [summary]: #summary

--- a/text/2115-argument-lifetimes.md
+++ b/text/2115-argument-lifetimes.md
@@ -1,7 +1,7 @@
 - Feature Name: argument_lifetimes
 - Start Date: 2017-08-17
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2115
-- Rust Issue: https://github.com/rust-lang/rust/issues/44524
+- RFC PR: [rust-lang/rfcs#2115](https://github.com/rust-lang/rfcs/pull/2115)
+- Rust Issue: [rust-lang/rust#44524](https://github.com/rust-lang/rust/issues/44524)
 
 # Summary
 [summary]: #summary

--- a/text/2124-option-filter.md
+++ b/text/2124-option-filter.md
@@ -1,7 +1,7 @@
 - Feature Name: option_filter
 - Start Date: 2017-08-21
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2124
-- Rust Issue: https://github.com/rust-lang/rust/issues/45860
+- RFC PR: [rust-lang/rfcs#2124](https://github.com/rust-lang/rfcs/pull/2124)
+- Rust Issue: [rust-lang/rust#45860](https://github.com/rust-lang/rust/issues/45860)
 
 # Summary
 [summary]: #summary

--- a/text/2126-path-clarity.md
+++ b/text/2126-path-clarity.md
@@ -1,7 +1,7 @@
 - Feature Name: TBD
 - Start Date: 2017-08-24
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2126
-- Rust Issue: https://github.com/rust-lang/rust/issues/44660
+- RFC PR: [rust-lang/rfcs#2126](https://github.com/rust-lang/rfcs/pull/2126)
+- Rust Issue: [rust-lang/rust#44660](https://github.com/rust-lang/rust/issues/44660)
 
 # Summary
 [summary]: #summary

--- a/text/2128-use-nested-groups.md
+++ b/text/2128-use-nested-groups.md
@@ -1,7 +1,7 @@
 - Feature Name: use_nested_groups
 - Start Date: 2017-08-25
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2128
-- Rust Issue: https://github.com/rust-lang/rust/issues/44494
+- RFC PR: [rust-lang/rfcs#2128](https://github.com/rust-lang/rfcs/pull/2128)
+- Rust Issue: [rust-lang/rust#44494](https://github.com/rust-lang/rust/issues/44494)
 
 # Summary
 [summary]: #summary

--- a/text/2132-copy-closures.md
+++ b/text/2132-copy-closures.md
@@ -1,7 +1,7 @@
 - Feature Name: `copy_closures`
 - Start Date: 2017-08-27
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2132
-- Rust Issue: https://github.com/rust-lang/rust/issues/44490
+- RFC PR: [rust-lang/rfcs#2132](https://github.com/rust-lang/rfcs/pull/2132)
+- Rust Issue: [rust-lang/rust#44490](https://github.com/rust-lang/rust/issues/44490)
 
 # Summary
 [summary]: #summary

--- a/text/2133-all-the-clones.md
+++ b/text/2133-all-the-clones.md
@@ -1,7 +1,7 @@
 - Feature Name: `all_the_clones`
 - Start Date: 2017-08-28
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2133
-- Rust Issue: https://github.com/rust-lang/rust/issues/44496
+- RFC PR: [rust-lang/rfcs#2133](https://github.com/rust-lang/rfcs/pull/2133)
+- Rust Issue: [rust-lang/rust#44496](https://github.com/rust-lang/rust/issues/44496)
 
 # Summary
 [summary]: #summary

--- a/text/2137-variadic.md
+++ b/text/2137-variadic.md
@@ -1,7 +1,7 @@
 - Feature Name: variadic
 - Start Date: 2017-08-21
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2137
-- Rust Issue: https://github.com/rust-lang/rust/issues/44930
+- RFC PR: [rust-lang/rfcs#2137](https://github.com/rust-lang/rfcs/pull/2137)
+- Rust Issue: [rust-lang/rust#44930](https://github.com/rust-lang/rust/issues/44930)
 
 # Summary
 [summary]: #summary

--- a/text/2141-alternative-registries.md
+++ b/text/2141-alternative-registries.md
@@ -1,7 +1,7 @@
 - Feature Name: cargo_alternative_registries
 - Start Date: 2017-09-06
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2141
-- Rust Issue: https://github.com/rust-lang/rust/issues/44931
+- RFC PR: [rust-lang/rfcs#2141](https://github.com/rust-lang/rfcs/pull/2141)
+- Rust Issue: [rust-lang/rust#44931](https://github.com/rust-lang/rust/issues/44931)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
Raw URL strings (e.g. `https://example.com`) are not recognized as links in [published mdbook](http://rust-lang.github.io/rfcs/).
So this PR converts them into Markdown style (e.g. `[link](https://example.com)`).