### PR TITLE
Fix pseudocode typo in RFC 1951

### DIFF
--- a/text/1951-expand-impl-trait.md
+++ b/text/1951-expand-impl-trait.md
@@ -222,7 +222,7 @@ fn foo<T, U>(t: T, u: U) where
 
 fn foo(
     t: impl Whatever + SomethingElse,
-    u: impl,
+    u: impl Whatever,
 )
 ```
 


### PR DESCRIPTION
I believe this `Whatever` was accidentally left out.