### PR TITLE
Update RFC 0430 to allow underscores between numbers in CamelCase names

### DIFF
--- a/text/0430-finalizing-naming-conventions.md
+++ b/text/0430-finalizing-naming-conventions.md
@@ -46,6 +46,9 @@ precisely, the proposed (and mostly followed) conventions are:
 In `UpperCamelCase`, acronyms count as one word: use `Uuid` rather than
 `UUID`.  In `snake_case`, acronyms are lower-cased: `is_xid_start`.
 
+In `UpperCamelCase` names multiple numbers can be separated by a `_`
+for clarity: `Windows10_1709` instead of `Windows101709`.
+
 In `snake_case` or `SCREAMING_SNAKE_CASE`, a "word" should never
 consist of a single letter unless it is the last "word". So, we have
 `btree_map` rather than `b_tree_map`, but `PI_2` rather than `PI2`.


### PR DESCRIPTION
See rust-lang/rust#46907

Note: This is already implement and in stable (without RFC). It just updates the text to avoid confusion and to make this better known.

Found this while editing #2457.