### PR TITLE
RFC: `Self` in type definitions allowing `enum List<T> { Nil, Cons(T, Box<Self>) }`

### DIFF
--- a/text/0000-self-in-typedefs.md
+++ b/text/0000-self-in-typedefs.md
@@ -391,7 +391,7 @@ When `Self` is used to construct an infinite type as in:
 ```rust
 enum List<T> {
     Nil,
-    Cons(T, List<T>)
+    Cons(T, Self)
 }
 ```
 


### PR DESCRIPTION
### [Rendered](https://github.com/Centril/rfcs/blob/rfc/self-in-typedefs/text/0000-self-in-typedefs.md)

-----------------------

The special `Self` identifier is now permitted in `struct`, `enum`, and `union`
type definitions. A simple example `struct` is:

```rust
enum List<T> {
    Nil,
    Cons(T, Box<Self>) // <-- Notice the `Self` instead of `List<T>`
}
```

-----------------------

Thanks to @eddyb for giving me the idea, and among others to @est31 for reviewing.