### PR TITLE
Add a link to the Futures RFC from the async/await RFC

### DIFF
--- a/text/2394-async_await.md
+++ b/text/2394-async_await.md
@@ -9,7 +9,7 @@
 Add async & await syntaxes to make it more ergonomic to write code manipulating
 futures.
 
-This has a companion RFC to add a small futures API to libstd and libcore.
+This has [a companion RFC](2592-futures.md) to add a small futures API to libstd and libcore.
 
 # Motivation
 [motivation]: #motivation


### PR DESCRIPTION
Since Futures are now stable, this is likely to be something folks are looking for.