### PR TITLE
Don't preserve gh-pages history

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,13 @@ script:
   - git config --global user.name "bors"
   - git config --global user.email "bors@rust-lang.org"
   - git remote add upstream git@github.com:rust-lang/rfcs.git
-  - git fetch upstream
-  - git reset upstream/gh-pages
   - touch .
   # We don't use jekyll. Disable it so it doesn't assign special meaning to any
   # of our files (e.g. ignoring directories with a leading '_').
   - touch .nojekyll
   - git add -A .
   - git commit -m "Rebuild book at ${rev}"
-  - git push -q upstream HEAD:gh-pages > /dev/null 2>&1
+  - git push -fq upstream HEAD:gh-pages > /dev/null 2>&1
 branches:
   only:
     - master


### PR DESCRIPTION
As was suggested in #2750, we probably don't need to preserve the history for the `gh-pages` branch, since it's an artifact of `master` and could just be bloating the repository size.