### PR TITLE
0000-template.md: Encourage discussion of maintenance

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -23,6 +23,7 @@ Explain the proposal as if it was already included in the language and you were 
 - Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 - If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+- Discuss how this impacts the ability to read, understand, and maintain Rust code. Code is read and modified far more often than written; how will the proposed feature make code easier to maintain?
 
 For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
@@ -48,6 +49,7 @@ Why should we *not* do this?
 - Why is this design the best in the space of possible designs?
 - What other designs have been considered and what is the rationale for not choosing them?
 - What is the impact of not doing this?
+- If this is a language proposal, could this be done in a library or macro instead? Does the proposed change make Rust code easier or harder to read, understand, and maintain?
 
 # Prior art
 [prior-art]: #prior-art

--- a/0000-template.md
+++ b/0000-template.md
@@ -23,7 +23,7 @@ Explain the proposal as if it was already included in the language and you were 
 - Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 - If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
-- Discuss how this impacts the ability to read, understand, and maintain Rust code. Code is read and modified far more often than written; how will the proposed feature make code easier to maintain?
+- Discuss how this impacts the ability to read, understand, and maintain Rust code. Code is read and modified far more often than written; will the proposed feature make code easier to maintain?
 
 For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 


### PR DESCRIPTION
Add some points to encourage RFCs to discuss how a proposal impacts the
ease of reading, understanding, and maintaining Rust code, not just the
ease of writing it.

Inspired by many recent discussions on proposed language features.

cc @rust-lang/lang