### PR TITLE
Workaround google/pulldown-cmark#124 which has broken #1860 and #1990

### DIFF
--- a/text/1860-manually-drop.md
+++ b/text/1860-manually-drop.md
@@ -137,7 +137,7 @@ the structure fields gets dropped.
 <!--
 # Drawbacks
 [drawbacks]: #drawbacks
-
+--
 No drawbacks known at the time.
 -->
 

--- a/text/1990-external-doc-attribute.md
+++ b/text/1990-external-doc-attribute.md
@@ -1,12 +1,12 @@
 <!---
-Copyright 2017 The Rust Project Developers. See the COPYRIGHT
-file at the top-level directory of this distribution.
-
-Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-<LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-option. This file may not be copied, modified, or distributed
-except according to those terms.
+-- Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+-- file at the top-level directory of this distribution.
+--
+-- Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+-- http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+-- <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+-- option. This file may not be copied, modified, or distributed
+-- except according to those terms.
 -->
 
 - Feature Name: external_doc


### PR DESCRIPTION
Currently the page is empty http://rust-lang.github.io/rfcs/1990-external-doc-attribute.html because the license header contains a blank line.