### PR TITLE
Issues are not feature requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ beforehand, to ascertain that the RFC may be desirable; having a consistent
 impact on the project requires concerted effort toward consensus-building.
 
 The most common preparations for writing and submitting an RFC include talking
-the idea over on #rust-internals, filing and discussing ideas on the
-[RFC issue tracker], and occasionally posting "pre-RFCs" on the
-[developer discussion forum] for early review.
+the idea over on #rust-internals, discussing the topic on our [developer discussion forum],
+and occasionally posting "pre-RFCs" on the developer forum. You may file issues
+on this repo for discussion, but these are not actively looked at by the teams.
 
 As a rule of thumb, receiving encouraging feedback from long-standing project
 developers, and particularly members of the relevant [sub-team] is a good


### PR DESCRIPTION
Currently issues get often used as feature requests, where they basically get ignored because nobody is watching the issues.

I'd like to propose we stop allowing issues as feature requests and severely restrict the issues on this repo to tracking issues
and general housekeeping.

We instead encourage feature requests to become discussions on the internals forum.