### PR TITLE
Control-flow within a function: incorrect example

### DIFF
--- a/text/2094-nll.md
+++ b/text/2094-nll.md
@@ -536,7 +536,7 @@ problem cases, as well as a number of other interesting examples.
 ```rust
 let mut foo: T = ...;
 let mut bar: T = ...;
-let p: &T;
+let mut p: &T;
 
 p = &foo;
 // (0)
@@ -564,7 +564,7 @@ containing a list of discrete statements and a trailing terminator:
 ```
 // let mut foo: i32;
 // let mut bar: i32;
-// let p: &i32;
+// let mut p: &i32;
 
 A
 [ p = &foo     ]
@@ -608,7 +608,7 @@ are three lifetimes that result. We will call them `'p`, `'foo`, and
 ```rust
 let mut foo: T = ...;
 let mut bar: T = ...;
-let p: &'p T;
+let mut p: &'p T;
 //      --
 p = &'foo foo;
 //   ----
@@ -691,7 +691,7 @@ important to Example 4:
 ```rust
 let mut foo: T = ...;
 let mut bar: T = ...;
-let p: &'p T = &foo;
+let mut p: &'p T = &foo;
 // `p` is live here: its value may be used on the next line.
 if condition {
     // `p` is live here: its value will be used on the next line.


### PR DESCRIPTION
Fixes rust-lang/rfcs#2680