### PR TITLE
Typo: Change exists to exist in template.md#prior-art

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -55,7 +55,7 @@ Why should we *not* do this?
 Discuss prior art, both the good and the bad, in relation to this proposal.
 A few examples of what this can include are:
 
-- For language, library, cargo, tools, and compiler proposals: Does this feature exists in other programming languages and what experience have their community had?
+- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
 - For community proposals: Is this done by some other community and what were their experiences with it?
 - For other teams: What lessons can we learn from what other communities have done here?
 - Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.


### PR DESCRIPTION
In `0000-template.md`, in the section "Prior Art", IMO "exist" is the correct form of the verb in the first bullet point.