### PR TITLE
avoid unreasonable growth of the repository size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ script:
   # of our files (e.g. ignoring directories with a leading '_').
   - touch .nojekyll
   - git add -A .
-  - git commit -m "Rebuild book at ${rev}"
-  - git push -q upstream HEAD:gh-pages > /dev/null 2>&1
+  - git commit --amend -m "Rebuild book at ${rev}"
+  - git push -q --force-with-lease upstream HEAD:gh-pages > /dev/null 2>&1
 branches:
   only:
     - master
-


### PR DESCRIPTION
At the moment, the rfcs repo is pretty huge. The big history of
gh-pages is to blame, as each gh-pages commit contains a 50MB search.js
file. There's little value in preserving history of gh-pages branch,
so let's avoid creating new commits.

Note that someone should manually squash existing commits to one on the gh-pages branch. Alternatively, we can merge a one-off change to .travis.yml for squashing. 