### PR TITLE
Update the disambiguation handling in RFC 1946 (intra-rustdoc-links) to match impl concerns

### DIFF
--- a/text/1946-intra-rustdoc-links.md
+++ b/text/1946-intra-rustdoc-links.md
@@ -307,6 +307,8 @@ Our proposal is this:
   - It is possible that disambiguators for one kind of type-namespace object
     will work for the other (i.e. you can use `struct@` to refer to an enum),
     but do not rely on this.
+- Modules exist in both the type and value namespace and can be disambiguated
+  with a `mod@` or `module@`, e.g. `[module@foo]`
 - In links to macros,
   the link label can end with a `!`,
   e.g., `Look at the [FOO!] macro`. You can alternatively use a `macro@` prefix,
@@ -314,8 +316,9 @@ Our proposal is this:
 - For disambiguating links to values, we differentiate three cases:
   - Links to any kind of value (function, const, static) can be prefixed with `value@`,
     e.g., `See [value@foo]`.
-  - Links to functions can be written with a `()` suffix,
-    e.g., `Also see the [foo()] function`. You can also use `function@`.
+  - Links to functions and methods can be written with a `()` suffix,
+    e.g., `Also see the [foo()] function`. You can also use `function@`, `fn@`,
+    or `method@`.
   - Links to constants are prefixed with `const@`,
     e.g., `As defined in [const@FOO].`
   - Links to statics are prefixed with `static@`,

--- a/text/1946-intra-rustdoc-links.md
+++ b/text/1946-intra-rustdoc-links.md
@@ -315,7 +315,7 @@ Our proposal is this:
   - Links to any kind of value (function, const, static) can be prefixed with `value@`,
     e.g., `See [value@foo]`.
   - Links to functions can be written with a `()` suffix,
-    e.g., `Also see the [foo()] function`.
+    e.g., `Also see the [foo()] function`. You can also use `function@`.
   - Links to constants are prefixed with `const@`,
     e.g., `As defined in [const@FOO].`
   - Links to statics are prefixed with `static@`,

--- a/text/1946-intra-rustdoc-links.md
+++ b/text/1946-intra-rustdoc-links.md
@@ -289,7 +289,6 @@ Our proposal is this:
   applies to modules and tuple structs which exist in both namespaces.
   Rustdoc will throw an error if you use a non-disambiguated path in
   the case of there being a value in both the type and value namespace.
-  Non-disambiguated paths cannot be used to link to macros.
 - Links to types can be disambiguated by prefixing them with the concrete
   item type:
   - Links to any type-namespace object can be prefixed with `type@`,
@@ -309,8 +308,8 @@ Our proposal is this:
     will work for the other (i.e. you can use `struct@` to refer to an enum),
     but do not rely on this.
 - In links to macros,
-  the link label _must_ end with a `!`,
-  e.g., `Look at the [FOO!] macro`. You can alternatively use a `foo@` prefix,
+  the link label can end with a `!`,
+  e.g., `Look at the [FOO!] macro`. You can alternatively use a `macro@` prefix,
   e.g. `[macro@foo]`
 - For disambiguating links to values, we differentiate three cases:
   - Links to any kind of value (function, const, static) can be prefixed with `value@`,

--- a/text/1946-intra-rustdoc-links.md
+++ b/text/1946-intra-rustdoc-links.md
@@ -290,13 +290,13 @@ Our proposal is this:
   For consistency,
   it is also possible to prefix the type with the concrete item type:
   - Links to `struct`s can be prefixed with `struct `,
-    e.g., `See [struct Foo]`.
+    e.g., `See [struct@Foo]`.
   - Links to `enum`s can be prefixed with `enum `,
-    e.g., `See [enum foo]`.
+    e.g., `See [enum@foo]`.
   - Links to type aliases can be prefixed with `type `,
-    e.g., `See [type foo]`.
+    e.g., `See [type@foo]`.
   - Links to modules can be prefixed with `mod `,
-    e.g., `See [mod foo]`.
+    e.g., `See [mod@foo]`.
 - In links to macros,
   the link label must end with a `!`,
   e.g., `Look at the [FOO!] macro`.
@@ -304,9 +304,9 @@ Our proposal is this:
   - Links to functions are written with a `()` suffix,
     e.g., `Also see the [foo()] function`.
   - Links to constants are prefixed with `const `,
-    e.g., `As defined in [const FOO].`
+    e.g., `As defined in [const@FOO].`
   - Links to statics are prefixed with `static `,
-    e.g., `See [static FOO]`.
+    e.g., `See [static@FOO]`.
 
 It should be noted that in the RFC discussion it was determined
 that exact knowledge of the item type

--- a/text/1946-intra-rustdoc-links.md
+++ b/text/1946-intra-rustdoc-links.md
@@ -292,24 +292,37 @@ Our proposal is this:
   Non-disambiguated paths cannot be used to link to macros.
 - Links to types can be disambiguated by prefixing them with the concrete
   item type:
+  - Links to any type-namespace object can be prefixed with `type@`,
+    e.g., `See [type@foo]`. This will work for structs, enums, mods, traits,
+    and unions.
   - Links to `struct`s can be prefixed with `struct@`,
     e.g., `See [struct@Foo]`.
   - Links to `enum`s can be prefixed with `enum@`,
     e.g., `See [enum@foo]`.
-  - Links to type aliases can be prefixed with `type@`,
-    e.g., `See [type@foo]`.
   - Links to modules can be prefixed with `mod@`,
     e.g., `See [mod@foo]`.
+  - Links to traits can be prefixed with `trait@`,
+    e.g., `See [trait@foo]`.
+  - Links to unions can be prefixed with `union@`,
+    e.g., `See [union@foo]`.
+  - It is possible that disambiguators for one kind of type-namespace object
+    will work for the other (i.e. you can use `struct@` to refer to an enum),
+    but do not rely on this.
 - In links to macros,
   the link label _must_ end with a `!`,
-  e.g., `Look at the [FOO!] macro`.
+  e.g., `Look at the [FOO!] macro`. You can alternatively use a `foo@` prefix,
+  e.g. `[macro@foo]`
 - For disambiguating links to values, we differentiate three cases:
+  - Links to any kind of value (function, const, static) can be prefixed with `value@`,
+    e.g., `See [value@foo]`.
   - Links to functions can be written with a `()` suffix,
     e.g., `Also see the [foo()] function`.
   - Links to constants are prefixed with `const@`,
     e.g., `As defined in [const@FOO].`
   - Links to statics are prefixed with `static@`,
     e.g., `See [static@FOO]`.
+  - It is possible that disambiguators for one kind of type-namespace object
+    will work for the other (i.e. you can use `static@` to refer to a const),
 
 For disambiguation markers using an `@`, in implied shortcut links
 you can use a space instead of the `@`. In other words, `[struct Foo]`

--- a/text/1946-intra-rustdoc-links.md
+++ b/text/1946-intra-rustdoc-links.md
@@ -284,29 +284,36 @@ To be able to link to each item,
 we'll need a way to disambiguate the namespaces.
 Our proposal is this:
 
-- Links to types are written as described earlier,
-  with no pre- or suffix,
-  e.g., `Look at the [FOO] trait`.
-  For consistency,
-  it is also possible to prefix the type with the concrete item type:
-  - Links to `struct`s can be prefixed with `struct `,
+- In unambiguous cases paths can be written as described earlier,
+  with no pre- or suffix, e.g., `Look at the [FOO] trait`. This also
+  applies to modules and tuple structs which exist in both namespaces.
+  Rustdoc will throw an error if you use a non-disambiguated path in
+  the case of there being a value in both the type and value namespace.
+  Non-disambiguated paths cannot be used to link to macros.
+- Links to types can be disambiguated by prefixing them with the concrete
+  item type:
+  - Links to `struct`s can be prefixed with `struct@`,
     e.g., `See [struct@Foo]`.
-  - Links to `enum`s can be prefixed with `enum `,
+  - Links to `enum`s can be prefixed with `enum@`,
     e.g., `See [enum@foo]`.
-  - Links to type aliases can be prefixed with `type `,
+  - Links to type aliases can be prefixed with `type@`,
     e.g., `See [type@foo]`.
-  - Links to modules can be prefixed with `mod `,
+  - Links to modules can be prefixed with `mod@`,
     e.g., `See [mod@foo]`.
 - In links to macros,
-  the link label must end with a `!`,
+  the link label _must_ end with a `!`,
   e.g., `Look at the [FOO!] macro`.
-- For links to values, we differentiate three cases:
-  - Links to functions are written with a `()` suffix,
+- For disambiguating links to values, we differentiate three cases:
+  - Links to functions can be written with a `()` suffix,
     e.g., `Also see the [foo()] function`.
-  - Links to constants are prefixed with `const `,
+  - Links to constants are prefixed with `const@`,
     e.g., `As defined in [const@FOO].`
-  - Links to statics are prefixed with `static `,
+  - Links to statics are prefixed with `static@`,
     e.g., `See [static@FOO]`.
+
+For disambiguation markers using an `@`, in implied shortcut links
+you can use a space instead of the `@`. In other words, `[struct Foo]`
+is fine (and preferred).
 
 It should be noted that in the RFC discussion it was determined
 that exact knowledge of the item type
@@ -316,7 +323,6 @@ allows (and successfully resolves) a link
 with the wrong prefix that is in the same namespace.
 E.g., given an `struct Foo`, it may be possible to link to it using `[enum Foo]`,
 or, given a `mod bar`, it may be possible to link to that using `[struct bar]`.
-
 
 ## Errors
 [errors]: #errors


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/47046, we realized that the proposed disambiguation syntax is not valid CommonMark, and changed it to `[struct@Foo]`, etc.

Additionally, we feel that you should be allowed to use un-disambiguated paths to refer to values as long as there isn't a clash.

cc @QuietMisdreavus @killercup