### PR TITLE
text/1607-style-rfcs.md: Markdown formatting fix

### DIFF
--- a/text/1607-style-rfcs.md
+++ b/text/1607-style-rfcs.md
@@ -201,15 +201,15 @@ and newlines after the opening brace and before the closing brace). The former
 approach should be used for short struct literals, the latter for longer struct
 literals. For tools, the first approach should be used when the width of the
 fields (excluding commas and braces) is 16 characters. E.g.,
-
+>
 > ```rust
-let x = Foo { a: 42, b: 34 };
-let y = Foo {
-    a: 42,
-    b: 34,
-    c: 1000
-};
-```
+> let x = Foo { a: 42, b: 34 };
+> let y = Foo {
+>     a: 42,
+>     b: 34,
+>     c: 1000
+> };
+> ```
 
 (Note this is just an example, not a proposed guideline).
 


### PR DESCRIPTION
The previous rendering had half the page trapped in an unterminated code block ([old version rendered](https://github.com/rust-lang/rfcs/blob/f4b8b61a414298ba0f76d9b786d58ccdc34a44bb/text/1607-style-rfcs.md), [new version rendered](https://github.com/andersk/rust-rfcs/blob/68bba1594c20aeaed9a02b8196061254b0e85434/text/1607-style-rfcs.md)).