### PR TITLE
Markdown style link for mdbook (same as #2199)

### DIFF
--- a/text/1909-unsized-rvalues.md
+++ b/text/1909-unsized-rvalues.md
@@ -1,7 +1,7 @@
 - Feature Name: unsized_locals
 - Start Date: 2017-02-11
-- RFC PR: https://github.com/rust-lang/rfcs/pull/1909
-- Rust Issue: https://github.com/rust-lang/rust/issues/48055
+- RFC PR: [rust-lang/rfcs#1909](https://github.com/rust-lang/rfcs/pull/1909)
+- Rust Issue: [rust-lang/rust#48055](https://github.com/rust-lang/rust/issues/48055)
 
 # Summary
 [summary]: #summary

--- a/text/2056-allow-trivial-where-clause-constraints.md
+++ b/text/2056-allow-trivial-where-clause-constraints.md
@@ -1,7 +1,7 @@
 - Feature Name: `allow_trivial_constraints`
 - Start Date: 2017-07-05
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2056
-- Rust Issue: https://github.com/rust-lang/rust/issues/48214
+- RFC PR: [rust-lang/rfcs#2056](https://github.com/rust-lang/rfcs/pull/2056)
+- Rust Issue: [rust-lang/rust#48214](https://github.com/rust-lang/rust/issues/48214)
 
 # Summary
 [summary]: #summary

--- a/text/2091-inline-semantic.md
+++ b/text/2091-inline-semantic.md
@@ -1,7 +1,7 @@
 - Feature Name: `track_caller`
 - Start Date: 2017-07-31
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2091
-- Rust Issue: https://github.com/rust-lang/rust/issues/47809
+- RFC PR: [rust-lang/rfcs#2091](https://github.com/rust-lang/rfcs/pull/2091)
+- Rust Issue: [rust-lang/rust#47809](https://github.com/rust-lang/rust/issues/47809)
 
 ----
 

--- a/text/2116-alloc-me-maybe.md
+++ b/text/2116-alloc-me-maybe.md
@@ -1,7 +1,7 @@
 - Feature Name: fallible_collection_alloc
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2116
-- Rust Issue: https://github.com/rust-lang/rust/issues/48043
+- RFC PR: [rust-lang/rfcs#2116](https://github.com/rust-lang/rfcs/pull/2116)
+- Rust Issue: [rust-lang/rust#48043](https://github.com/rust-lang/rust/issues/48043)
 
 # Summary
 [summary]: #summary

--- a/text/2136-build-systems.md
+++ b/text/2136-build-systems.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2017-09-01
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2136
+- RFC PR: [rust-lang/rfcs#2136](https://github.com/rust-lang/rfcs/pull/2136)
 - Rust Issue: N/A
 
 # Summary

--- a/text/2145-type-privacy.md
+++ b/text/2145-type-privacy.md
@@ -1,7 +1,7 @@
 - Feature Name: N/A
 - Start Date: 2017-09-09
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2145
-- Rust Issue: https://github.com/rust-lang/rust/issues/48054
+- RFC PR: [rust-lang/rfcs#2145](https://github.com/rust-lang/rfcs/pull/2145)
+- Rust Issue: [rust-lang/rust#48054](https://github.com/rust-lang/rust/issues/48054)
 
 # Summary
 [summary]: #summary

--- a/text/2166-impl-only-use.md
+++ b/text/2166-impl-only-use.md
@@ -1,7 +1,7 @@
 - Feature Name: impl-only-use
 - Start Date: 2017-10-01
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2166
-- Rust Issue: https://github.com/rust-lang/rust/issues/48216
+- RFC PR: [rust-lang/rfcs#2166](https://github.com/rust-lang/rfcs/pull/2166)
+- Rust Issue: [rust-lang/rust#48216](https://github.com/rust-lang/rust/issues/48216)
 
 # Summary
 [summary]: #summary

--- a/text/2175-if-while-or-patterns.md
+++ b/text/2175-if-while-or-patterns.md
@@ -1,7 +1,7 @@
 - Feature Name: if_while_or_patterns
 - Start Date: 2017-10-16
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2175
-- Rust Issue: https://github.com/rust-lang/rust/issues/48215
+- RFC PR: [rust-lang/rfcs#2175](https://github.com/rust-lang/rfcs/pull/2175)
+- Rust Issue: [rust-lang/rust#48215](https://github.com/rust-lang/rust/issues/48215)
 
 # Summary
 [summary]: #summary

--- a/text/2195-really-tagged-unions.md
+++ b/text/2195-really-tagged-unions.md
@@ -1,6 +1,6 @@
 - Feature Name: really_tagged_unions
 - Start Date: 2017-10-30
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2195/
+- RFC PR: [rust-lang/rfcs#2195](https://github.com/rust-lang/rfcs/pull/2195)
 - Rust Issue: N/A
 
 # Summary


### PR DESCRIPTION
This work is the same as #2199; converts raw URL strings to Markdown style links.

It may be better to make `generate-book.sh` do this conversion automatically.