### PR TITLE
Add missing Copy bound for K in get_default in RFC 2094

### DIFF
--- a/text/2094-nll.md
+++ b/text/2094-nll.md
@@ -210,9 +210,9 @@ purposes of this section, assume that the `entry` API for maps does
 not exist):
 
 ```rust
-fn get_default<'r,K:Hash+Eq,V:Default>(map: &'r mut HashMap<K,V>,
-                                       key: K)
-                                       -> &'r mut V {
+fn get_default<'r,K:Hash+Eq+Copy,V:Default>(map: &'r mut HashMap<K,V>,
+                                            key: K)
+                                            -> &'r mut V {
     match map.get_mut(&key) { // -------------+ 'r
         Some(value) => value,              // |
         None => {                          // |
@@ -258,9 +258,9 @@ If we attempt the same workaround for this case that we tried
 in the previous example, we will find that it does not work:
 
 ```rust
-fn get_default1<'r,K:Hash+Eq,V:Default>(map: &'r mut HashMap<K,V>,
-                                        key: K)
-                                        -> &'r mut V {
+fn get_default1<'r,K:Hash+Eq+Copy,V:Default>(map: &'r mut HashMap<K,V>,
+                                             key: K)
+                                             -> &'r mut V {
     match map.get_mut(&key) { // -------------+ 'r
         Some(value) => return value,       // |
         None => { }                        // |
@@ -281,9 +281,9 @@ the fact that the borrow checker uses the precise control-flow of the
 function to determine which borrows are in scope.
 
 ```rust
-fn get_default2<'r,K:Hash+Eq,V:Default>(map: &'r mut HashMap<K,V>,
-                                        key: K)
-                                        -> &'r mut V {
+fn get_default2<'r,K:Hash+Eq+Copy,V:Default>(map: &'r mut HashMap<K,V>,
+                                             key: K)
+                                             -> &'r mut V {
     if map.contains(&key) {
     // ^~~~~~~~~~~~~~~~~~ 'n
         return match map.get_mut(&key) { // + 'r


### PR DESCRIPTION
While this could be changed to not require Copy bound, this would add a lot of extra noise, when the focus in those code examples are non-lexical lifetimes.

(forgot this in my previous PR)