### PR TITLE
RFC: letrec

### DIFF
--- a/text/0000-letrec.md
+++ b/text/0000-letrec.md
@@ -1,0 +1,98 @@
+- Feature Name: letrec
+- Start Date: 2018-09-26
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+A new syntax keyword `letrec`, for recursive local binding.
+
+# Motivation
+[motivation]: #motivation
+
+By using the `letrec` keyword, we can make local recursive closures.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+The `letrec` keyword is similar to `let`,
+it should only be used when its right hand side is a closure,
+it is different from `let` in that,
+the binding introduced by `letrec`
+is effective in the body of the closure at the right hand side.
+
+```rust
+fn sum (
+    term: &impl Fn (f64) -> f64, a: f64,
+    next: &impl Fn (f64) -> f64, b: f64,
+) -> f64 {
+    letrec sum_iter = |a, result| {
+        if a > b {
+            result
+        } else {
+            sum_iter (next (a), term (a) + result)
+        }
+    };
+    sum_iter (a, 0.0)
+}
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The semantics and implementation of the `letrec` keyword
+is well understood in functional languages such as Scheme and Ocaml.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+No known drawbacks.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+Without recursive local binding,
+the example above must be written as the folllowing:
+
+(in which, the recursive local binding
+must be defined as a global auxiliary function
+with extra arguments.)
+
+```rust
+fn sum_iter (
+    term: &impl Fn (f64) -> f64, a: f64,
+    next: &impl Fn (f64) -> f64, b: f64,
+    result: f64,
+) -> f64 {
+    if a > b {
+        result
+    } else {
+        sum_iter (
+            term, next (a),
+            next, b,
+            term (a) + result)
+    }
+}
+
+fn sum (
+    term: &impl Fn (f64) -> f64, a: f64,
+    next: &impl Fn (f64) -> f64, b: f64,
+) -> f64 {
+    sum_iter (term, a, next, b, 0.0)
+}
+```
+
+There are known workaround when the language itself does not support recursive local binding.
+For example,
+in https://stackoverflow.com/questions/16946888/is-it-possible-to-make-a-recursive-closure-in-rust
+auxiliary local struct is used.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+Also semantics and implementation of `letrec` is well known,
+but it still a state of art syntax keyword.
+
+It is still challenging to implement it well,
+specially when adding it to an existing language implementation.


### PR DESCRIPTION
[Rendered](https://github.com/xieyuheng/rfcs/blob/master/text/0000-letrec.md)

In another note about the motivation.

While making an attempt to teach Rust as first programming language,
I looked into existing arts of teaching first programming language.

"Structure and Interpretation of Computer Programs" (a.k.a. SICP)
by Harold Abelson and Gerald Jay Sussman,
is one of the best one I have ever known.

It is written for the dynamic language Scheme.

I am trying to translate it to idiomatic Rust,
also adding some narratives about Rust's type system and borrow checker.

Hopefully, at least I can provide some good reading materials for new programmers
who wish to study Rust as her or his first programming language.

While making this attempt, this "letrec problem" occurs.

Please review the RFC for details about `letrec`.
