### PR TITLE
RFC: Add `is_sorted` to the standard library

### DIFF
--- a/text/0000-is-sorted.md
+++ b/text/0000-is-sorted.md
@@ -19,7 +19,7 @@ is sorted. The most important use cases are probably **unit tests** and
 The lack of an `is_sorted()` function in Rust's standard library has led to
 [countless programmers implementing their own](https://github.com/search?l=Rust&q=%22fn+is_sorted%22&type=Code&utf8=%E2%9C%93).
 While it is possible to write a one-liner using iterators (e.g.
-`(0..arr.len() - 1).all(|i| arr[i] < arr[i + 1])`), it is still unnecessary
+`(0..arr.len() - 1).all(|i| arr[i] <= arr[i + 1])`), it is still unnecessary
 overhead while writing *and* reading the code.
 
 In [the corresponding issue on the main repository](https://github.com/rust-lang/rust/issues/44370)

--- a/text/0000-is-sorted.md
+++ b/text/0000-is-sorted.md
@@ -19,8 +19,8 @@ is sorted. The most important use cases are probably **unit tests** and
 The lack of an `is_sorted()` function in Rust's standard library has led to
 [countless programmers implementing their own](https://github.com/search?l=Rust&q=%22fn+is_sorted%22&type=Code&utf8=%E2%9C%93).
 While it is possible to write a one-liner using iterators (e.g.
-`(0..arr.len() - 1).all(|i| arr[i] <= arr[i + 1])`), it is still unnecessary
-overhead while writing *and* reading the code.
+`(0..arr.len() - 1).all(|i| arr[i] <= arr[i + 1])`¹), it is still unnecessary
+mental overhead while writing *and* reading the code.
 
 In [the corresponding issue on the main repository](https://github.com/rust-lang/rust/issues/44370)
 (from which a few comments are referenced) everyone seems to agree on the
@@ -39,6 +39,12 @@ D's [`std.algorithm.sorting.is_sorted`](https://dlang.org/library/std/algorithm/
 and others. (Curiously, many (mostly) more high-level programming language –
 like Ruby, Javascript, Java, Haskell and Python – seem to lack such a function.)
 
+¹ In the initial version of this RFC, this code snippet contained a bug
+(`<` instead of `<=`). This subtle mistake happens very often: in this RFC,
+[in the discussion thread about this RFC](https://github.com/rust-lang/rfcs/pull/2351#issuecomment-370126518),
+in [this StackOverflow answer](https://stackoverflow.com/posts/51272639/revisions)
+and in many more places. Thus, avoiding this common bug is another good
+reason to add `is_sorted()`.
 
 ## Fast Implementation via SIMD
 

--- a/text/0000-is-sorted.md
+++ b/text/0000-is-sorted.md
@@ -23,7 +23,7 @@ While it is possible to write a one-liner using iterators (e.g.
 overhead while writing *and* reading the code.
 
 In [the corresponding issue on the main repository](https://github.com/rust-lang/rust/issues/44370)
-(from which I will reference a few comments) everyone seems to agree on the
+(from which a few comments are referenced) everyone seems to agree on the
 basic premise: we want such a function.
 
 Having `is_sorted()` and friends in the standard library would:

--- a/text/0000-is-sorted.md
+++ b/text/0000-is-sorted.md
@@ -40,6 +40,16 @@ and others. (Curiously, many (mostly) more high-level programming language –
 like Ruby, Javascript, Java, Haskell and Python – seem to lack such a function.)
 
 
+## Fast Implementation via SIMD
+
+Lastly, it is possible to implement `is_sorted` for many common types with SIMD
+instructions which improves speed significantly. It is unlikely that many
+programmers will take the time to write SIMD code themselves, thus everyone
+would benefit if this rather difficult implementation work is done in the
+standard library.
+
+
+
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
@@ -162,10 +172,8 @@ condition `a <= b` holds. For slices/iterators with zero or one element,
 the function returns `false` if any two consecutive elements are not
 comparable (this is an implication of the `a <= b` condition from above).
 
-A note about implementation: it's sufficient to only do real work in
-`Iterator::is_sorted_by`. All other methods can simply be implemented by
-(directly or indirectly) using `Iterator::is_sorted_by`. A sample
-implementation can be found [here](https://play.rust-lang.org/?gist=431ff42fe8ba5980fcf9250c8bc4492b&version=stable).
+A sample implementation can be found
+[here](https://play.rust-lang.org/?gist=431ff42fe8ba5980fcf9250c8bc4492b&version=stable).
 
 
 # Drawbacks

--- a/text/2351-is-sorted.md
+++ b/text/2351-is-sorted.md
@@ -1,7 +1,7 @@
-- Feature Name: is_sorted
+- Feature Name: `is_sorted`
 - Start Date: 2018-02-24
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: [rust-lang/rfcs#2351](https://github.com/rust-lang/rfcs/pull/2351)
+- Rust Issue: [rust-lang/rust#53485](https://github.com/rust-lang/rust/issues/53485)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
Add the methods `is_sorted`, `is_sorted_by` and `is_sorted_by_key` to `[T]` and `Iterator`.

[**Rendered**](https://github.com/LukasKalbertodt/rfcs/blob/rfc-add-is-sorted/text/0000-is-sorted.md)

---

CC https://github.com/rust-lang/rust/issues/44370

EDIT: I posted [a comment](https://github.com/rust-lang/rfcs/pull/2351#issuecomment-380724938) summarizing the discussion so far.