### PR TITLE
Amend the template from RFC 1589

### DIFF
--- a/text/1589-rustc-bug-fix-procedure.md
+++ b/text/1589-rustc-bug-fix-procedure.md
@@ -98,29 +98,31 @@ What follows is a template for tracking issues.
 
 ---------------------------------------------------------------------------
 
-This is the **summary issue** for the `YOUR_LINT_NAME_HERE`
-future-compatibility warning and other related errors. The goal of
-this page is describe why this change was made and how you can fix
-code that is affected by it. It also provides a place to ask questions
-or register a complaint if you feel the change should not be made. For
-more information on the policy around future-compatibility warnings,
-see our [breaking change policy guidelines][guidelines].
+#### What is this lint about
 
-[guidelines]: LINK_TO_THIS_RFC
+*Describe here what kinds of Rust code will cause the lint to trigger.*
 
-#### What is the warning for?
+*Motivational text or historical information is also of use, but the
+most important thing is to explain what kind of code the lint is
+detecting.*
 
-*Describe the conditions that trigger the warning and how they can be
-fixed. Also explain why the change was made.**
+*You may wish to include a link to this RFC as part of explaining the
+lint in some manner, for example:*
 
-#### When will this warning become a hard error?
-                    
-At the beginning of each 6-week release cycle, the Rust compiler team
-will review the set of outstanding future compatibility warnings and
-nominate some of them for **Final Comment Period**. Toward the end of
-the cycle, we will review any comments and make a final determination
-whether to convert the warning into a hard error or remove it
-entirely.
+For more information on the policy around future-compatibility
+warnings, see our [breaking change policy guidelines][RFC 1589].
+
+[RFC 1589]: https://github.com/rust-lang/rfcs/blob/master/text/1589-rustc-bug-fix-procedure.md
+
+#### How to fix this warning/error
+
+*Explain here what the developer needs to do to address the warning.*
+
+#### Current status
+
+- [ ] PR ? introduces the `YOUR_LINT_NAME_HERE` lint as warn-by-default
+- [ ] PR ? makes the `YOUR_LINT_NAME_HERE` lint deny-by-default
+- [ ] PR ? makes the `YOUR_LINT_NAE_HERE` lint a hard error
 
 ---------------------------------------------------------------------------
 
@@ -277,6 +279,10 @@ policy and not making any sort of breaking change at all:
 [unresolved]: #unresolved-questions
 
 N/A
+
+# Amendments
+
+* Amended template to match current practice.
 
 <!-- -Links--------------------------------------------------------------------- -->
 

--- a/text/1589-rustc-bug-fix-procedure.md
+++ b/text/1589-rustc-bug-fix-procedure.md
@@ -98,6 +98,16 @@ What follows is a template for tracking issues.
 
 ---------------------------------------------------------------------------
 
+This is the **summary issue** for the `YOUR_LINT_NAME_HERE`
+future-compatibility warning and other related errors. The goal of
+this page is describe why this change was made and how you can fix
+code that is affected by it. It also provides a place to ask questions
+or register a complaint if you feel the change should not be made. For
+more information on the policy around future-compatibility warnings,
+see our [breaking change policy guidelines][RFC 1589].
+
+[RFC 1589]: https://github.com/rust-lang/rfcs/blob/master/text/1589-rustc-bug-fix-procedure.md
+
 #### What is this lint about
 
 *Describe here what kinds of Rust code will cause the lint to trigger.*
@@ -105,14 +115,6 @@ What follows is a template for tracking issues.
 *Motivational text or historical information is also of use, but the
 most important thing is to explain what kind of code the lint is
 detecting.*
-
-*You may wish to include a link to this RFC as part of explaining the
-lint in some manner, for example:*
-
-For more information on the policy around future-compatibility
-warnings, see our [breaking change policy guidelines][RFC 1589].
-
-[RFC 1589]: https://github.com/rust-lang/rfcs/blob/master/text/1589-rustc-bug-fix-procedure.md
 
 #### How to fix this warning/error
 


### PR DESCRIPTION
Amend the issue template from text of RFC 1589 to match current actual practice of future-compatibility lints.

In particular, while working on rust-lang/rust#58608, I discovered that the current batch of [C-future-compatibility tracking issues](https://github.com/rust-lang/rust/labels/C-future-compatibility) don't look anything like the template provided in this RFC.

So I took inspiration from one them (rust-lang/#57644 in particular) when composing my own rust-lang/rust#59014, but I wanted to back-propagate the template that seems to have evolved into the original RFC text so that people who use the RFC as the basis for their own issue will start off on the right foot. 