### PR TITLE
Fix typo in 2349-pin.md

### DIFF
--- a/text/2349-pin.md
+++ b/text/2349-pin.md
@@ -231,7 +231,7 @@ impl<T: ?Sized> PinBox<T> {
 ```
 
 These APIs make `PinBox` a reasonable way of handling data which does not
-implement `!Unpin`. Once you heap allocate that data inside of a `PinBox`, you
+implement `Unpin`. Once you heap allocate that data inside of a `PinBox`, you
 know that it will never change address again, and you can hand out `Pin`
 references to that data.
 


### PR DESCRIPTION
This double-negation ("not implement `!Unpin`") looks like a typo. `PinBox` is useful for immovable types (which do not implement `Unpin`), right?