### PR TITLE
[mdbook] Disable jekyll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ script:
   - git fetch upstream
   - git reset upstream/gh-pages
   - touch .
+  # We don't use jekyll. Disable it so it doesn't assign special meaning to any
+  # of our files (e.g. ignoring directories with a leading '_').
+  - touch .nojekyll
   - git add -A .
   - git commit -m "Rebuild book at ${rev}"
   - git push -q upstream HEAD:gh-pages > /dev/null 2>&1


### PR DESCRIPTION
We don't use jekyll, however it is enabled by default for `gh-pages`, which causes [directories with a leading '_' to  not be served](https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/). This, in turn, causes the `/_FontAwesome/*` paths generated by `mdbook` to 404.

r? @rust-lang/docs 