### PR TITLE
Discriminant bits

### DIFF
--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -34,13 +34,12 @@ This allows for an efficient representation of discriminant sets, which is both 
 
 ## Disciminant data
 
-`Discriminant::bit_size` and `Discriminant#data` are two methods to retrieve the structure of the discriminant.
+`Discriminant::bit_size` is a method to retrieve the minimal number in bits necessary to represent this discriminant.
 
 ```rust
 const fn bit_size() -> usize { }
 ```
 
-The `bit_size` function returns the number of bits necessary to represent this discriminant.
 This number is not subject to optimisation, so e.g. `Option<&str>` reports a bitsize of `1`.
 
 For example:
@@ -57,25 +56,27 @@ enum RGB {
     Blue
 }
 
-Discriminant<Cell>.bit_size() == 1
-Discriminant<Option<&str>>.bit_size() == 1
-Discriminant<RGB>.bit_size() == 2
+Discriminant<Cell>::bit_size() == 1
+Discriminant<Option<&str>>::bit_size() == 1
+Discriminant<RGB>::bit_size() == 2
 ```
 
 This information can be used to pack multiple discriminants easily for efficient storage and easy indexing.
 
+`Discriminat<T>` gains the methods `into_bits` and `from_bits`:
+
 ```rust
-fn into_data(&self) -> u128
+fn into_bits(&self) -> u128
 ```
 
 Returns a bit representation of the discriminant.
 This data can be used to construct an efficient storage or index.
 
 ```rust
-fn from_data<T>(data: u128) -> Discriminant<T>
+fn from_bits(data: u128) -> Self
 ```
 
-Creates a Discriminant from emitted data usable for comparison.
+Creates a `Discriminant` from emitted bits usable for comparison.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -98,6 +99,8 @@ The added methods increase API surface in stdlib.
 - Why is this design the best in the space of possible designs?
 - What other designs have been considered and what is the rationale for not choosing them?
 - What is the impact of not doing this?
+- `from_data` and `into_data` could instead be straight `From/Into` implementations
+- Alternatively, `from/into_bits` could return a `Bits<T>` type with a richer interface
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -11,7 +11,8 @@ Add methods to `std::mem::Discriminant` which inform of the space necessary for 
 # Motivation
 [motivation]: #motivation
 
-Rust encourages using enums to encode data with multiple variants. And example of this can be found in the [game of life tutorial][game-of-life-tutorial].
+Rust encourages using enums to encode data with multiple variants.
+An example of this can be found in the [game of life tutorial][game-of-life-tutorial].
 
 ```rust
 enum Cell {
@@ -20,7 +21,9 @@ enum Cell {
 }
 ```
 
-Using these enums in collections is wasteful, as each instance reserves at least 1 byte of space. Similarly, `std::mem::size_of<Discriminant<Cell>>()` is at least 1 byte. For that reason, the book later goes on and replaces `Vec<Cell>` by [`fixedbitset`][game-of-life-exercise].
+Using these enums in collections is wasteful, as each instance reserves at least 1 byte of space.
+Similarly, `std::mem::size_of<Discriminant<Cell>>()` is at least 1 byte.
+For that reason, the book later goes on and replaces `Vec<Cell>` by [`fixedbitset`][game-of-life-exercise], ending up with a much less intuitive implementation.
 
 If it were possible to read the exact necessary size and the bit representation the descriminant, we could have interface like this:
 
@@ -43,7 +46,8 @@ This allows for an efficient representation of Discriminant sets, which is both 
 const fn bit_size() -> usize { }
 ```
 
-The `bit_size` function returns the number of bits necessary to represent this discriminant. This number is not subject to optimisation, so e.g. `Option<&str>` reports a bitsize of `1`.
+The `bit_size` function returns the number of bits necessary to represent this discriminant.
+This number is not subject to optimisation, so e.g. `Option<&str>` reports a bitsize of `1`.
 
 For example:
 
@@ -61,7 +65,7 @@ enum RGB {
 
 Discriminant<Cell>.bit_size() == 1
 Discriminant<Option<&str>>.bit_size() == 1
-Discriminant<RGB::Red>.bit_size == 2
+Discriminant<RGB>.bit_size() == 2
 ```
 
 This information can be used to pack multiple discriminants easily for in bitfields for efficient storage and easy indexing.
@@ -70,7 +74,8 @@ This information can be used to pack multiple discriminants easily for in bitfie
 fn data(&self) -> u128
 ```
 
-Returns a bit representation of the discriminant. This data can be used to construct an efficient storage or index.
+Returns a bit representation of the discriminant.
+This data can be used to construct an efficient storage or index.
 
 ```rust
 fn from_data<T>(data: u128) -> Discriminant<T>
@@ -81,11 +86,12 @@ Creates a Discriminant from emitted data usable for comparison.
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The feature may interact with non-exaustive enums. In this case, still, the currently used discriminant size should be used.
+The feature may interact with non-exaustive enums.
+In this case, still, the currently used discriminant size should be used.
 
 Adding the proposed functions probably entails adding a new compiler intrinsic `discriminant_size`.
 
-Empty enums are of 0 size.
+Empty enums are of size 0.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -40,7 +40,7 @@ This allows for an efficient representation of Discriminant sets, which is both 
 `Discriminant#bit_size` and `Discriminant#data` are two methods to retrieve the structure of the discriminant.
 
 ```rust
-fn bit_size(&self) -> usize { }
+const fn bit_size(&self) -> usize { }
 ```
 
 The `bit_size` function returns the number of bits necessary to represent this discriminant. This number is not subject to optimisation, so e.g. `Option<&str>` reports a bitsize of `1`.
@@ -108,6 +108,7 @@ The added methods increase API surface in stdlib.
 - Naming of the functions could be improved.
 - A basic implementation of a bitfield should be created during the implementation phase
 - Exact layout of the returned usize value is not clear, especially endianess.
+- `std::mem::discriminant` isn't const, which makes `bit_size` unreachable as a const function. Can `std::mem::discriminant` be const?
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -43,7 +43,7 @@ This allows for an efficient representation of Discriminant sets, which is both 
 fn bit_size(&self) -> usize { }
 ```
 
-The `bit_size` function returns the number of bits necessary to represent this discriminant. This number is not necessarily the number of bits actually used, as this is subject to optimization.
+The `bit_size` function returns the number of bits necessary to represent this discriminant. This number is not subject to optimisation, so e.g. `Option<&str>` reports a bitsize of `1`.
 
 For example:
 

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -1,0 +1,115 @@
+- Feature Name: discriminant_bits
+- Start Date: 2019-04-01
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Add methods to `std::mem::Discriminant` which inform of the space necessary for a bitwise representation of an enums Dicriminant and the bits itself in an opaque fashion.
+
+# Motivation
+[motivation]: #motivation
+
+Rust encourages using enums to encode data with multiple variants. And example of this can be found in the [game of life tutorial][game-of-life-tutorial].
+
+```rust
+enum Cell {
+    Dead  = 0,
+    Alive = 1
+}
+```
+
+Using these enums in collections is wasteful, as each instance reserves at least 1 byte of space. Similarly, `std::mem::size_of<Discriminant<Cell>>()` is at least 1 byte. For that reason, the book later goes on and replaces `Vec<Cell>` by a bit vector.
+
+If it were possible to read the exact necessary size and the bit representation the descriminant, we could have interface like this:
+
+```rust
+let x = PackedBits<Cell>;
+```
+
+Where `PackedBits` uses exactly as much space as necessary.
+
+This allows for an efficient representation of Discriminant sets, which is both useful for simple enums, but also for crating an index of all Discriminant values present in collection.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## Disciminant data
+
+`Discriminant#bit_size` and `Discriminant#data` are two methods to retrieve the structure of the discriminant.
+
+```rust
+fn bit_size(&self) -> usize { }
+```
+
+The `bit_size` function returns the number of bits necessary to represent this discriminant. This number is not necessarily the number of bits actually used, as this is subject to optimization.
+
+For example:
+
+```rust
+enum Cell {
+    Dead = 0,
+    Alive = 1,
+}
+
+enum RGB {
+    Red,
+    Green,
+    Blue
+}
+
+std::mem::discriminant(Cell::Alive).bit_size == 1
+std::mem::discriminant(Option::None as Option<&str>).bit_size == 1
+std::mem::discriminant(RGB::Red).bit_size == 2
+```
+
+This information can be used to pack multiple discriminants easily for in bitfields for efficient storage and easy indexing.
+
+```rust
+fn data(&self) -> usize
+```
+
+Returns a bit representation of the discriminant. This data can be used to construct an efficient storage or index.
+
+```rust
+fn from_data<T>(data: usize) -> Discriminant<T>
+```
+
+Creates a Discriminant from emitted data usable for comparison.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The feature may interact with non-exaustive enums. In this case, still, the currently used discriminant size should be used.
+
+Adding the proposed functions probably entails adding a new compiler intrinsic `discriminant_size`.
+
+Empty enums are of 0 size.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+The added methods increase API surface in stdlib.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- Naming of the functions could be improved.
+- A basic implementation of a bitfield should be created during the implementation phase
+- Exact layout of the returned usize value is not clear, especially endianess.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+The feature is self-contained and I don't see direct extensions.

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -81,7 +81,7 @@ Creates a `Discriminant` from emitted bits usable for comparison.
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The feature may interact with non-exaustive enums.
+The feature may interact with non-exhaustive enums.
 In this case, still, the currently used discriminant size should be used.
 
 Adding the proposed functions probably entails adding a new compiler intrinsic `discriminant_size`.

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -20,7 +20,7 @@ enum Cell {
 }
 ```
 
-Using these enums in collections is wasteful, as each instance reserves at least 1 byte of space. Similarly, `std::mem::size_of<Discriminant<Cell>>()` is at least 1 byte. For that reason, the book later goes on and replaces `Vec<Cell>` by a bit vector.
+Using these enums in collections is wasteful, as each instance reserves at least 1 byte of space. Similarly, `std::mem::size_of<Discriminant<Cell>>()` is at least 1 byte. For that reason, the book later goes on and replaces `Vec<Cell>` by [`fixedbitset`][game-of-life-exercise].
 
 If it were possible to read the exact necessary size and the bit representation the descriminant, we could have interface like this:
 
@@ -113,3 +113,6 @@ The added methods increase API surface in stdlib.
 [future-possibilities]: #future-possibilities
 
 The feature is self-contained and I don't see direct extensions.
+
+[game-of-life-tutorial]: https://rustwasm.github.io/docs/book/game-of-life/implementing.html
+[game-of-life-exercise]: https://rustwasm.github.io/docs/book/game-of-life/implementing.html#exercises

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -37,7 +37,7 @@ This allows for an efficient representation of discriminant sets, which is both 
 `Discriminant::bit_size` is a method to retrieve the minimal number in bits necessary to represent this discriminant.
 
 ```rust
-const fn bit_size() -> usize { }
+const fn bit_size() -> usize;
 ```
 
 This number is not subject to optimisation, so e.g. `Option<&str>` reports a bitsize of `1`.

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Add methods to `std::mem::Discriminant` which inform of the space necessary for a bitwise representation of an enums Dicriminant and the bits itself in an opaque fashion.
+Add methods to `std::mem::Discriminant` which inform of the space necessary for a bitwise representation of an enum's discriminant and the bits itself in an opaque fashion.
 
 # Motivation
 [motivation]: #motivation
@@ -25,15 +25,9 @@ Using these enums in collections is wasteful, as each instance reserves at least
 Similarly, `std::mem::size_of<Discriminant<Cell>>()` is at least 1 byte.
 For that reason, the book later goes on and replaces `Vec<Cell>` by [`fixedbitset`][game-of-life-exercise], ending up with a much less intuitive implementation.
 
-If it were possible to read the exact necessary size and the bit representation the descriminant, we could have interface like this:
+If it were possible to read the exact necessary size and the bit representation the descriminant, we could have a `PackedBits<T>` that uses exactly as much space as necessary.
 
-```rust
-let x = PackedBits<Cell>;
-```
-
-Where `PackedBits` uses exactly as much space as necessary.
-
-This allows for an efficient representation of Discriminant sets, which is both useful for simple enums, but also for crating an index of all Discriminant values present in collection.
+This allows for an efficient representation of discriminant sets, which is both useful for simple enums, but also for crating an index of all discriminant values present in collection.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -68,10 +62,10 @@ Discriminant<Option<&str>>.bit_size() == 1
 Discriminant<RGB>.bit_size() == 2
 ```
 
-This information can be used to pack multiple discriminants easily for in bitfields for efficient storage and easy indexing.
+This information can be used to pack multiple discriminants easily for efficient storage and easy indexing.
 
 ```rust
-fn data(&self) -> u128
+fn into_data(&self) -> u128
 ```
 
 Returns a bit representation of the discriminant.

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -63,7 +63,7 @@ Discriminant<RGB>::bit_size() == 2
 
 This information can be used to pack multiple discriminants easily for efficient storage and easy indexing.
 
-`Discriminat<T>` gains the methods `into_bits` and `from_bits`:
+`Discriminant<T>` gains the methods `into_bits` and `from_bits`:
 
 ```rust
 fn into_bits(&self) -> u128

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -37,10 +37,10 @@ This allows for an efficient representation of Discriminant sets, which is both 
 
 ## Disciminant data
 
-`Discriminant#bit_size` and `Discriminant#data` are two methods to retrieve the structure of the discriminant.
+`Discriminant::bit_size` and `Discriminant#data` are two methods to retrieve the structure of the discriminant.
 
 ```rust
-const fn bit_size(&self) -> usize { }
+const fn bit_size() -> usize { }
 ```
 
 The `bit_size` function returns the number of bits necessary to represent this discriminant. This number is not subject to optimisation, so e.g. `Option<&str>` reports a bitsize of `1`.
@@ -59,21 +59,21 @@ enum RGB {
     Blue
 }
 
-std::mem::discriminant(Cell::Alive).bit_size == 1
-std::mem::discriminant(Option::None as Option<&str>).bit_size == 1
-std::mem::discriminant(RGB::Red).bit_size == 2
+Discriminant<Cell>.bit_size() == 1
+Discriminant<Option<&str>>.bit_size() == 1
+Discriminant<RGB::Red>.bit_size == 2
 ```
 
 This information can be used to pack multiple discriminants easily for in bitfields for efficient storage and easy indexing.
 
 ```rust
-fn data(&self) -> usize
+fn data(&self) -> u128
 ```
 
 Returns a bit representation of the discriminant. This data can be used to construct an efficient storage or index.
 
 ```rust
-fn from_data<T>(data: usize) -> Discriminant<T>
+fn from_data<T>(data: u128) -> Discriminant<T>
 ```
 
 Creates a Discriminant from emitted data usable for comparison.
@@ -107,8 +107,6 @@ The added methods increase API surface in stdlib.
 
 - Naming of the functions could be improved.
 - A basic implementation of a bitfield should be created during the implementation phase
-- Exact layout of the returned usize value is not clear, especially endianess.
-- `std::mem::discriminant` isn't const, which makes `bit_size` unreachable as a const function. Can `std::mem::discriminant` be const?
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-discriminant-bits.md
+++ b/text/0000-discriminant-bits.md
@@ -23,7 +23,7 @@ enum Cell {
 
 Using these enums in collections is wasteful, as each instance reserves at least 1 byte of space.
 Similarly, `std::mem::size_of<Discriminant<Cell>>()` is at least 1 byte.
-For that reason, the book later goes on and replaces `Vec<Cell>` by [`fixedbitset`][game-of-life-exercise], ending up with a much less intuitive implementation.
+For that reason, the Wasm book later goes on and replaces `Vec<Cell>` by [`fixedbitset`][game-of-life-exercise], ending up with a much less intuitive implementation.
 
 If it were possible to read the exact necessary size and the bit representation the descriminant, we could have a `PackedBits<T>` that uses exactly as much space as necessary.
 


### PR DESCRIPTION
* [rendered](https://github.com/skade/rfcs/blob/discriminant-bits/text/0000-discriminant-bits.md)

# Summary

This RFC proposes to expose the minimum size necessary to encode the discriminant of an enum, without exposing the exact encoding itself. This can be useful to write bitlevel collections.

Thanks @joshtriplett @Manishearth @eddyb and VLQC for early review <3.

Some details, especially naming, are very much bikesheddable.