### PR TITLE
Convert raw-string URLs to Markdown

### DIFF
--- a/text/2169-euclidean-modulo.md
+++ b/text/2169-euclidean-modulo.md
@@ -1,7 +1,7 @@
 - Feature Name: `euclidean_modulo`
 - Start Date: 2017-10-09
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2169
-- Rust Issue: https://github.com/rust-lang/rust/issues/49048
+- RFC PR: [rust-lang/rfcs#2169](https://github.com/rust-lang/rfcs/pull/2169)
+- Rust Issue: [rust-lang/rust#49048](https://github.com/rust-lang/rust/issues/49048)
 
 # Summary
 [summary]: #summary

--- a/text/2226-fmt-debug-hex.md
+++ b/text/2226-fmt-debug-hex.md
@@ -1,7 +1,7 @@
 - Feature Name: fmt-debug-hex
 - Start Date: 2017-11-24
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2226
-- Rust Issue: https://github.com/rust-lang/rust/issues/48584
+- RFC PR: [rust-lang/rfcs#2226](https://github.com/rust-lang/rfcs/pull/2226)
+- Rust Issue: [rust-lang/rust#48584](https://github.com/rust-lang/rust/issues/48584)
 
 # Summary
 [summary]: #summary

--- a/text/2230-bury-description.md
+++ b/text/2230-bury-description.md
@@ -1,6 +1,6 @@
 - Feature Name: optional_error_description
 - Start Date: 2017-11-29
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2230
+- RFC PR: [rust-lang/rfcs#2230](https://github.com/rust-lang/rfcs/pull/2230)
 - Rust Issue: (leave this empty)
 
 # Default implementation of `Error::description()`

--- a/text/2314-roadmap-2018.md
+++ b/text/2314-roadmap-2018.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2018-01-23
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2314
+- RFC PR: [rust-lang/rfcs#2314](https://github.com/rust-lang/rfcs/pull/2314)
 - Rust Issue: N/A
 
 # Summary

--- a/text/2394-async_await.md
+++ b/text/2394-async_await.md
@@ -1,7 +1,7 @@
 - Feature Name: async_await
 - Start Date: 2018-03-30
-- RFC PR: https://github.com/rust-lang/rfcs/pull/2394
-- Rust Issue: https://github.com/rust-lang/rust/issues/50547
+- RFC PR: [rust-lang/rfcs#2394](https://github.com/rust-lang/rfcs/pull/2394)
+- Rust Issue: [rust-lang/rust#50547](https://github.com/rust-lang/rust/issues/50547)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
Raw-string URLs (e.g. `https://github.com/rust-lang/rfcs/pull/2169`) is not rendered as URLs on http://rust-lang.github.io/rfcs/.
So I converted them to markdown style URLs.

I used this script:

```bash
#!/bin/sh

sed -Ei 's$RFC PR: https://github.com/rust-lang/rfcs/pull/([0-9]+)\/?$RFC PR: [rust-lang/rfcs#\1](https://github.com/rust-lang/rfcs/pull/\1)$' text/*.md
sed -Ei 's$Rust Issue: https://github.com/rust-lang/rust/issues/([0-9]+)\/?$Rust Issue: [rust-lang/rust#\1](https://github.com/rust-lang/rust/issues/\1)$' text/*.md
```