### PR TITLE
Transparent Unions and Enums

### DIFF
--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Allow `#[repr(transparent)]` on `union`s an univariant `enum`s that have exactly one non-zero-sized field (just like `struct`s).
+Allow `#[repr(transparent)]` on `union`s and univariant `enum`s that have exactly one non-zero-sized field (just like `struct`s).
 
 # Motivation
 [motivation]: #motivation
@@ -135,6 +135,8 @@ Like transarent `struct`s, a transparent `union` of type `U` and transparent `en
 
 Like transparent `struct`s, transparent `union`s and `enum`s are FFI-safe if and only if their underlying representation type is also FFI-safe.
 
+A `union` may not be eligible for the same nonnull-style optimizations that a `struct` or `union` (with the same fields) are eligible for. Adding `#[repr(transparent)]` to  `union` does not change this. To give a more concrete example, it is unspecified whether `size_of::<T>()` is equal to `size_of::<Option<T>>()`, where `T` is a `union` (regardless of whether it is transparent). The Rust compiler is free to perform this optimization if possible, but is not required to, and different compiler versions may differ in their application of these optimizations.  
+
 # Drawbacks
 [drawbacks]: #drawbacks
 
@@ -217,7 +219,9 @@ In summary, many of the questions regarding `#[repr(transparent)]` on a `union` 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-None (yet).
+The role of `#[repr(transparent)]` in nonnull-style optimizations is not entirely clear. Specifically, it is unclear whether the user can rely on these optimizations to be performed when they make a type transparent. [Transparent `union`s somewhat complicate the matter](https://github.com/rust-lang/rfcs/pull/2645#issuecomment-470699497). General concensus seems to be that the compiler is free to decide where and when to perform nonnull-style optimizations on `union`s (regardless of whether or not the `union` is transaprent), and no guarantees are made to the user about when and if those optimizations will be applied. It is still an open question exactly what guarantees (if any) Rust makes about transparent `struct`s (and `enum`s) and nonnull-style optimizations.
+
+This RFC doesn't propose any changes to transparent `struct`s, and so does not strictly depend on this question being resolved. But since this RFC is attempting to round out the `#[repr(transparent)]` feature, it seems reasonable to dedicate some time to attempting to round out the guarantees about `#[repr(transparent)]` on `struct`s.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -85,7 +85,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 > https://github.com/rust-lang/rfcs/pull/1758#issuecomment-274670231
 > + **[joshtriplett][joshtriplett_1]:** "In terms of interactions with other features, I think this needs to specify what happens if you apply it to a union with one field, a union with multiple fields, a struct (tuple or otherwise) with multiple fields, a single-variant enum with one field, an enum struct variant where the enum uses `repr(u32)` or similar. The answer to some of those might be "compile error", but some of them (e.g. the union case) may potentially make sense in some contexts."
 
-> https://github.com/rust-lang/rfcs/pull/1758#issuecomment-290757356
+[pnkfelix_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-290757356
 > **pnkfelix:** "However, I personally do not think we need to expand the scope of the feature. So I am okay with leaving it solely defined on `struct`, and leave `union`/`enum` to a follow-on RFC later. (Much the same with a hypothetical `newtype` feature.)"
 
 In summary, many of the questions regarding `#[repr(transparent)]` on a `union` were the same as applying it to a multi-field `struct`. These questions have since been answered, so there should be no problems with applying those same answers to `union`.

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -78,7 +78,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 > + **nox:** "I tried to be conservative for now given I don't have a use case for univariant unions and enums in FFI context."
 
 [eddyb_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-254872520
-> **eddyb:** "I found another important usecase: for `ManuallyDrop<T>`, to be useful in arrays (i.e. small vector optimizations), it needs to have the same layout as `T` and AFAICT `#[repr(C)]` is not guaranteed to do the right thing"
+> + **[eddyb][eddyb_1]:** "I found another important usecase: for `ManuallyDrop<T>`, to be useful in arrays (i.e. small vector optimizations), it needs to have the same layout as `T` and AFAICT `#[repr(C)]` is not guaranteed to do the right thing"
 > **retep998:** "So we'd need to be able to specify `#[repr(transparent)]` on unions?"
 > + **eddyb:** "That's the only way to be sure AFAICT, yes."
 

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -77,7 +77,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 > + **[nagisa][nagisa_1]:** "Why not univariant unions and enums?"
 > + **nox:** "I tried to be conservative for now given I don't have a use case for univariant unions and enums in FFI context."
 
-> https://github.com/rust-lang/rfcs/pull/1758#issuecomment-254872520
+[eddyb_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-254872520
 > **eddyb:** "I found another important usecase: for `ManuallyDrop<T>`, to be useful in arrays (i.e. small vector optimizations), it needs to have the same layout as `T` and AFAICT `#[repr(C)]` is not guaranteed to do the right thing"
 > **retep998:** "So we'd need to be able to specify `#[repr(transparent)]` on unions?"
 > **eddyb:** "That's the only way to be sure AFAICT, yes."

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -185,7 +185,7 @@ struct Cryptor {
     // Imagine there a few fields here, defined by an external C library.
 }
 
-// This method may be called from C (or Rust!), and matches the C
+// This function may be called from C (or Rust!), and matches the C
 // function signature: bool(Cryptor *cryptor)
 pub extern "C" fn init_cryptor(cryptor: &mut core::mem::MaybeUninit<Cryptor>) -> bool {
     // Initialize the cryptor and return whether we succeeded

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -86,7 +86,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 > + **[joshtriplett][joshtriplett_1]:** "In terms of interactions with other features, I think this needs to specify what happens if you apply it to a union with one field, a union with multiple fields, a struct (tuple or otherwise) with multiple fields, a single-variant enum with one field, an enum struct variant where the enum uses `repr(u32)` or similar. The answer to some of those might be "compile error", but some of them (e.g. the union case) may potentially make sense in some contexts."
 
 [pnkfelix_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-290757356
-> **pnkfelix:** "However, I personally do not think we need to expand the scope of the feature. So I am okay with leaving it solely defined on `struct`, and leave `union`/`enum` to a follow-on RFC later. (Much the same with a hypothetical `newtype` feature.)"
+> + **[pnkfelix][pnkfelix_1]:** "However, I personally do not think we need to expand the scope of the feature. So I am okay with leaving it solely defined on `struct`, and leave `union`/`enum` to a follow-on RFC later. (Much the same with a hypothetical `newtype` feature.)"
 
 In summary, many of the questions regarding `#[repr(transparent)]` on a `union` were the same as applying it to a multi-field `struct`. These questions have since been answered, so there should be no problems with applying those same answers to `union`.
 

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -66,8 +66,6 @@ The logic controlling whether a `union` of type `U` may be `#[repr(transparent)]
 
 It would be nice to make `MaybeUninit<T>` `#[repr(transparent)]`. This type is a `union`, and thus this RFC is required to allow making it transparent.
 
-Of course, the standard "do nothing" alternative exists. Rust doesn't strictly *require* this feature. But it would benefit from this, so the "do nothing" alternative is undesirable.
-
 # Prior art
 [prior-art]: #prior-art
 

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -19,7 +19,7 @@ Making types like these `#[repr(transparent)]` would be useful in certain cases.
 - Protects against accidental violations of that intent (e.g., adding a new non-ZST field to a transparent union will result in a compiler error).
 - Makes a clear API guarantee that a `Wrapper<T>` can be transmuted to a `T`.
 
-Transparent `union`s are a nice complement to transparent `struct`s, and this RFC rounds out the `#[repr(transparent)]` feature.
+Transparent `union`s are a nice complement to transparent `struct`s, and this RFC is a step towards rounding out the `#[repr(transparent)]` feature.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -98,6 +98,6 @@ None (yet).
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Univariant `enum`s are ommitted from this RFC in an effort to keep the scope small and avoid unnecessary bikeshedding. A future RFC could explore `#[repr(transparent)]` on a univariant `enum`.
+Univariant `enum`s are ommitted from this RFC in an effort to keep the scope small. A future RFC could explore `#[repr(transparent)]` on a univariant `enum`.
 
 If a `union` has multiple non-ZST fields, a future RFC could propose a way to choose the representation of that `union` ([example](https://internals.rust-lang.org/t/pre-rfc-transparent-unions/9441/6)).

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -80,7 +80,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 [eddyb_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-254872520
 > **eddyb:** "I found another important usecase: for `ManuallyDrop<T>`, to be useful in arrays (i.e. small vector optimizations), it needs to have the same layout as `T` and AFAICT `#[repr(C)]` is not guaranteed to do the right thing"
 > **retep998:** "So we'd need to be able to specify `#[repr(transparent)]` on unions?"
-> **eddyb:** "That's the only way to be sure AFAICT, yes."
+> + **eddyb:** "That's the only way to be sure AFAICT, yes."
 
 [joshtriplett_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-274670231
 > + **[joshtriplett][joshtriplett_1]:** "In terms of interactions with other features, I think this needs to specify what happens if you apply it to a union with one field, a union with multiple fields, a struct (tuple or otherwise) with multiple fields, a single-variant enum with one field, an enum struct variant where the enum uses `repr(u32)` or similar. The answer to some of those might be "compile error", but some of them (e.g. the union case) may potentially make sense in some contexts."

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -40,7 +40,7 @@ union CustomUnion {
 For consistency with transparent `struct`s, a `union` must have exactly one non-zero-sized field. If all fields are zero-sized, the `union` must not be `#[repr(transparent)]`:
 
 ```rust
-// This (non-transparent) is already valid in stable Rust:
+// This (non-transparent) union is already valid in stable Rust:
 pub union Good {
     pub nothing: (),
 }

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -159,7 +159,7 @@ extern "C" fn log_event(message: core::ptr::NonNull<libc::c_char>,
 fn main() {
     extern "C" {
         fn set_log_handler(handler: extern "C" fn(core::ptr::NonNull<libc::c_char>,
-                           Context));
+                                                  Context));
     }
 
     // Set the log handler so the external C library can call log_event.

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -73,7 +73,7 @@ Of course, the standard "do nothing" alternative exists. Rust doesn't strictly *
 
 See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (which introduced `#[repr(transparent)]`) for some discussion on applying the attribute to a `union`. A summary of the discussion:
 
-> https://github.com/rust-lang/rfcs/pull/1758#discussion_r80436621
+[nagisa_1]: https://github.com/rust-lang/rfcs/pull/1758#discussion_r80436621
 > **nagisa:** "Why not univariant unions and enums?"
 > **nox:** "I tried to be conservative for now given I don't have a use case for univariant unions and enums in FFI context."
 

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -1,0 +1,103 @@
+- Feature Name: transparent_unions
+- Start Date: 2019-02-13
+- RFC PR:
+- Rust Issue:
+
+# Summary
+[summary]: #summary
+
+Allow `#[repr(transparent)]` on `union`s that have exactly one non-zero-sized field (just like `struct`s).
+
+# Motivation
+[motivation]: #motivation
+
+Some `union` types are thin newtype-style wrappers around another type, like `MaybeUninit<T>` (and [once upon a time](https://doc.rust-lang.org/1.26.1/src/core/mem.rs.html#950), `ManuallyDrop<T>`). This type is intended to be used in the same places as `T`, but without being `#[repr(transparent)]` the actual compatibility between it and `T` is left unspecified.
+
+Making types like these `#[repr(transparent)]` would be useful in certain cases. For example, making a `union Wrapper<T>` transparent:
+
+- Clearly expresses the intent of the developer.
+- Protects against accidental violations of that intent (e.g., adding a new non-ZST field to a transparent union will result in a compiler error).
+- Makes a clear API guarantee that a `Wrapper<T>` can be transmuted to a `T`.
+
+Transparent `union`s are a nice complement to transparent `struct`s, and this RFC rounds out the `#[repr(transparent)]` feature.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+A `union` may be `#[repr(transparent)]` in exactly the same conditions in which a struct may be `#[repr(transparent)]`. Some concrete illustrations follow.
+
+A union may be `#[repr(transparent)]` if it has exactly one non-zero-sized field:
+
+```rust
+// This union has the same representation as `usize`.
+#[repr(transparent)]
+union CustomUnion {
+    field: usize,
+    nothing: (),
+}
+```
+
+If the `union` is generic over `T` and has a field of type `T`, it may also be `#[repr(transparent)]` (even if `T` is a zero-sized type):
+
+```rust
+// This union has the same representation as `T`.
+#[repr(transparent)]
+pub union GenericUnion<T: Copy> { // Unions with non-`Copy` fields are unstable.
+    pub field: T,
+    pub nothing: (),
+}
+
+// This is okay even though `()` is a zero-sized type.
+pub const THIS_IS_OKAY: GenericUnion<()> = GenericUnion { field: () };
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The logic controlling whether a `union` of type `U` may be `#[repr(transparent)]` should match the logic controlling whether a `struct` of type `S` may be `#[repr(transparent)]` (assuming `U` and `S` have the same generic parameters and fields).
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- `#[repr(transparent)]` on a `union` is of limited use. There are cases where it is useful, but they're not common and some users might unnecessarily apply `#[repr(transparent)]` to a `union`.
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+It would be nice to make `MaybeUninit<T>` `#[repr(transparent)]`. This type is a `union`, and thus this RFC is required in order to allow making it transparent.
+
+Of course, the standard "do nothing" alternative exists. Rust doesn't strictly *require* this feature. But it would benefit from this, so the "do nothing" alternative is undesirable.
+
+# Prior art
+[prior-art]: #prior-art
+
+See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (which introduced `#[repr(transparent)]`) for some discussion on applying the attribute to a `union`. A summary of the discussion:
+
+> https://github.com/rust-lang/rfcs/pull/1758#discussion_r80436621
+> **nagisa:** "Why not univariant unions and enums?"
+> **nox:** "I tried to be conservative for now given I don't have a use case for univariant unions and enums in FFI context."
+
+> https://github.com/rust-lang/rfcs/pull/1758#issuecomment-254872520
+> **eddyb:** "I found another important usecase: for `ManuallyDrop<T>`, to be useful in arrays (i.e. small vector optimizations), it needs to have the same layout as `T` and AFAICT `#[repr(C)]` is not guaranteed to do the right thing"
+> **retep998:** "So we'd need to be able to specify `#[repr(transparent)]` on unions?"
+> **eddyb:** "That's the only way to be sure AFAICT, yes."
+
+> https://github.com/rust-lang/rfcs/pull/1758#issuecomment-274670231
+> **joshtriplett:** "In terms of interactions with other features, I think this needs to specify what happens if you apply it to a union with one field, a union with multiple fields, a struct (tuple or otherwise) with multiple fields, a single-variant enum with one field, an enum struct variant where the enum uses `repr(u32)` or similar. The answer to some of those might be "compile error", but some of them (e.g. the union case) may potentially make sense in some contexts."
+
+> https://github.com/rust-lang/rfcs/pull/1758#issuecomment-290757356
+> **pnkfelix:** "However, I personally do not think we need to expand the scope of the feature. So I am okay with leaving it solely defined on `struct`, and leave `union`/`enum` to a follow-on RFC later. (Much the same with a hypothetical `newtype` feature.)"
+
+In summary, many of the questions regarding `#[repr(transparent)]` on a `union` were the same as applying it to a multi-field `struct`. These questions have since been answered, and I see no problems with applying those same answers to `union`.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+None (yet).
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Univariant `enum`s are ommitted from this RFC in an effort to keep the scope small and avoid unnecessary bikeshedding. A future RFC could explore `#[repr(transparent)]` on a univariant `enum`.
+
+If a `union` has multiple non-ZST fields, a future RFC could propose a way to choose the representation of that enum ([example](https://internals.rust-lang.org/t/pre-rfc-transparent-unions/9441/6)).

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -19,7 +19,7 @@ Making types like these `#[repr(transparent)]` would be useful in certain cases.
 
 - Clearly expresses the intent of the developer.
 - Protects against accidental violations of that intent (e.g., adding a new variant or non-ZST field will result in a compiler error).
-- Makes a clear API guarantee that a `Wrapper<T>` can be transmuted to a `T` or substituted for a `T` in an FFI function's signature.
+- Makes a clear API guarantee that a `Wrapper<T>` can be transmuted to a `T` or substituted for a `T` in an FFI function's signature (though users must be careful to not pass uninitialized values through FFI to code where uninitialized values are undefined behavior (like C and C++)).
 
 Transparent `union`s and univariant `enum`s are a nice complement to transparent `struct`s, and this RFC rounds out the `#[repr(transparent)]` feature.
 

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -74,7 +74,7 @@ Of course, the standard "do nothing" alternative exists. Rust doesn't strictly *
 See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (which introduced `#[repr(transparent)]`) for some discussion on applying the attribute to a `union`. A summary of the discussion:
 
 [nagisa_1]: https://github.com/rust-lang/rfcs/pull/1758#discussion_r80436621
-> **nagisa:** "Why not univariant unions and enums?"
+> + **[nagisa][nagisa_1]:** "Why not univariant unions and enums?"
 > **nox:** "I tried to be conservative for now given I don't have a use case for univariant unions and enums in FFI context."
 
 > https://github.com/rust-lang/rfcs/pull/1758#issuecomment-254872520

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -37,7 +37,22 @@ union CustomUnion {
 }
 ```
 
-If the `union` is generic over `T` and has a field of type `T`, it may also be `#[repr(transparent)]` (even if `T` is a zero-sized type):
+For consistency with transparent `struct`s, a `union` must have exactly one non-zero-sized field. If all fields are zero-sized, the `union` must not be `#[repr(transparent)]`:
+
+```rust
+// This (non-transparent) is already valid in stable Rust:
+pub union Good {
+    pub nothing: (),
+}
+
+// Error: transparent union needs exactly one non-zero-sized field, but has 0
+#[repr(transparent)]
+pub union Bad {
+    pub nothing: (),
+}
+```
+
+The one exception is if the `union` is generic over `T` and has a field of type `T`, it may be `#[repr(transparent)]` even if `T` is a zero-sized type:
 
 ```rust
 // This union has the same representation as `T`.

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -64,7 +64,7 @@ The logic controlling whether a `union` of type `U` may be `#[repr(transparent)]
 # Rationale and alternatives
 [alternatives]: #alternatives
 
-It would be nice to make `MaybeUninit<T>` `#[repr(transparent)]`. This type is a `union`, and thus this RFC is required in order to allow making it transparent.
+It would be nice to make `MaybeUninit<T>` `#[repr(transparent)]`. This type is a `union`, and thus this RFC is required to allow making it transparent.
 
 Of course, the standard "do nothing" alternative exists. Rust doesn't strictly *require* this feature. But it would benefit from this, so the "do nothing" alternative is undesirable.
 

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -83,7 +83,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 > **eddyb:** "That's the only way to be sure AFAICT, yes."
 
 > https://github.com/rust-lang/rfcs/pull/1758#issuecomment-274670231
-> **joshtriplett:** "In terms of interactions with other features, I think this needs to specify what happens if you apply it to a union with one field, a union with multiple fields, a struct (tuple or otherwise) with multiple fields, a single-variant enum with one field, an enum struct variant where the enum uses `repr(u32)` or similar. The answer to some of those might be "compile error", but some of them (e.g. the union case) may potentially make sense in some contexts."
+> + **[joshtriplett][joshtriplett_1]:** "In terms of interactions with other features, I think this needs to specify what happens if you apply it to a union with one field, a union with multiple fields, a struct (tuple or otherwise) with multiple fields, a single-variant enum with one field, an enum struct variant where the enum uses `repr(u32)` or similar. The answer to some of those might be "compile error", but some of them (e.g. the union case) may potentially make sense in some contexts."
 
 > https://github.com/rust-lang/rfcs/pull/1758#issuecomment-290757356
 > **pnkfelix:** "However, I personally do not think we need to expand the scope of the feature. So I am okay with leaving it solely defined on `struct`, and leave `union`/`enum` to a follow-on RFC later. (Much the same with a hypothetical `newtype` feature.)"

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -88,7 +88,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 > https://github.com/rust-lang/rfcs/pull/1758#issuecomment-290757356
 > **pnkfelix:** "However, I personally do not think we need to expand the scope of the feature. So I am okay with leaving it solely defined on `struct`, and leave `union`/`enum` to a follow-on RFC later. (Much the same with a hypothetical `newtype` feature.)"
 
-In summary, many of the questions regarding `#[repr(transparent)]` on a `union` were the same as applying it to a multi-field `struct`. These questions have since been answered, and I see no problems with applying those same answers to `union`.
+In summary, many of the questions regarding `#[repr(transparent)]` on a `union` were the same as applying it to a multi-field `struct`. These questions have since been answered, so there should be no problems with applying those same answers to `union`.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -82,7 +82,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 > **retep998:** "So we'd need to be able to specify `#[repr(transparent)]` on unions?"
 > **eddyb:** "That's the only way to be sure AFAICT, yes."
 
-> https://github.com/rust-lang/rfcs/pull/1758#issuecomment-274670231
+[joshtriplett_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-274670231
 > + **[joshtriplett][joshtriplett_1]:** "In terms of interactions with other features, I think this needs to specify what happens if you apply it to a union with one field, a union with multiple fields, a struct (tuple or otherwise) with multiple fields, a single-variant enum with one field, an enum struct variant where the enum uses `repr(u32)` or similar. The answer to some of those might be "compile error", but some of them (e.g. the union case) may potentially make sense in some contexts."
 
 [pnkfelix_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-290757356

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -79,7 +79,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 
 [eddyb_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-254872520
 > + **[eddyb][eddyb_1]:** "I found another important usecase: for `ManuallyDrop<T>`, to be useful in arrays (i.e. small vector optimizations), it needs to have the same layout as `T` and AFAICT `#[repr(C)]` is not guaranteed to do the right thing"
-> **retep998:** "So we'd need to be able to specify `#[repr(transparent)]` on unions?"
+> + **retep998:** "So we'd need to be able to specify `#[repr(transparent)]` on unions?"
 > + **eddyb:** "That's the only way to be sure AFAICT, yes."
 
 [joshtriplett_1]: https://github.com/rust-lang/rfcs/pull/1758#issuecomment-274670231

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -75,7 +75,7 @@ See [the discussion on RFC #1758](https://github.com/rust-lang/rfcs/pull/1758) (
 
 [nagisa_1]: https://github.com/rust-lang/rfcs/pull/1758#discussion_r80436621
 > + **[nagisa][nagisa_1]:** "Why not univariant unions and enums?"
-> **nox:** "I tried to be conservative for now given I don't have a use case for univariant unions and enums in FFI context."
+> + **nox:** "I tried to be conservative for now given I don't have a use case for univariant unions and enums in FFI context."
 
 > https://github.com/rust-lang/rfcs/pull/1758#issuecomment-254872520
 > **eddyb:** "I found another important usecase: for `ManuallyDrop<T>`, to be useful in arrays (i.e. small vector optimizations), it needs to have the same layout as `T` and AFAICT `#[repr(C)]` is not guaranteed to do the right thing"

--- a/text/0000-transparent-unions.md
+++ b/text/0000-transparent-unions.md
@@ -100,4 +100,4 @@ None (yet).
 
 Univariant `enum`s are ommitted from this RFC in an effort to keep the scope small and avoid unnecessary bikeshedding. A future RFC could explore `#[repr(transparent)]` on a univariant `enum`.
 
-If a `union` has multiple non-ZST fields, a future RFC could propose a way to choose the representation of that enum ([example](https://internals.rust-lang.org/t/pre-rfc-transparent-unions/9441/6)).
+If a `union` has multiple non-ZST fields, a future RFC could propose a way to choose the representation of that `union` ([example](https://internals.rust-lang.org/t/pre-rfc-transparent-unions/9441/6)).

--- a/text/2645-transparent-unions.md
+++ b/text/2645-transparent-unions.md
@@ -1,7 +1,7 @@
-- Feature Name: transparent_enunions
+- Feature Name: `transparent_enunions`
 - Start Date: 2019-02-13
-- RFC PR:
-- Rust Issue:
+- RFC PR: [rust-lang/rfcs#2645](https://github.com/rust-lang/rfcs/pull/2645)
+- Rust Issue: [rust-lang/rust#60405](https://github.com/rust-lang/rust/issues/60405)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
Let's allow `#[repr(transparent)]` on `union`s and univariant `enum`s that have exactly one non-zero-sized field (just like `struct`s).

[Rendered](https://github.com/mjbshaw/rfcs/blob/transparent_unions/text/0000-transparent-unions.md).

<sub>[Pre-RFC Discourse discussion on internals.rust-lang.org](https://internals.rust-lang.org/t/pre-rfc-transparent-unions/9441).</sub>