### PR TITLE
Add note to RFC 505 that it has been amended by RFC 1574

### DIFF
--- a/text/0505-api-comment-conventions.md
+++ b/text/0505-api-comment-conventions.md
@@ -2,6 +2,13 @@
 - RFC PR: [rust-lang/rfcs#505](https://github.com/rust-lang/rfcs/pull/505)
 - Rust Issue: N/A
 
+# Note
+
+This RFC has been amended by [RFC 1574], which contains [a combined version of the conventions][combined].
+
+[RFC 1574]: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md
+[combined]: https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text
+
 # Summary
 
 This is a conventions RFC, providing guidance on providing API documentation


### PR DESCRIPTION
RFC 1574 amended RFC 505. This change adds a note to the beginning of RFC 505, noting the amendment and linking to RFC 1574 and the combined version of the conventions contained in Appendix A of RFC 1574.