### PR TITLE
Unstable features accidentally usable on the Stable release chanel are still unstable

### DIFF
--- a/text/1105-api-evolution.md
+++ b/text/1105-api-evolution.md
@@ -22,6 +22,10 @@ The RFC covers only API issues; other issues related to language features,
 lints, type inference, command line arguments, Cargo, and so on are considered
 out of scope.
 
+The stability promise specifically does *not* apply to unstable features,
+even if they are accidentally usable on the Stable release channel
+under certain conditions such as because of bugs in the compiler.
+
 # Motivation
 
 Both Rust and its library ecosystem have adopted [semver](http://semver.org/), a


### PR DESCRIPTION
In some cases, it is possible to use unstable features on the Stable release channel. For example:

* In expressions, only the final components of a `foo::bar::baz` path is checked for stability: https://github.com/rust-lang/rust/issues/15702. (See for example https://github.com/rust-lang/rust/pull/49896#issuecomment-381292836.)
* By creating a crate named `test` or with some other name of a standard library crate, is it possible to override what is called by some compiler-generated code. Things break when the signature of those calls later change: https://github.com/rust-lang/rust/issues/49942
* Using the bootstrap flag

This PR proposes that the semantic versioning / stability promise normally associated to the Stable release channel specifically do *not* extend to such cases. Finding a way to bypass the stability system should not be sufficient to make unstable features de-facto stable.