### PR TITLE
Add a link to https://rfcbot.rs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Rust RFCs
+# Rust RFCs - [Active RFC List](https://rfcbot.rs/)
+
 [Rust RFCs]: #rust-rfcs
 
 Many changes, including bug fixes and documentation improvements can be


### PR DESCRIPTION
Fixes #2454

WDYT of just adding it next to the title? Or should it be lower down somewhere?