### PR TITLE
Fix typo

### DIFF
--- a/text/2394-async_await.md
+++ b/text/2394-async_await.md
@@ -107,7 +107,7 @@ evaluating any of the body (just like an async function).
 ```rust
 fn main() {
     let closure = async || {
-         println("Hello from async closure.");
+         println!("Hello from async closure.");
     };
     println!("Hello from main");
     let future = closure();


### PR DESCRIPTION
`println!()` is a macro and should be called with `!`.