### PR TITLE
WIP: "C panic" ABI specifier

### DIFF
--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -45,7 +45,8 @@ for the non-Rust code, or this feature may not be supported at all.
 # Drawbacks
 [drawbacks]: #drawbacks
 
-TODO
+- Only works as long as Rust uses the same unwinding mechanism as C++.
+- Does not allow external library bindings to specify whether callbacks they accept are expected to unwind.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -20,7 +20,7 @@ TODO
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-TODO
+The `#[unwind(allowed)]` attribute permits functions with non-Rust ABIs (e.g. `extern "C" fn`) to unwind rather than terminating the process.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -28,10 +28,10 @@ TODO
 TODO: incorporate changes from discussion here:
 https://github.com/rust-lang/rust/pull/63909
 
-By default, Rust assumes that an external function imported with extern "C"
+By default, Rust assumes that an external function imported with extern "C" { ... }
 cannot unwind, and Rust will abort if a panic would propagate out of a Rust
-function exported with extern "C" function. If you specify the #[unwind]
-attribute on an extern "C" function, Rust will instead allow an unwind (such as
+function with a non-"Rust" ABI ("`extern`") specification. If you specify the #[unwind(allowed)]
+attribute on a function with a non-"Rust" ABI, Rust will instead allow an unwind (such as
 a panic) to proceed through that function boundary using Rust's normal unwind
 mechanism. This may potentially allow Rust code to call non-Rust code that
 calls back into Rust code, and then allow a panic to propagate from Rust to
@@ -41,8 +41,9 @@ The Rust unwind mechanism is intentionally not specified here. Catching a Rust
 panic in Rust code compiled with a different Rust toolchain or options is not
 specified. Catching a Rust panic in another language or vice versa is not
 specified. The Rust unwind may or may not run non-Rust destructors as it
-unwinds. Propagating a Rust panic through non-Rust code may require
-target-specific options for the non-Rust code, or may not be supported at all.
+unwinds. Propagating a Rust panic through non-Rust code is unspecified; implementations
+that define the behavior may require
+target-specific options for the non-Rust code, or this feature may not be supported at all.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -50,7 +50,9 @@ compatible with the unspecified Rust unwinding mechanism.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-The `#[unwind(allowed)]` attribute permits function declarations and definitions with non-Rust ABIs (e.g. `extern "C" fn`) to unwind rather than terminating the process.
+When used on Rust functions with non-Rust ABIs (e.g. `extern "C" fn`), the `#[unwind(allowed)]` attribute permits unwinding out of the annotated function; without the attribute, the process will automatically be terminated at the function boundary.
+
+When used on declarations of imported functions (e.g. `extern "C" { fn ... }`), the `#[unwind(allowed)]` attribute ensures that if the function unwinds, the unwind will be propagated though any calling code; without the attribute, the behavior is undefined.
 
 Calls to function pointers with non-Rust ABIs, as opposed to declared or defined functions,
 currently are permitted to unwind. This RFC does not change this behavior.
@@ -78,7 +80,7 @@ for the non-Rust code, or this feature may not be supported at all.
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- Only works as long as the foreign code supports the same unwinding mechanism as Rust.
+- Only works as long as the foreign code supports the same unwinding mechanism as Rust. (Currently, Rust and C++ code compiled for ABI-compatible backends use the same mechanism.)
 - Does not allow external library bindings to specify whether callbacks they accept are expected to unwind.
 
 # Rationale and alternatives
@@ -103,7 +105,7 @@ The alternatives considered are:
 
    - Additional non-Rust code must be maintained.
    - `setjmp`/`longjmp` incur runtime overhead even when no unwinding is required, whereas many
-     system unwinders incur runtime overhead only when unwinding.
+     unwinding mechanisms incur runtime overhead only when unwinding.
    - Wrappers that must be present at Rust compile time are not suitable for applications with
      dynamic, generated code.
 

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -27,7 +27,7 @@ The `#[unwind(allowed)]` attribute permits functions with non-Rust ABIs (e.g. `e
 
 By default, Rust assumes that an external function imported with `extern "C" {
 ... }` cannot unwind, and Rust will abort if a panic would propagate out of a
-Rust function with a non-"Rust" ABI ("`extern`") specification. If you specify
+Rust function with a non-"Rust" ABI ("`extern "ABI" fn`") specification. If you specify
 the `#[unwind(allowed)]` attribute on a function with a non-"Rust" ABI, Rust
 will instead allow an unwind (such as a panic) to proceed through that function
 boundary using Rust's normal unwind mechanism. This may potentially allow Rust

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -51,7 +51,9 @@ for the non-Rust code, or this feature may not be supported at all.
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-TODO
+The goal is to enable the current use-cases for unwinding panics through foreign code while providing safer behaviour towards bindings not expecting that, with minimal changes to the language.
+
+We should try not to prevent the RFC 2699 or other later RFC from resolving the above disadvantages on top of this one.
 
 - https://github.com/rust-lang/rfcs/pull/2699
 

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -1,0 +1,75 @@
+- Feature Name: `simple_unwind_attribute`
+- Start Date: 2019-08-29
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Provides an annotation to permit functions with explicit ABI specifications
+(such as `extern "C"`) to unwind
+
+# Motivation
+[motivation]: #motivation
+
+TODO
+
+- soundness & optimization
+- libjpeg/mozjpeg
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+TODO
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+TODO: incorporate changes from discussion here:
+https://github.com/rust-lang/rust/pull/63909
+
+By default, Rust assumes that an external function imported with extern "C"
+cannot unwind, and Rust will abort if a panic would propagate out of a Rust
+function exported with extern "C" function. If you specify the #[unwind]
+attribute on an extern "C" function, Rust will instead allow an unwind (such as
+a panic) to proceed through that function boundary using Rust's normal unwind
+mechanism. This may potentially allow Rust code to call non-Rust code that
+calls back into Rust code, and then allow a panic to propagate from Rust to
+Rust across the non-Rust code.
+
+The Rust unwind mechanism is intentionally not specified here. Catching a Rust
+panic in Rust code compiled with a different Rust toolchain or options is not
+specified. Catching a Rust panic in another language or vice versa is not
+specified. The Rust unwind may or may not run non-Rust destructors as it
+unwinds. Propagating a Rust panic through non-Rust code may require
+target-specific options for the non-Rust code, or may not be supported at all.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+TODO
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+TODO
+
+- https://github.com/rust-lang/rfcs/pull/2699
+
+# Prior art
+[prior-art]: #prior-art
+
+TODO
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+TODO
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+TODO
+
+- `unwind(abort)`
+- non-"C" ABIs

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -70,5 +70,7 @@ TODO
 
 TODO
 
+- https://github.com/rust-lang/rfcs/pull/2699
+
 - `unwind(abort)`
 - non-"C" ABIs

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -25,25 +25,22 @@ The `#[unwind(allowed)]` attribute permits functions with non-Rust ABIs (e.g. `e
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-TODO: incorporate changes from discussion here:
-https://github.com/rust-lang/rust/pull/63909
-
-By default, Rust assumes that an external function imported with extern "C" { ... }
-cannot unwind, and Rust will abort if a panic would propagate out of a Rust
-function with a non-"Rust" ABI ("`extern`") specification. If you specify the #[unwind(allowed)]
-attribute on a function with a non-"Rust" ABI, Rust will instead allow an unwind (such as
-a panic) to proceed through that function boundary using Rust's normal unwind
-mechanism. This may potentially allow Rust code to call non-Rust code that
-calls back into Rust code, and then allow a panic to propagate from Rust to
-Rust across the non-Rust code.
+By default, Rust assumes that an external function imported with `extern "C" {
+... }` cannot unwind, and Rust will abort if a panic would propagate out of a
+Rust function with a non-"Rust" ABI ("`extern`") specification. If you specify
+the `#[unwind(allowed)]` attribute on a function with a non-"Rust" ABI, Rust
+will instead allow an unwind (such as a panic) to proceed through that function
+boundary using Rust's normal unwind mechanism. This may potentially allow Rust
+code to call non-Rust code that calls back into Rust code, and then allow a
+panic to propagate from Rust to Rust across the non-Rust code.
 
 The Rust unwind mechanism is intentionally not specified here. Catching a Rust
 panic in Rust code compiled with a different Rust toolchain or options is not
 specified. Catching a Rust panic in another language or vice versa is not
 specified. The Rust unwind may or may not run non-Rust destructors as it
-unwinds. Propagating a Rust panic through non-Rust code is unspecified; implementations
-that define the behavior may require
-target-specific options for the non-Rust code, or this feature may not be supported at all.
+unwinds. Propagating a Rust panic through non-Rust code is unspecified;
+implementations that define the behavior may require target-specific options
+for the non-Rust code, or this feature may not be supported at all.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -26,7 +26,7 @@ The `#[unwind(allowed)]` attribute permits functions with non-Rust ABIs (e.g. `e
 [reference-level-explanation]: #reference-level-explanation
 
 By default, Rust assumes that an external function imported with `extern "C" {
-... }` cannot unwind, and Rust will abort if a panic would propagate out of a
+... }` (or another ABI other than `"Rust"`) cannot unwind, and Rust will abort if a panic would propagate out of a
 Rust function with a non-"Rust" ABI ("`extern "ABI" fn`") specification. If you specify
 the `#[unwind(allowed)]` attribute on a function with a non-"Rust" ABI, Rust
 will instead allow an unwind (such as a panic) to proceed through that function

--- a/text/0000-simple_unwind_annotation.md
+++ b/text/0000-simple_unwind_annotation.md
@@ -94,8 +94,8 @@ We should try not to prevent the RFC 2699 or other later RFC from resolving the 
 
 The alternatives considered are:
 
-1. Solve the soundness bug by aborting instead of unwinding when reaching an FFI boundary
-   (https://github.com/rust-lang/rust/issues/52652). As a workaround for applications that would
+1. Stabilize the [abort-on-FFI-boundary behavior](https://github.com/rust-lang/rust/issues/52652)
+   without providing any mechanism to change this behavior. As a workaround for applications that would
    otherwise need this unwinding, we would recommend the use of wrappers to translate Rust panics to
    and from C ABI-compatible values at FFI boundaries, with a foreign control mechanism like
    `setjmp`/`longjmp` or C++ exceptions to skip or unwind segments of foreign stack.


### PR DESCRIPTION
Some preliminary conversation and drafting took place in https://github.com/rust-lang/rust/pull/63909.

There are some remaining "TODO" sections.

[Rendered](https://github.com/rust-lang/rfcs/blob/SimpleUnwindAnnotation/text/0000-simple_unwind_annotation.md)