### PR TITLE
Amend RFC 1758 (repr(transparent)) w.r.t. repr(align)

### DIFF
--- a/text/1758-repr-transparent.md
+++ b/text/1758-repr-transparent.md
@@ -117,16 +117,14 @@ have the same representation as their underlying types.
 
 [RFC 1649]: https://github.com/rust-lang/rfcs/pull/1649
 
-This new representation cannot be used with any other representation attribute
-but alignment, to be able to specify a transparent wrapper with additional
-alignment constraints:
+This new representation cannot be used with any other representation attribute:
 
 ```rust
 #[repr(transparent, align = "128")]
-struct OverAligned(f64); // Behaves as a bare f64 with 128 bits alignment.
+struct BogusAlign(f64); // Error, must be aligned like the underlying type.
 
 #[repr(C, transparent)]
-struct BogusRepr(f64); // Nonsensical, repr cannot be C and transparent.
+struct BogusRepr(f64); // Error, repr cannot be C and transparent.
 ```
 
 As a matter of optimisation, eligible `#[repr(Rust)]` structs behave as if


### PR DESCRIPTION
The RFC made contradictory statements on whether repr(align(N)) can be combined with repr(transparent). [Discussion on the tracking issue][discuss] did not find a good reason to support it, so this commit makes the RFC internally consistent by prohibiting align(N) on transparent structs.

[discuss]: https://github.com/rust-lang/rust/issues/43036#issuecomment-352172909