### PR TITLE
Fix in-band lifetimes example with backreferences

### DIFF
--- a/text/2115-argument-lifetimes.md
+++ b/text/2115-argument-lifetimes.md
@@ -334,8 +334,8 @@ tomorrow you would write:
 
 ```rust
 fn elided(&self) -> &str
-fn two_args(arg1: &Foo, arg2: &Bar) -> &'arg2 Baz
-fn two_lifetimes(arg1: &Foo, arg2: &Bar) -> &'arg1 Quux<'arg2>
+fn two_args(arg1: &Foo, arg2: &'a Bar) -> &'a Baz
+fn two_lifetimes(arg1: &'a Foo, arg2: &'b Bar) -> &'a Quux<'b>
 
 impl MyStruct<'A> {
     fn foo(&self) -> &'A str


### PR DESCRIPTION
Backreferences are listed as a "possible extension or alternative" in RFC #2115, so the examples should not include them. This is further reinforced by commit c20ea6db254feac3536de7ae8a13bfdee2b07b42, which appears to have been intended to remove all instances of backreferences in the examples, but missed these. (Note, in particular, that the commit removed the backreferences in the example in the Summary section, and the two lines fixed in this PR are identical to two of the lines changed in that commit.)

@dhardy also [observed this issue](https://github.com/rust-lang/rfcs/pull/2115#issuecomment-329122960).