### PR TITLE
RFC: Constants in array repeat expressions

### DIFF
--- a/text/0000-const-repeat-expr.md
+++ b/text/0000-const-repeat-expr.md
@@ -34,9 +34,9 @@ impl<T: ConstDefault, const N: usize> ConstDefault for [T; N] {
 }
 ```
 
-[`std::mem::uninitialized()`]: https://doc.rust-lang.org/nightly/std/mem/fn.uninitialized.html
+[`mem::uninitialized()`]: https://doc.rust-lang.org/nightly/std/mem/fn.uninitialized.html
 
-In the example given by [`std::mem::uninitialized()`], a value of type
+In the example given by [`mem::uninitialized()`], a value of type
 `[Vec<u32>; 1000]` is created and filled. With this RFC, and when `Vec::new()`
 becomes const, the user can simply write:
 
@@ -93,7 +93,18 @@ fn main() {
 }
 ```
 
-Thus, the compiler may rewrite this internally as:
+Thus, the compiler may rewrite the following:
+
+```rust
+fn main() {
+    type T = Option<Box<u32>>;
+    const X: T = None;
+    let mut arr = [X; 2];
+    arr[0] = Some(Box::new(1));
+}
+```
+
+internally as:
 
 ```rust
 // This is the value to be repeated and typeof(X) the type it has.
@@ -134,7 +145,7 @@ argues that the change is quite intuitive.
 [`ptr::write(..)`]: https://doc.rust-lang.org/nightly/std/ptr/fn.write.html
 
 The alternative, in addition to simply not doing this, is to modify a host of
-other constructs such as [`std::mem::uninitialized()`], for loops over iterators,
+other constructs such as [`mem::uninitialized()`], for loops over iterators,
 [`ptr::write`] to be `const`, which is is a larger change. The design offered by
 this RFC is therefore the simplest and most non-intrusive design. It is also
 the most consistent.

--- a/text/0000-const-repeat-expr.md
+++ b/text/0000-const-repeat-expr.md
@@ -1,0 +1,152 @@
+- Feature Name: const_repeat_expr
+- Start Date: 2017-10-20
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Relaxes the rules for repeat expressions, `[x; N]` such that `x` may also be
+`const`, in addition to `typeof(x): Copy`. The result of `[x; N]` where `x` is
+`const` is itself also `const`.
+
+# Motivation
+[motivation]: #motivation
+
+[RFC 2000, `const_generics`]: https://github.com/rust-lang/rfcs/blob/master/text/2000-const-generics.md
+[`const_default` RFC]: https://github.com/Centril/rfcs/blob/rfc/const-default/text/0000-const-default.md
+
+[RFC 2000, `const_generics`] introduced the ability to have generically sized
+arrays. Even with that RFC, it is currently impossible to create such an array
+that is also `const`. Creating an array that is `const` may for example be
+useful for the [`const_default` RFC] which proposes the following trait:
+
+```rust
+pub trait ConstDefault { const DEFAULT: Self; }
+```
+
+To add an implementation of this trait for an array of any size where the
+elements of type `T` are `ConstDefault`, as in:
+
+```rust
+impl<T: ConstDefault, const N: usize> ConstDefault for [T; N] {
+    const DEFAULT: Self = [T::DEFAULT; N];
+}
+```
+
+[`std::mem::uninitialized()`]: https://doc.rust-lang.org/nightly/std/mem/fn.uninitialized.html
+
+In the example given by [`std::mem::uninitialized()`], a value of type
+`[Vec<u32>; 1000]` is created and filled. With this RFC, and when `Vec::new()`
+becomes const, the user can simply write:
+
+```rust
+let data = [Vec::<u32>::new(); 1000];
+println!("{:?}", &data[0]);
+```
+
+this removes one common reason to use `uninitialized()` which **"is incredibly
+dangerous"**.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+You have a variable or expression `X` which is const, for example:
+
+```rust
+type T = Option<Box<u32>>;
+const X: T = None;
+```
+
+Now, you'd like to use array repeat expressions `[X; N]` to create an array
+containing a bunch of `X`es. Sorry, you are out of luck!
+
+But with this RFC, you can now write:
+
+```rust
+const X: T = None;
+const arr: [u32; 100] = [X; 100];
+```
+
+or, if you wish to modify the array later:
+
+```rust
+const X: T = None;
+let mut arr = [x; 100];
+arr[0] = Some(Box::new(1));
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+Values which are `const` are freely duplicatable as seen in the following
+example which compiles today. This is also the case with `Copy`. Therefore, the
+value `X` in the repeat expression may be simply treated as if it were of a
+`Copy` type.
+
+```rust
+fn main() {
+    type T = Option<Box<u32>>;
+    const X: T = None;
+    let mut arr = [X, X];
+    arr[0] = Some(Box::new(1));
+}
+```
+
+Thus, the compiler may rewrite this internally as:
+
+```rust
+// This is the value to be repeated and typeof(X) the type it has.
+const X: typeof(X) = VALUE;
+// N is the size of the array and how many times to repeat X.
+const N: usize = SIZE;
+
+{
+    let mut data: [typeof(X); N];
+
+    unsafe {
+        data = mem::uninitialized();
+    
+        let mut iter = (&mut data[..]).into_iter();
+        while let Some(elem) = iter.next() {
+            // ptr::write does not run destructor of elem already in array.
+            // Since X is const, it can not panic.
+            ptr::write(elem, X);
+        }
+    }
+
+    data
+}
+```
+
+Additionally, the pass that checks `const`ness must treat `[X; N]` as a `const`
+value.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+It might make the semantics of array initializers more fuzzy. The RFC, however,
+argues that the change is quite intuitive.
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+[`ptr::write(..)`]: https://doc.rust-lang.org/nightly/std/ptr/fn.write.html
+
+The alternative, in addition to simply not doing this, is to modify a host of
+other constructs such as [`std::mem::uninitialized()`], for loops over iterators,
+[`ptr::write`] to be `const`, which is is a larger change. The design offered by
+this RFC is therefore the simplest and most non-intrusive design. It is also
+the most consistent.
+
+The impact of not doing this change is to not enable generically sized arrays to
+be `const`.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+[`drop_types_in_const`]: https://github.com/rust-lang/rfcs/blob/master/text/1440-drop-types-in-const.md
+
+The relation to [`drop_types_in_const`] should be resolved during the RFC process.
+The soundness of the proposal should be verified.
+Other than that, there are no unresolved questions.

--- a/text/0000-const-repeat-expr.md
+++ b/text/0000-const-repeat-expr.md
@@ -65,14 +65,14 @@ But with this RFC, you can now write:
 
 ```rust
 const X: T = None;
-const arr: [u32; 100] = [X; 100];
+const arr: [T; 100] = [X; 100];
 ```
 
 or, if you wish to modify the array later:
 
 ```rust
 const X: T = None;
-let mut arr = [x; 100];
+let mut arr = [X; 100];
 arr[0] = Some(Box::new(1));
 ```
 
@@ -108,7 +108,10 @@ internally as:
 
 ```rust
 // This is the value to be repeated and typeof(X) the type it has.
+// If a `VALUE` panics, it happens during compile time at this point
+// and not later.
 const X: typeof(X) = VALUE;
+
 // N is the size of the array and how many times to repeat X.
 const N: usize = SIZE;
 
@@ -121,7 +124,7 @@ const N: usize = SIZE;
         let mut iter = (&mut data[..]).into_iter();
         while let Some(elem) = iter.next() {
             // ptr::write does not run destructor of elem already in array.
-            // Since X is const, it can not panic.
+            // Since X is const, it can not panic at this point.
             ptr::write(elem, X);
         }
     }
@@ -156,8 +159,4 @@ be `const`.
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-[`drop_types_in_const`]: https://github.com/rust-lang/rfcs/blob/master/text/1440-drop-types-in-const.md
-
-The relation to [`drop_types_in_const`] should be resolved during the RFC process.
-The soundness of the proposal should be verified.
-Other than that, there are no unresolved questions.
+There are no unresolved questions.

--- a/text/2203-const-repeat-expr.md
+++ b/text/2203-const-repeat-expr.md
@@ -1,7 +1,7 @@
-- Feature Name: const_repeat_expr
+- Feature Name: `const_repeat_expr`
 - Start Date: 2017-10-20
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: [rust-lang/rfcs#2203](https://github.com/rust-lang/rfcs/pull/2203)
+- Rust Issue: [rust-lang/rust#49147](https://github.com/rust-lang/rust/issues/49147)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
[Rendered.](https://github.com/Centril/rfcs/blob/rfc/const-repeat-expr/text/0000-const-repeat-expr.md)

Relaxes the rules for repeat expressions, `[x; N]` such that `x` may also be `const`, in addition to `typeof(x): Copy`. The result of `[x; N]` where `x` is `const` is itself also `const`.