### PR TITLE
Generic Pointer to Field

### DIFF
--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -121,8 +121,6 @@ impl<'a, F: Field> Project<F> for &'a F::Parent where F::Type: 'a {
 }
 ```
 
-
-
 This is the technical portion of the RFC. Explain the design in sufficient detail that:
 
 - Its interaction with other features is clear.
@@ -135,55 +133,28 @@ The section should return to the examples given in the previous section, and exp
 [drawbacks]: #drawbacks
 
 Why should we *not* do this?
+- This adds quite a bit of complexity and can increase compile times
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
+- The `&[mut] raw T` could solve some of the problems, but only for raw pointers. It doesn't help with abstractions.
+- Somehow expand on `Deref` to allow dereferencing to a smart pointer
+    - This would require Generic Associated Types at the very least, and maybe some other features like assocaited traits
 
 # Prior art
 [prior-art]: #prior-art
 
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
-
-- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
-
-This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
-If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
-
-Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
-Please also take into consideration that rust sometimes intentionally diverges from common language features.
+- C++'s pointer to members `Parent::*field`
+- Java's `class Field`
+    - Similar reflection capabilies in other languages
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+- Syntax for the type fields (not to be decided before accepting this RFC, but must be decided before stabilization)
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would
-be and how it would affect the language and project as a whole in a holistic
-way. Try to use this section as a tool to more fully consider all possible
-interactions with the project and language in your proposal.
-Also consider how the this all fits into the roadmap for the project
-and of the relevant sub-team.
-
-This is also a good place to "dump ideas", if they are out of scope for the
-RFC you are writing but otherwise related.
-
-If you have tried and cannot think of any future possibilities,
-you may simply state that you cannot think of anything.
-
-Note that having something written down in the future-possibilities section
-is not a reason to accept the current or a future RFC; such notes should be
-in the section on motivation or rationale in this or subsequent RFCs.
-The section merely provides additional information.
+- Extend the `Project` trait to implement all smart pointers in the standard library

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -28,7 +28,7 @@ struct FieldDescriptor {
 /// The compiler should prevent user implementations for `Field`,
 /// i.e. only the compiler is allowed to implement `Field`
 /// This is to prevent people from creating fake "fields"
-trait Field {
+unsafe trait Field {
     /// The type that the field is a part of
     type Parent;
     /// The type of the field

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -30,9 +30,9 @@ struct FieldDescriptor {
 /// This is to prevent people from creating fake "fields"
 unsafe trait Field {
     /// The type that the field is a part of
-    type Parent;
+    type Parent: ?Sized;
     /// The type of the field
-    type Type;
+    type Type: ?Sized;
 
     /// The metadata required to get to the field using raw pointers
     const FIELD_DESCRIPTOR: FieldDescriptor;

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -235,7 +235,8 @@ The `Field` trait will only be implemented by the compiler, and it compiler shou
 - Distant Future, we could reformulate `Copy` based on the `Field` trait so that it enforces that all of the fields of a type must be `Copy` in order to be the type to be `Copy`, and thus reduce the amount of magic in the compiler.
 
 - a `Project` and `PinProjectable` traits
-
+    - These were in an earier version of this RFC, but were removed as they are not essential, and this RFC is already rather niche. So to limit the scope of this RFC, they were removed. If this RFC is accepted, then `Project` and `PinProjectable` could be implmented as library items outside of `std`.
+     
 ## `trait Project`
 
 ```rust

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -6,12 +6,14 @@
 # Summary
 [summary]: #summary
 
-This feature could serve as the backbone for some pointer to field syntax, and even if no syntax is made, this feature serves as a safe generic way to talk about types and their fields.
+This feature could serve as the backbone for some pointer to field syntax, and even if no syntax is made, this feature serves as a safe generic way to talk about types and their fields, and projections through raw pointers.
 
 # Motivation
 [motivation]: #motivation
 
-The motivation for this feature is to allow safe projection through smart pointers, for example `Pin<&mut T>` to `Pin<&mut Field>`. This is a much needed feature to make `Pin<P>` more usable in safe-contexts, without the need to use unsafe to map to a field. This also can allow projection through other smart pointers like `Rc<T>`, `Arc<T>`. This feature cannot be implemented as a library effectively because it depends on the layouts of types, so it requires integration with the Rust compiler until Rust gets a stable layout (which may never happen).
+The motivation for this feature is to build a foundation for libraries to allow projections through smart pointers. For example, through `Pin<&mut T>` to `Pin<&mut Field>`. This is a much needed feature to make `Pin<P>` more usable in safe-contexts, without the need to use unsafe to map to a field. This also can allow projection through other smart pointers like `Rc<T>`, `Arc<T>`. This feature cannot be implemented as a library effectively because it depends on the layouts of types, so it requires integration with the Rust compiler until Rust gets a stable layout (which may never happen).
+
+This feature will also allow for safer patterns in `unsafe` code that deals with intrusive data strutures via `inverse_*` projections. It will also provide projections through raw pointers, which are currently not possible to do safely without a `#[repr(...)]` attribute (and even then it is easy to make a mistake). This will make `unsafe` code easier to audit and easier to write sound `unsafe` code.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -167,6 +167,26 @@ impl<'a, T> Pin<&'a mut T> {
 
 If `PinProjectable` is accepted, then `Project` trait will also be implemented for `Pin<&T>`, `Pin<&mut T>` and will be bound by `PinProjectable`.
 
+Some notes about field types:
+
+You can make a field type for the following types of types
+* tuples `(T, U, ...)`
+    * `<(T, U)>.0`
+    * `<(T, U)>::0`
+    * `(T, U)~0`
+* tuple structs `Foo(T, U, ...)`
+    * `Foo.0`
+    * `Foo::0`
+    * `Foo~0`
+* structs `struct Foo { field: Field, ... }`
+    * same syntax as tuple struct
+* unions `union Foo { field: Field }`
+    * same syntax as tuple struct
+    * constructing a field type is `unsafe`, this is because accessing fields of `union`s is unsafe
+
+All fields types are treated as if they are declared in the same crate as their `Parent` type.
+This will allow users to implement traits for field types, like the `PinProjectable` trait.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -1,0 +1,189 @@
+- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+This feature could serve as the backbone for some pointer to field syntax, and even if no syntax is made, this feature serves as a safe generic way to talk about types and their fields.
+
+# Motivation
+[motivation]: #motivation
+
+The motivation for this feature is to allow safe projection through smart pointers, for example `Pin<&mut T>` to `Pin<&mut Field>`. This is a much needed feature to make `Pin<P>` more usable in safe-contexts, without the need to use unsafe to map to a field. This also can allow projection through other smart pointers like `Rc<T>`, `Arc<T>`. This feature cannot be implemented as a library effectively because it depends on the layouts of types, so it requires integration with the Rust compiler until Rust gets a stable layout (which may never happen).
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+First the core trait, type, and functions that need to be added
+
+```rust
+/// Contains metadata about how to get to the field from the parent using raw pointers
+/// This is an opaque type that never needs to be stablized, and it only an implementation detail
+struct MetaData {
+    ...
+}
+
+/// The compiler should prevent user implementations for `Field`,
+/// i.e. only the compiler is allowed to implement `Field`
+/// This is to prevent people from creating fake "fields"
+trait Field {
+    /// The type that the field is a part of
+    type Parent;
+    /// The type of the field
+    type Type;
+
+    /// The metadata required to get to the field using raw pointers
+    const META: MetaData;
+}
+
+trait Project<F: Field> {
+    /// The projected version of Self
+    type Projection;
+
+    fn project(self, field: F) -> Self::Projection;
+}
+
+impl<T: ?Sized> *const T {
+    unsafe fn project_unchecked<F: Field<Parent = T>>(self, field: F) -> *const F::Type {
+        // make the field pointer, this code is allowed to assume that
+        // self points to a valid instance of T
+        ... 
+    }
+}
+
+impl<T: ?Sized> *mut T {
+    unsafe fn project_unchecked<F: Field<Parent = T>>(self, field: F) -> *mut F::Type {
+        // make the field pointer, this code is allowed to assume that
+        // self points to a valid instance of T
+        ...
+    }
+}
+```
+
+Now we need some syntax to refer to the fields of types. Some ideas for the syntax are
+
+* `Parent.field`
+* `Parent::field` // bad as it conflicts with associated functions
+* `Parent~field` // or any other sigil
+
+We will call these field types, because they will desugar to a unit type that correctly implements `Field`, like so
+
+```rust
+struct Foo {
+    bar: Bar
+}
+
+struct Foo.bar;
+
+impl Field for Foo.bar { ... }
+```
+
+These are the core parts of this proposal. Every other part of this proposal can be postponed or dropped without affecting this feature's core principles.
+
+Using these core parts we can build as a library projections through `Pin<&T>`, `Rc<_>` and more. We can then use this to safely project through smart pointers like so.
+
+```rust
+let foo   : Pin<Box<Foo>    = Box::pin(immovable);
+let foo   : Pin<&mut Foo>   = foo.as_mut();
+let field : Pin<&mut Field> = foo.project(Foo.field);
+```
+But to do safe pin projections we will need to introduce a marker trait.
+```rust
+/// The only people who can implement `PinProjectable` are the creator of the parent type
+/// This allows people to opt-in to allowing their fields to be pin projectable.
+/// The guarantee is that once you create `Pin<P<Parent>>`, all of the same guarantees that
+/// apply to `Pin<P<Parent>>` also apply to `Pin<P<Field>>`
+/// For all `Parent: Unpin`, these can be auto implemented for all of their fields.
+unsafe trait PinProjectable: Field {}
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The field types needs to interact with the privacy rules for fields. A field type has the same privacy as the field it is derived from. Anything else would be too restrictive or unsound.
+
+As example of how to implement `Project`, here is the implementation for `&T`.
+
+```rust
+impl<'a, F: Field> Project<F> for &'a F::Parent where F::Type: 'a {
+    type Projection = &'a F::Type;
+
+    fn project(self, field: F) -> Self {
+        unsafe {
+            // This is safe because a reference is always valids
+            let ptr: *const F::Type = (self as *const F::Parent).project_unchecked(field);
+
+            &*ptr
+        }
+    }
+}
+```
+
+
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the language and project as a whole in a holistic
+way. Try to use this section as a tool to more fully consider all possible
+interactions with the project and language in your proposal.
+Also consider how the this all fits into the roadmap for the project
+and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -91,8 +91,6 @@ impl<T: ?Sized> *mut T {
 
 These will allowing projections through raw pointers without dereferencing the raw pointer. This is useful for building projections through other abstractions like smart pointers (`Rc<T>`, `Pin<&T>`)!
 
-This is the extent of the core api of this RFC.
-
 Using this we can do something like this
 ```rust
 struct Foo {
@@ -162,13 +160,13 @@ raw pointer projections need to be implemented as intrinsics because there is no
 
 We need both `project_unchecked` and `wrapping_project` because there are some important optimization available inside of LLVM related to aliasing and escape analysis. In particular the LLVM `inbounds` assertion tells LLVM that a pointer offset stays within the same allocation and if the pointer is invalid or the offset does not stay within the same allocation it is considered UB. This behaviour is exposed via `project_unchecked`. This can be used by implementations of the `Project` trait for smart pointers that are always valid, like `&T` to enable better codegen. `wrapping_project` on the other hand will not assert `inbounds`, and will just wrap around if the pointer offset is larger than `usize::max_value()`. This safe defined behaviour, even if it is almost always a bug, unlike `project_unchecked` which is UB on invalid pointers or offsets.
 
-This corresponds with `core::ptr::add` and `core::ptr::wrapping_add` in safety and behaviour.
+This corresponds with `<*const _>::add` and `<*const _>::wrapping_add` in safety and behaviour.
 
 `inverse_project_unchecked` and `inverse_wrapping_project` are have all of the same safety requirements as their counterparts, and some more.
 
 `inverse_project_unchecked` and `inverse_wrapping_project` produces a valid pointer without UB if and only if the initial pointer is both valid and points to a field in the parent type used to perform the inverse projection. `inverse_wrapping_project` will never cause UB, but may produce invalid pointers. `inverse_project_unchecked` will cause UB if the condition above is not met. This is different from `project_unchecked` and `wrapping_project` because they only need to validate the original pointer, not the resulting pointer.
 
-`inverse_project_unchecked` and `inverse_wrapping_project` correspond to `core::ptr::sub` and `core::ptr::wrapping_sub` in safety and behaviour.
+`inverse_project_unchecked` and `inverse_wrapping_project` correspond to `<*const _>::sub` and `<*const _>::wrapping_sub` in safety and behaviour.
 
 For example of where `project_unchecked` would be UB.
 

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -206,3 +206,4 @@ If `PinProjectable` is accepted, then `Project` trait will also be implemented f
 
 - Extend the `Project` trait to implement all smart pointers in the standard library
 - [`InitPtr`](https://internals.rust-lang.org/t/idea-pointer-to-field/10061/72), which encapsulates all of the safety requirements of `project_unchecked` into `InitPtr::new` and safely implements `Project`
+- Distant Future, we could reformulate `Copy` based on the `Field` trait so that it enforces that all of the fields of a type must be `Copy` in order to be the type to be `Copy`, and thus reduce the amount of magic in the compiler.

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -261,6 +261,8 @@ The `Field` trait will only be implemented by the compiler, and it compiler shou
 - [`InitPtr`](https://internals.rust-lang.org/t/idea-pointer-to-field/10061/72), which encapsulates all of the safety requirements of `project_unchecked` into `InitPtr::new` and safely implements `Project`
 - Distant Future, we could reformulate `Copy` based on the `Field` trait so that it enforces that all of the fields of a type must be `Copy` in order to be the type to be `Copy`, and thus reduce the amount of magic in the compiler.
 - Integration with Custom DSTs
+- Integration with a possible Enum Variants as Types feature
+    - This will allow projecting to enum variants safely
 
 - a `Project` and `PinProjectable` traits
     - These were in an earier version of this RFC, but were removed as they are not essential, and this RFC is already rather niche. So to limit the scope of this RFC, they were removed. If this RFC is accepted, then `Project` and `PinProjectable` could be implmented as library items outside of `std`.

--- a/text/0000-ptr-to-field.md
+++ b/text/0000-ptr-to-field.md
@@ -195,6 +195,7 @@ If `PinProjectable` is accepted, then `Project` trait will also be implemented f
 - Are we going to accept `PinProjectable`?
     - If not, we won't have a safe way to do pin-projections
     - Do we want another way to do safe pin-projections?
+- Do we want to strip this proposal down to just the [api specified here](https://github.com/rust-lang/rfcs/pull/2708#issuecomment-499578814), where we only have the `Field` trait, `FieldDescriptor` type, and some associated functions on raw pointers.
 
 - Syntax for the type fields
     - not to be decided before accepting this RFC, but must be decided before stabilization


### PR DESCRIPTION
[Rendered](https://github.com/KrishnaSannasi/rfcs/blob/ptr-to-field/text/0000-ptr-to-field.md)

This RFC aims to provide a generic way to talk about the fields on types! Then go one step further and allow smart pointers to project to those fields!
```rust
struct Foo { bar: Bar }
let x: Pin<&Foo> = ...;
let y = x.project(Foo.bar);
```

[here](https://github.com/KrishnaSannasi/generic-field-projection) is a very alpha crate that implements some of the ideas laid on in this RFC.