### PR TITLE
standard lazy types

### DIFF
--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -384,6 +384,8 @@ While it is possible to implement blocking in `#[no_std]` via a spin lock, we ex
 Spin locks are a sharp tool, which should only be used in specific circumstances (namely, when you have full control over thread scheduling).
 `#[no_std]` code might end up in user space applications with preemptive scheduling, where unbounded spin locks are inappropriate.
 
+A spin-lock based implementation of `OnceCell` is provided on crates.io in [`conquer-once`] crate.
+
 ## Poisoning
 
 As a cell can be empty or fully initialized, the proposed API does not use poisoning.
@@ -506,3 +508,4 @@ This design doesn't always work in Rust, as closing over `self` runs afoul of th
 [`lazy_static`]: https://crates.io/crates/lazy_static
 [`lazycell`]: https://crates.io/crates/lazycell
 [`once_cell`]: https://crates.io/crates/once_cell
+[`conquer-once`]: https://github.com/oliver-giersch/conquer-once

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -255,7 +255,7 @@ For this reason, the implementaion would simply deadlock, with a note that a dea
 [drawbacks]: #drawbacks
 
 * This is a moderately large addition to stdlib, there's a chance we do something wrong.
-  This can be mitigated by piece-wise stabilization (in particular, `Lazy` convenience types are optional) and the fact that API is battle-tested via `once_cell` crate.
+  This can be mitigated by piece-wise stabilization (in particular, `Lazy` convenience types are optional) and the fact that API is tested in the crates.io ecosystem via `once_cell` crate.
 
 * The design of `Lazy` type uses default type-parameter as a work-around for the absence of type-inference of statics.
 

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -180,7 +180,7 @@ static GLOBAL_DATA: Lazy<Mutex<HashMap<i32, String>>> = Lazy::new(|| {
 });
 ```
 
-Moreover, once `#[thread_local]` attribute is stable, `Lazy` will supplant `std::thread_local!` as well:
+Moreover, once `#[thread_local]` attribute is stable (which is not on the road to stabilization yet), `Lazy` will supplant `std::thread_local!` as well:
 
 ```rust
 use std::cell::{RefCell, Lazy};

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -1,0 +1,416 @@
+- Feature Name: `once_cell`
+- Start Date: 2019-10-17
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Add support for lazy initialized values to standard library, effectively superseding the popular [`lazy_static`] crate.
+
+```rust
+use std::sync::Lazy;
+
+// `BACKTRACE` implements `Deref<Target = Option<String>>` and is initialized
+// on the first access
+static BACKTRACE: Lazy<Option<String>> = Lazy::new(|| {
+    std::env::var("RUST_BACKTRACE").ok()
+});
+```
+
+# Motivation
+[motivation]: #motivation
+
+Working with lazy initialized values is ubiquitous, [`lazy_static`] and [`lazycell`] crates have more than 20 million downloads combined.
+Although some of the popularity of `lazy_static` can be attributed to current limitations of constant evaluation in Rust, there are many cases when even perfect const fn can't replace lazy values.
+
+At the same time, working with lazy values in Rust is not easy:
+
+* Implementing them requires moderately tricky unsafe code. Multiple soundness holes were found in the implementations from crates.io.
+* C++ and Java provide language-level delayed initialization for static values, while Rust requires explicit code to handle runtime-initialization.
+* Rust borrowing rules require a special pattern when implementing lazy fields.
+
+While `lazy_static` is implemented using macros, to work-around language limitations, today it is possible to implement similar functionality without resorting to macros, as a natural combination of two features:
+* lazy values
+* `static` keyword
+
+We can have a single canonical API for a commonly used tricky unsafe concept, so we probably should have it!
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Lazy values are a form of interior mutability.
+The key observation is that restricting a cell to single assignment allows to safely return a shared reference to the contents of the cell.
+Such cell is called `OnceCell`, by analogy with `std::sync::Once` type. The core API is as follows:
+
+```rust
+pub struct OnceCell<T> { ... }
+
+impl<T> OnceCell<T> {
+    /// Creates a new empty cell.
+    pub const fn new() -> OnceCell<T>;
+
+    /// Gets the reference to the underlying value.
+    ///
+    /// Returns `None` if the cell is empty.
+    pub fn get(&self) -> Option<&T>;
+
+    /// Sets the contents of this cell to `value`.
+    ///
+    /// Returns `Ok(())` if the cell was empty and `Err(value)` if it was
+    /// full.
+    pub fn set(&self, value: T) -> Result<(), T>;
+
+    /// Gets the contents of the cell, initializing it with `f`
+    /// if the cell was empty.
+    ///
+    /// # Panics
+    ///
+    /// If `f` panics, the panic is propagated to the caller, and the cell
+    /// remains uninitialized.
+    ///
+    /// It is an error to reentrantly initialize the cell from `f`. Doing
+    /// so results in a panic.
+    pub fn get_or_init<F>(&self, f: F) -> &T
+    where
+        F: FnOnce() -> T,
+    ;
+
+    /// Gets the contents of the cell, initializing it with `f` if
+    /// the cell was empty. If the cell was empty and `f` failed, an
+    /// error is returned.
+    ///
+    /// # Panics
+    ///
+    /// If `f` panics, the panic is propagated to the caller, and the cell
+    /// remains uninitialized.
+    ///
+    /// It is an error to reentrantly initialize the cell from `f`. Doing
+    /// so results in a panic.
+    pub fn get_or_try_init<F, E>(&self, f: F) -> Result<&T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    ;
+}
+```
+
+Notable features of the API:
+
+* `OnceCell` is created empty, by a const fn.
+* Initialization succeeds at most once.
+* `get_or_init` and `get_or_try_init` methods can be used to conveniently initialize a cell.
+* `get_` family of methods return `&T`.
+
+Similarly to other interior mutability primitives, `OnceCell` comes in two flavors:
+
+* Non thread-safe `std::cell::OnceCell`.
+* Thread-safe `std::sync::OnceCell`.
+
+Here's how `OnceCell` can be used to implement lazy-initialized global data:
+
+```rust
+use std::{sync::{Mutex, OnceCell}, collections::HashMap};
+
+fn global_data() -> &'static Mutex<HashMap<i32, String>> {
+    static INSTANCE: OnceCell<Mutex<HashMap<i32, String>>> = OnceCell::new();
+    INSTANCE.get_or_init(|| {
+        let mut m = HashMap::new();
+        m.insert(13, "Spica".to_string());
+        m.insert(74, "Hoyten".to_string());
+        Mutex::new(m)
+    })
+}
+```
+
+Here's how `OnceCell` can be used to implement a lazy field:
+
+```rust
+use std::{fs, io, path::PathBuf, cell::OnceCell};
+
+struct Ctx {
+    config_path: PathBuf,
+    config: OnceCell<String>,
+}
+
+impl Ctx {
+    pub fn get_config(&self) -> Result<&str, io::Error> {
+        let cfg = self.config.get_or_try_init(|| {
+            fs::read_to_string(&self.config_path)
+        })?;
+        Ok(cfg.as_str())
+    }
+}
+```
+
+We also provide a more convenient but less powerful `Lazy<T, F>` wrapper around `OnceCell<T>`, which allows to specify the initializing closure at creation time:
+
+```rust
+pub struct Lazy<T, F = fn() -> T> { ... }
+
+impl<T, F> Lazy<T, F> {
+    /// Creates a new lazy value with the given initializing function.
+    pub const fn new(init: F) -> Lazy<T, F>;
+}
+
+impl<T, F: FnOnce() -> T> Lazy<T, F> {
+    /// Forces the evaluation of this lazy value and returns a reference to
+    /// the result.
+    ///
+    /// This is equivalent to the `Deref` impl, but is explicit.
+    pub fn force(this: &Lazy<T, F>) -> &T;
+}
+
+impl<T, F: FnOnce() -> T> Deref for Lazy<T, F> {
+    type Target = T;
+
+    fn deref(&self) -> &T;
+}
+```
+
+`Lazy` directly replaces `lazy_static!`:
+
+```rust
+use std::{sync::{Mutex, Lazy}, collections::HashMap};
+
+static GLOBAL_DATA: Lazy<Mutex<HashMap<i32, String>>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert(13, "Spica".to_string());
+    m.insert(74, "Hoyten".to_string());
+    Mutex::new(m)
+});
+```
+
+Moreover, once `#[thread_local]` attribute is stable, `Lazy` will supplant `std::thread_local!` as well:
+
+```rust
+use std::cell::{RefCell, Lazy};
+
+#[thread_local]
+pub static FOO: Lazy<RefCell<u32>> = Lazy::new(|| RefCell::new(1));
+```
+
+Unlike `lazy_static!`, `Lazy` can be used used for locals:
+
+```rust
+use std::cell::Lazy;
+
+fn main() {
+    let ctx = vec![1, 2, 3];
+    let thunk = Lazy::new(|| {
+        ctx.iter().sum::<i32>()
+    });
+    assert_eq!(*thunk, 6);
+}
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The proposed API is directly copied from [`once_cell`] crate.
+
+Altogether, this RFC proposes to add four types:
+
+* `std::cell::OnceCell`, `std::cell::Lazy`
+* `std::sync::OnceCell`, `std::sync::Lazy`
+
+`OnceCell` is an important core primitive.
+`Lazy` can be stabilized separately from `OnceCell`, or it can be omitted from the standard library altogether.
+However, it provides significantly nicer ergonomics for the common use-case of static lazy values.
+
+Non thread-safe flavor is implemented by storing an `UnsafeCell<Option<T>>`:
+
+```rust
+pub struct OnceCell<T> {
+    // Invariant: written to at most once.
+    inner: UnsafeCell<Option<T>>,
+}
+```
+
+The implementation is mostly straightforward.
+The only tricky bit is that reentrant initialization should be explicitly forbidden.
+That is, the following program panics:
+
+```rust
+let x: OnceCell<Box<i32>> = OnceCell::new();
+let dangling_ref: Cell<Option<&i32>> = Cell::new(None);
+x.get_or_init(|| {
+    let r = x.get_or_init(|| Box::new(92));
+    dangling_ref.set(Some(r));
+    Box::new(62)
+});
+println!("would be use after free: {:?}", dangling_ref.get().unwrap());
+```
+
+Non thread-safe flavor can be added to `core` as well.
+
+The thread-safe variant is implemented similarly to `std::sync::Once`.
+Crucially, it has support for blocking: if many threads call `get_or_init` concurrently, only one will be able to execute the closure, while all other threads will block.
+For this reason, `std::sync::OnceCell` can not be provided in core.
+Even the minimal `OnceCell::<T>::set` API requires support for blocking, because one can't atomically set arbitrary `T`.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+* This is a moderately large addition to stdlib, there's a chance we do something wrong.
+  This can be mitigated by piece-wise stabilization (in particular, `Lazy` convenience types are optional) and the fact that API is battle-tested via `once_cell` crate.
+
+* The design of `Lazy` type uses default type-parameter as a work-around for the absence of type-inference of statics.
+
+* We use the same name for unsync and sync types, which might be confusing.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+## Why not `Lazy` as a primitive?
+
+On the first look, it may seem like we don't need `OnceCell`, and should only provide `Lazy`.
+The critical drawback of `Lazy` is that it's not always possible to provide the closure at creation time.
+
+This is important for lazy fields:
+
+```rust
+struct Ctx {
+    config_path: PathBuf,
+    config: Lazy<String, ???>,
+}
+
+impl Ctx {
+    pub fn new(config_path: PathBuf) -> Ctx {
+        Ctx {
+            config_path,
+            config: Lazy::new(|| {
+                // We would like to write something like
+                // `fs::read_to_string(&self.config_path)`
+                // here, but we can't have access to `self`
+                ???
+            })
+        }
+    }
+}
+```
+
+Or for singletons, initialized with parameters:
+
+```rust
+use std::{env, io, sync::OnceCell};
+
+#[derive(Debug)]
+pub struct Logger { ... }
+
+static INSTANCE: OnceCell<Logger> = OnceCell::new();
+impl Logger {
+    pub fn global() -> &'static Logger {
+        INSTANCE.get().expect("logger is not initialized")
+    }
+    fn from_cli(args: env::Args) -> Result<Logger, std::io::Error> { ... }
+}
+
+fn main() {
+    let logger = Logger::from_cli(env::args()).unwrap();
+
+    // Note how we use locally-created value for initialization.
+    INSTANCE.set(logger).unwrap();
+
+    // use `Logger::global()` from now on
+}
+```
+
+## Why `OnceCell` as a primitive?
+
+It is possible to imagine a type, slightly more general than `OnceCell`:
+
+```rust
+struct OnceFlipCell<U, V> { ... }
+
+impl<U, V> OnceFlipCell<U, V> {
+    const fn new(initial_value: U) -> OnceFlipCell<U, V>;
+
+    fn get_or_init<F: FnOnce(U) -> V>(&self, f: F) -> &V;
+}
+
+type OnceCell<T> = OnceFlipCell<(), T>;
+```
+
+That is, we can store some initial state in the cell and consume it during initialization.
+In practice, such flexibility seems to be rarely required.
+Even if we add a type, similar to `OnceFlipCell`, having a dedicated `OnceCell` (which *could* be implemented on top of `OnceFlipCell`) type simplifies common use-case.
+
+## Poisoning
+
+As a cell can be empty or fully initialized, the proposed API does not use poisoning.
+If an initialization function panics, the cell remains uninitialized.
+An alternative would be to add poisoning, which will make all subsequent `get` calls to panic.
+
+Similarly, because `OnceCell` provides strong exception safety guarantee, it implements `UnwindSafe`:
+
+```rust
+impl<T: UnwindSafe>                    UnwindSafe for OnceCell<T> {}
+impl<T: UnwindSafe + RefUnwindSafe> RefUnwindSafe for OnceCell<T> {}
+```
+
+## Default type parameter on `Lazy`
+
+`Lazy` is defined with default type parameter.
+
+```rust
+pub struct Lazy<T, F = fn() -> T> { ... }
+```
+
+This is important to make using `Lazy` in static contexts convenient.
+Without this default, the user would have to type `T` type twice:
+
+```rust
+static GLOBAL_DATA: Lazy<Mutex<HashMap<i32, String>>, fn() -> Mutex<HashMap<i32, String>>
+    = Lazy::new(|| ... );
+```
+
+If we allow type inference in statics, this could be shortened to
+
+```rust
+static GLOBAL_DATA: Lazy<Mutex<HashMap<i32, String>>, _>
+    = Lazy::new(|| ... );
+```
+
+There are two drawbacks of using fn pointer type:
+
+* fn pointers are not ZSTs, so we waste one pointer per static lazy value.
+  Lazy locals will generally rely on type-inference and will use more specific closure type.
+* Specifying type for local lazy value might be tricky: `let x: Lazy<i32> = Lazy::new(|| closed_over_var)` fails with type error, the correct syntax is `let x: Lazy<i32, _> = Lazy::new(|| closed_over_var)`.
+
+## Only thread-safe flavor
+
+It is possible to add only `sync` version of the types, as they are the most useful.
+However, this will be against zero cost abstractions spirit.
+Additionally, non thread-safe version is required to replace `thread_local!` macro without imposing synchronization.
+
+# Prior art
+[prior-art]: #prior-art
+
+The primary bit of prior art here is the [`once_cell`] library, which itself draws on multiple sources:
+
+* [double-checked-cell](https://crates.io/crates/double-checked-cell)
+* [lazy-init](https://crates.io/crates/lazy-init)
+* [lazycell](https://crates.io/crates/lazycell)
+* [mitochondria](https://crates.io/crates/mitochondria)
+* [lazy_static](https://crates.io/crates/lazy_static)
+
+Many languages provide library-defined lazy values, for example [Kotlin](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/lazy.html#kotlin$lazy(kotlin.Function0((kotlin.lazy.T)))).
+Typically, a lazy value is just a wrapper around closure.
+This design doesn't always work in Rust, as closing over `self` runs afoul of the borrow checker, we need a more primitive `OnceCell` type.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What is the best naming/place for these types?
+- What is the best naming scheme for methods? Is it `get_or_try_init` or `try_inert_with`?
+- Is the `F = fn() -> T` hack worth it?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+* Once `#[thread_local]` attribute is stable, `cell::Lazy` can serve as a replacement for `std::thread_local!` macro.
+* Supporting type inference in constants might allow us to drop the default type parameter on `Lazy`.
+
+[`lazy_static`]: https://crates.io/crates/lazy_static
+[`lazycell`]: https://crates.io/crates/lazycell
+[`once_cell`]: https://crates.io/crates/once_cell

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -22,7 +22,7 @@ static BACKTRACE: Lazy<Option<String>> = Lazy::new(|| {
 [motivation]: #motivation
 
 Working with lazy initialized values is ubiquitous, [`lazy_static`] and [`lazycell`] crates have more than 20 million downloads combined.
-Although some of the popularity of `lazy_static` can be attributed to current limitations of constant evaluation in Rust, there are many cases when even perfect const fn can't replace lazy values.
+Although some of the popularity of `lazy_static` can be attributed to current limitations of constant evaluation in Rust, there are many cases when even perfect `const fn` can't replace lazy values.
 
 At the same time, working with lazy values in Rust is not easy:
 
@@ -333,7 +333,7 @@ type OnceCell<T> = OnceFlipCell<(), T>;
 
 That is, we can store some initial state in the cell and consume it during initialization.
 In practice, such flexibility seems to be rarely required.
-Even if we add a type, similar to `OnceFlipCell`, having a dedicated `OnceCell` (which *could* be implemented on top of `OnceFlipCell`) type simplifies common use-case.
+Even if we add a type, similar to `OnceFlipCell`, having a dedicated `OnceCell` (which *could* be implemented on top of `OnceFlipCell`) type simplifies a common use-case.
 
 ## Poisoning
 
@@ -380,7 +380,7 @@ There are two drawbacks of using fn pointer type:
 ## Only thread-safe flavor
 
 It is possible to add only `sync` version of the types, as they are the most useful.
-However, this will be against zero cost abstractions spirit.
+However, this would be against zero cost abstractions spirit.
 Additionally, non thread-safe version is required to replace `thread_local!` macro without imposing synchronization.
 
 # Prior art

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -189,6 +189,8 @@ use std::cell::{RefCell, Lazy};
 pub static FOO: Lazy<RefCell<u32>> = Lazy::new(|| RefCell::new(1));
 ```
 
+However, `#[thread_local]` attribute is pretty far from stabilization at the moment, and due to the required special handling of destructors, it's unclear if just using `cell::Lazy` will work out.
+
 Unlike `lazy_static!`, `Lazy` can be used used for locals:
 
 ```rust
@@ -202,8 +204,6 @@ fn main() {
     assert_eq!(*thunk, 6);
 }
 ```
-
-However, `#[thread_local]` attribute is pretty far from stabilization at the moment, and due to the required special handling of destructors, it's unclear if just using `cell::Lazy` will work out.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -191,7 +191,7 @@ pub static FOO: Lazy<RefCell<u32>> = Lazy::new(|| RefCell::new(1));
 
 However, `#[thread_local]` attribute is pretty far from stabilization at the moment, and due to the required special handling of destructors, it's unclear if just using `cell::Lazy` will work out.
 
-Unlike `lazy_static!`, `Lazy` can be used used for locals:
+Unlike `lazy_static!`, `Lazy` can be used for locals:
 
 ```rust
 use std::cell::Lazy;

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -21,7 +21,7 @@ static BACKTRACE: Lazy<Option<String>> = Lazy::new(|| {
 # Motivation
 [motivation]: #motivation
 
-Working with lazy initialized values is ubiquitous, [`lazy_static`] and [`lazycell`] crates have more than 20 million downloads combined.
+Working with lazy initialized values is ubiquitous, [`lazy_static`] and [`lazycell`] crates are used throughout the ecosystem.
 Although some of the popularity of `lazy_static` can be attributed to current limitations of constant evaluation in Rust, there are many cases when even perfect `const fn` can't replace lazy values.
 
 At the same time, working with lazy values in Rust is not easy:

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -70,7 +70,7 @@ impl<T> OnceCell<T> {
     /// remains uninitialized.
     ///
     /// It is an error to reentrantly initialize the cell from `f`. Doing
-    /// so results in a panic.
+    /// so results in a panic or a deadlock.
     pub fn get_or_init<F>(&self, f: F) -> &T
     where
         F: FnOnce() -> T,
@@ -86,7 +86,7 @@ impl<T> OnceCell<T> {
     /// remains uninitialized.
     ///
     /// It is an error to reentrantly initialize the cell from `f`. Doing
-    /// so results in a panic.
+    /// so results in a panic or a deadlock.
     pub fn get_or_try_init<F, E>(&self, f: F) -> Result<&T, E>
     where
         F: FnOnce() -> Result<T, E>,
@@ -246,6 +246,8 @@ Non thread-safe flavor can be added to `core` as well.
 The thread-safe variant is implemented similarly to `std::sync::Once`.
 Crucially, it has support for blocking: if many threads call `get_or_init` concurrently, only one will be able to execute the closure, while all other threads will block.
 For this reason, most of `std::sync::OnceCell` API can not be provided in `core`.
+In the `sync` case, reliably panicking on re-entrant initialization is not trivial.
+For this reason, the implementaion would simply deadlock, with a note that a deadlock might be elevated to panic in the future.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-standard-lazy-types.md
+++ b/text/0000-standard-lazy-types.md
@@ -180,7 +180,7 @@ static GLOBAL_DATA: Lazy<Mutex<HashMap<i32, String>>> = Lazy::new(|| {
 });
 ```
 
-Moreover, once `#[thread_local]` attribute is stable (which is not on the road to stabilization yet), `Lazy` will supplant `std::thread_local!` as well:
+Moreover, once `#[thread_local]` attribute is stable, `Lazy` might supplant `std::thread_local!` as well:
 
 ```rust
 use std::cell::{RefCell, Lazy};
@@ -202,6 +202,8 @@ fn main() {
     assert_eq!(*thunk, 6);
 }
 ```
+
+However, `#[thread_local]` attribute is pretty far from stabilization at the moment, and due to the required special handling of destructors, it's unclear if just using `cell::Lazy` will work out.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/text/2788-standard-lazy-types.md
+++ b/text/2788-standard-lazy-types.md
@@ -1,7 +1,7 @@
 - Feature Name: `once_cell`
 - Start Date: 2019-10-17
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- RFC PR: [rust-lang/rfcs#2788](https://github.com/rust-lang/rfcs/pull/2788)
+- Rust Issue: [rust-lang/rust#74465](https://github.com/rust-lang/rust/issues/74465)
 
 # Summary
 [summary]: #summary
@@ -148,7 +148,7 @@ pub struct LazyCell<T, F = fn() -> T> { ... }
 impl<T, F: FnOnce() -> T> LazyCell<T, F> {
     /// Creates a new lazy value with the given initializing function.
     pub const fn new(init: F) -> LazyCell<T, F>;
-    
+
     /// Forces the evaluation of this lazy value and returns a reference to
     /// the result.
     ///


### PR DESCRIPTION
Add support for lazy initialized values to standard library, effectively superseding the popular `lazy_static` crate.

```rust
use std::sync::Lazy;

// `BACKTRACE` implements `Deref<Target = Option<String>>` 
// and is initialized on the first access
static BACKTRACE: Lazy<Option<String>> = Lazy::new(|| {
    std::env::var("RUST_BACKTRACE").ok()
});
```

[Rendered](https://github.com/matklad/rfcs/blob/std-lazy/text/0000-standard-lazy-types.md)