### PR TITLE
[mdbook] Disable the Search Index

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,2 +1,6 @@
 [output.html]
 no-section-label = true
+
+[output.html.search]
+# Don't generate the search index, which is currently 38MB.
+copy-js = false


### PR DESCRIPTION
This PR prevents `mdbook` from generating `searchindex.js` and related files. This means that searching the content at http://rust-lang.github.io/rfcs/ will no longer work.

`searchindex.js` currently contains 38MB(!!) of JavaScript. Even when compressed, that's still around 6MB. Aside from being unreasonably large, this also causes Mobile Safari to crash the tab.

Search functionality is still available on the GitHub repo, so I suggest disabling the search index until its size can somehow be reduced.