### PR TITLE
cfg-attr-multi: Fix typo

### DIFF
--- a/text/2539-cfg_attr-multiple-attrs.md
+++ b/text/2539-cfg_attr-multiple-attrs.md
@@ -102,7 +102,7 @@ fn bewitche() {}
 Note: The `cfg_attr` can expand to another `cfg_attr`. For example,
 `#[cfg_attr(linux, cfg_attr(feature = "multithreaded", some_other_attribute))`
 is valid. This example would be equivalent to
-`#[cfg_attr(and(linux, feaure ="multithreaded"), some_other_attribute)]`.
+`#[cfg_attr(all(linux, feaure ="multithreaded"), some_other_attribute)]`.
 
 ## Warning When Zero Attributes
 


### PR DESCRIPTION
`and()` is not a valid configuration predicate, but `all()` is.