### PR TITLE
Fix inconsistency in in-band-lifetimes RFC

### DIFF
--- a/text/2115-argument-lifetimes.md
+++ b/text/2115-argument-lifetimes.md
@@ -334,8 +334,8 @@ tomorrow you would write:
 
 ```rust
 fn elided(&self) -> &str
-fn two_args(arg1: &Foo, arg2: &Bar) -> &'arg2 Baz
-fn two_lifetimes(arg1: &Foo, arg2: &Bar) -> &'arg1 Quux<'arg2>
+fn two_args(arg1: &Foo, arg2: &'arg2 Bar) -> &'arg2 Baz
+fn two_lifetimes(arg1: &'arg1 Foo, arg2: &'arg2 Bar) -> &'arg1 Quux<'arg2>
 
 impl MyStruct<'A> {
     fn foo(&self) -> &'A str


### PR DESCRIPTION
As noted [here](https://github.com/rust-lang/rfcs/pull/2115/commits/c20ea6db254feac3536de7ae8a13bfdee2b07b42#r135393851) two of the function signatures missed the update from backreferences to in-band declaration.