### PR TITLE
RFC: Attributes in formal function parameter position

### DIFF
--- a/text/2540-formal-function-parameter-attributes.md
+++ b/text/2540-formal-function-parameter-attributes.md
@@ -36,7 +36,11 @@ For raw pointers that are oftentimes used when operating with C code one could p
 You could for example mirror C's restrict keyword or even be more explicit by stating what pointer argument might overlap.
 
 ```rust
-fn foo(#[overlaps_with(in_b) in_a: *const u8, #[overlaps_with(in_a)] in_b: *const u8, #[restrict] out: *mut u8);
+fn foo(
+ #[overlaps_with(in_b)] in_a: *const u8,
+ #[overlaps_with(in_a)] in_b: *const u8,
+ #[restrict] out: *mut u8
+);
 ```
 
 Which might state that the pointers `in_a` and `in_b` might overlap but `out` is non overlapping.
@@ -52,7 +56,7 @@ Also procedural macros could greatly benefit from having their own defined custo
 Formal parameters of functions, methods, closures and functions in trait definitions may have attributes attached to them.
 This allows to provide additional information to a given formal parameter.
 
-To reify this we introduce the `#[unused]` attribute that states that the attributed parameter is unused in the associated implementation.
+For the next examples the hypothetical `#[unused]` attribute means that the attributed parameter is unused in the associated implementation.
 
 ## Examples
 

--- a/text/2540-formal-function-parameter-attributes.md
+++ b/text/2540-formal-function-parameter-attributes.md
@@ -16,7 +16,8 @@ Having attributes on formal function parameters allows for certain different use
 ## Example: Handling of unused parameter
 
 In today's Rust it is possible to prefix the name of an identifier to silence the compiler about it being unused.
-With attributes in formal function parameter position we could have an attribute like `#[unused]` that explicitely states this for a given parameter.
+With attributes in formal function parameter position we could hypothetically have an attribute like `#[unused]` that explicitely states this for a given parameter.
+Note that `#[unused]` is not part of this proposal but merely a simple usecase.
 
 ```rust
 fn foo(#[unused] bar: u32) -> bool;
@@ -28,7 +29,7 @@ Instead of
 fn foo(_bar: u32) -> bool
 ```
 
-This would better reflect the explicit nature of Rust compared to the underscore prefix as of today.
+Especially Rust beginners might find the meaning of the above code snippet to be clearer.
 
 ## Example: Low-level code
 
@@ -46,9 +47,36 @@ fn foo(
 Which might state that the pointers `in_a` and `in_b` might overlap but `out` is non overlapping.
 Please note that I am *not* proposing to actually add this to the language!
 
-## Example: Procedural Macros
+## Example: Usable with cfg_attr
 
-Also procedural macros could greatly benefit from having their own defined custom attributes on formal parameters.
+```rust
+fn foo(#[cfg_attr(foo, bar)] baz: u32);
+```
+
+Which states that `baz` is attributed with the attribute `bar` if `foo` evaluates to `true`.
+
+## Example: Documentation comments
+
+Since documentation comments are attributes in their underlying representation we could have doc comments
+for single parameters like shown below.
+
+```rust
+/// Description of foo.
+fn foo(
+ /// Description of foo's first parameter bar
+ bar: u32
+);
+```
+
+Of course this raises other questions:
+- How does rust-fmt handle these?
+- Are they allowed or should we postpone their allowance to another RFC?
+
+## Example: Procedural macros and custom attributes
+
+Also procedural macros and custom attributes could greatly benefit from having their own defined custom attributes on formal parameters.
+
+Examples will follow.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/2540-formal-function-parameter-attributes.md
+++ b/text/2540-formal-function-parameter-attributes.md
@@ -85,8 +85,6 @@ Other attributes might be very useful as for formal parameters in a method decla
 
 ## Errors & Warnings
 
-There are two errornous situations when it comes to 
-
 ### Warning: Unused attribute
 
 When using an non-defined attribute that is not used by either the language or a custom defined procedural macro.

--- a/text/2540-formal-function-parameter-attributes.md
+++ b/text/2540-formal-function-parameter-attributes.md
@@ -100,7 +100,7 @@ fn foo(#[unused] self, ..) { .. }
 fn foo(#[unused] &self, ..) { .. }
 fn foo(#[unused] &mut self, ..) { .. }
 
-// Closures & Lamdas
+// Closures
 |#[unused] x| { .. }
 ```
 
@@ -162,7 +162,7 @@ constructions like the following will become legal.
 - Function definitions
 - Method definitions
 - Trait function declarations and defnitions (with or without default impl)
-- Lambda & closure definitions
+- Closure definitions
 
 ### Example: A single attributed parameter for function decl or definition
 
@@ -196,7 +196,7 @@ fn foo(#[bar(Hello)] baz: bool);
 fn bar(#[qux(qiz = World)] baz: bool);
 ```
 
-### Example: Lambdas & closures
+### Example: Closures
 
 ```rust
 let mut v = [5, 4, 1, 3, 2];

--- a/text/2540-formal-function-parameter-attributes.md
+++ b/text/2540-formal-function-parameter-attributes.md
@@ -315,8 +315,8 @@ fn foo(#[inline] bar: u32) { .. }
 Let `OuterAttr` denote the production for an attribute `#[...]`.
 
 On the formal parameters of an `fn` item, including on method receivers,
-and irrespective of whether the `fn` has a body or not, `OuterAttr+` is allowed.
-For example, all the following are valid:
+and irrespective of whether the `fn` has a body or not, `OuterAttr+` is allowed
+but not required. For example, all the following are valid:
 
 ```rust
 fn g1(#[attr1] #[attr2] pat: Type) { .. }
@@ -334,10 +334,16 @@ fn g6<'a>(#[attr] &'a self) { .. }
 fn g7<'a>(#[attr] &'a mut self) { .. }
 
 fn g8(#[attr] self: Self) { .. }
+
+fn g9(#[attr] self: Rc<Self>) { .. }
 ```
 
 The attributes here apply to the parameter *as a whole*,
 e.g. in `g2`, `#[attr]` applies to `pat: Type` as opposed to `pat`.
+
+More generally, an `fn` item contains a list of formal parameters separated or
+terminated by `,` and delimited by `(` and `)`. Each parameter in that list may
+optionally be prefixed by `OuterAttr+`.
 
 ### Variadics
 
@@ -348,6 +354,8 @@ extern "C" {
     fn foo(x: u8, #[attr] ...);
 }
 ```
+
+That is, for the purposes of this RFC, `...` is considered as a parameter.
 
 ### Anonymous parameters in Rust 2015
 

--- a/text/2540-formal-function-parameter-attributes.md
+++ b/text/2540-formal-function-parameter-attributes.md
@@ -220,7 +220,7 @@ in the following example:
 fn foo(bar: bool);
 ```
 
-Note that this does not work in all situations (for example closures) and might invole even
+Note that this does not work in all situations (for example closures) and might involve even
 more complexity in user's code than simply allowing formal function parameter attributes.
 
 ## Impact

--- a/text/2540-formal-function-parameter-attributes.md
+++ b/text/2540-formal-function-parameter-attributes.md
@@ -1,0 +1,242 @@
+- Feature Name: formal_function_param_attrs
+- Start Date: 2018-10-14
+- RFC PR: 
+- Rust Issue: 
+
+# Summary
+[summary]: #summary
+
+This RFC proposes to allow attributes in formal function parameter position.
+
+# Motivation
+[motivation]: #motivation
+
+Having attributes on formal function parameters allows for certain different use cases.
+
+## Example: Handling of unused parameter
+
+In today's Rust it is possible to prefix the name of an identifier to silence the compiler about it being unused.
+With attributes in formal function parameter position we could have an attribute like `#[unused]` that explicitely states this for a given parameter.
+
+```rust
+fn foo(#[unused] bar: u32) -> bool;
+```
+
+Instead of
+
+```rust
+fn foo(_bar: u32) -> bool
+```
+
+This would better reflect the explicit nature of Rust compared to the underscore prefix as of today.
+
+## Example: Low-level code
+
+For raw pointers that are oftentimes used when operating with C code one could provide the compiler with additional information about the set of parameters.
+You could for example mirror C's restrict keyword or even be more explicit by stating what pointer argument might overlap.
+
+```rust
+fn foo(#[overlaps_with(in_b) in_a: *const u8, #[overlaps_with(in_a)] in_b: *const u8, #[restrict] out: *mut u8);
+```
+
+Which might state that the pointers `in_a` and `in_b` might overlap but `out` is non overlapping.
+Please note that I am *not* proposing to actually add this to the language!
+
+## Example: Procedural Macros
+
+Also procedural macros could greatly benefit from having their own defined custom attributes on formal parameters.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Formal parameters of functions, methods, closures and functions in trait definitions may have attributes attached to them.
+This allows to provide additional information to a given formal parameter.
+
+To reify this we introduce the `#[unused]` attribute that states that the attributed parameter is unused in the associated implementation.
+
+## Examples
+
+The syntax for this is demonstrated by the code below:
+
+```rust
+// Function
+fn foo(#[unused] bar: u32) { .. }
+
+// Methods & trait & definitions:
+// - `self` can also be attributed
+fn foo(#[unused] self, ..) { .. }
+fn foo(#[unused] &self, ..) { .. }
+fn foo(#[unused] &mut self, ..) { .. }
+
+// Closures & Lamdas
+|#[unused] x| { .. }
+```
+
+### Trait declarations
+
+```rust
+fn foo(#[unused] self);
+```
+
+Note that while the `#[unused]` attribute is syntactically
+possible to put here it doesn't actually make sense semantically
+since method declarations have no implementation.
+Other attributes might be very useful as for formal parameters in a method declaration.
+
+## Errors & Warnings
+
+There are two errornous situations when it comes to 
+
+### Warning: Unused attribute
+
+When using an non-defined attribute that is not used by either the language or a custom defined procedural macro.
+
+```
+warning: unused attribute
+ --> src/main.rs:2
+  |
+2 | #[foo] bar: u32
+  | ^^^^^^^^^
+  |
+  = note: #[warn(unused_attributes)] on by default
+```
+
+### Error: Malformed attribute
+
+When using a known attribute that is not defined for formal parameters such as when attributing `fn main` with `#[allow]`.
+
+Example shows the usage of the known attribute `#[inline]` used on a formal parameter without being defined for it.
+
+```
+error[E0452]: malformed lint attribute
+ --> src/main.rs:2
+  |
+2 | #[inline] bar: u32
+  | ^^^^^^^^
+```
+
+The same applies for attributes with an incorrect format such as `#[inline(key = value)]` that is handled as its done in other contexts.
+
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+## Description
+
+In accordance to the RFC for [attributes for generic params](https://github.com/frol/rust-rfcs/blob/master/text/1327-dropck-param-eyepatch.md)
+this feature is guarded by the `formal_function_param_attrs` feature guard.
+
+The grammar of the following language items has to be adjusted to allow that
+constructions like the following will become legal.
+
+- Function definitions
+- Method definitions
+- Trait function declarations and defnitions (with or without default impl)
+- Lambda & closure definitions
+
+### Example: A single attributed parameter for function decl or definition
+
+```rust
+fn foo(#[bar] baz: bool);
+fn bar(#[bar] qux: bool) { println!("hi"); }
+```
+
+### Example: For methods or trait function definitions
+
+```rust
+fn into_foo(#[bar] self);
+fn foo(#[bar] &self);
+fn foo_mut(#[bar] &mut self);
+```
+
+### Example: Multiple attributed parameters
+
+```rust
+// Twice the same attribute
+fn fst_foo(#[bar] baz: bool, #[bar] qiz: u32);
+
+// Different attributes
+fn snd_foo(#[bar] baz: bool, #[qux] qiz: u32);
+```
+
+### Example: Any structured attribute
+
+```rust
+fn foo(#[bar(Hello)] baz: bool);
+fn bar(#[qux(qiz = World)] baz: bool);
+```
+
+### Example: Lambdas & closures
+
+```rust
+let mut v = [5, 4, 1, 3, 2];
+v.sort_by(|#[bar] a, #[baz] b| a.cmp(b));
+```
+
+## Errors
+
+Users can encounter two different errorneous situations.
+
+### Unknown attribute used
+
+When a user is using an attribute that is not known at the point of its invokation
+a warning is generated similar to other usages of unknown attributes in the language.
+
+This may for example happen in the context of a procedural macros.
+
+### Malformed attribute
+
+When a user is using a known or language defined attribute at a non supported location
+an error is generated like in other usages of malformed attributes in the language.
+An example can be seen in the previous section.
+
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+All drawbacks for attributes in any location also count for this proposal.
+
+Having attributes in many different places of the language complicates its grammar.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+## Why is this proposal considered the best in the space of available ideas?
+
+This proposal clearly goes the path of having attributes in more places of the language.
+It nicely plays together with the advance of procedural macros and macros 2.0 where users
+can define their own attributes for their special purposes.
+
+## Alternatives
+
+An alternative to having attributes for formal parameters might be to just use the current
+set of available attributable items to store meta information about formal parameters like
+in the following example:
+
+```rust
+#[ignore(param = bar)]
+fn foo(bar: bool);
+```
+
+Note that this does not work in all situations (for example closures) and might invole even
+more complexity in user's code than simply allowing formal function parameter attributes.
+
+## Impact
+
+The impact will most certainly be that users might create custom attributes when
+designing procedural macros involving formal function parameters.
+
+There should be no breakage of existing code.
+
+# Prior art
+[prior-art]: #prior-art
+
+Some example languages that allows for attributes in formal function parameter positions are C# and C++.
+
+Also note that attributes in other parts of the Rust language could be considered prior art to this proposal.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+We might want to introduce new attributes for the language like the mentioned `#[unused]` attribute.
+However, this RFC proposes to decide upon this in another RFC.

--- a/text/2565-formal-function-parameter-attributes.md
+++ b/text/2565-formal-function-parameter-attributes.md
@@ -1,7 +1,7 @@
 - Feature Name: `param_attrs`
 - Start Date: 2018-10-14
-- RFC PR: 
-- Rust Issue: 
+- RFC PR: [rust-lang/rfcs#2565](https://github.com/rust-lang/rfcs/pull/2565)
+- Rust Issue: [rust-lang/rust#60406](https://github.com/rust-lang/rust/issues/60406)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
This RFC proposes to add attributes in formal function parameter position.

[Rendered](https://github.com/Robbepop/rfcs/blob/master/text/2540-formal-function-parameter-attributes.md)