### PR TITLE
RFC 2349: Conform to header format

### DIFF
--- a/text/2349-pin.md
+++ b/text/2349-pin.md
@@ -1,7 +1,7 @@
-- Feature Name: pin
+- Feature Name: `pin`
 - Start Date: 2018-02-19
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2349
-- Rust Issue: https://github.com/rust-lang/rust/issues/49150
+- RFC PR: [rust-lang/rfcs#2349](https://github.com/rust-lang/rfcs/pull/2349)
+- Rust Issue: [rust-lang/rust#49150](https://github.com/rust-lang/rust/issues/49150)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
Fix the formatting at the top of `2349-pin.md`.