### PR TITLE
Propose implicit named arguments for formatting macros

### DIFF
--- a/text/0000-format-args-implicit-identifiers.md
+++ b/text/0000-format-args-implicit-identifiers.md
@@ -193,7 +193,7 @@ However, Python 3 cannot improve the ergonomics of these functions in the same w
 
 but as noted in [PEP 498](https://www.python.org/dev/peps/pep-0498/#no-use-of-globals-or-locals), the Python language designers had reasons why they wanted to avoid this pattern becoming commonplace in Python code.)
 
-Rust's macros are not constrained by the same technical limitations, being free to introduce syntax as long as it is supported by the macro system and hygeiene. The macros can therefore enjoy carefully-designed ergonomic improvements without needing to reach for large extensions such as interpolation.
+Rust's macros are not constrained by the same technical limitations, being free to introduce syntax as long as it is supported by the macro system and hygiene. The macros can therefore enjoy carefully-designed ergonomic improvements without needing to reach for large extensions such as interpolation.
 
 The RFC author would argue that if named arguments (implicit or regular) become popular as a result of implementation of this RFC, then the following interpolation-free invocations would be easy to read and good style:
 

--- a/text/0000-format-args-implicit-identifiers.md
+++ b/text/0000-format-args-implicit-identifiers.md
@@ -18,7 +18,7 @@ This would result in downstream macros based on `format_args!` to accept implici
     // implicit named arguments `species` and `name`
     format!("The {species}'s name is {name}.");
 
-(Downstream macros based on `format_args!` includes but is not limited to `format!`, `print!`, `write!`, `panic!`, and macros in the `log` crate.)
+(Downstream macros based on `format_args!` include but are not limited to `format!`, `print!`, `write!`, `panic!`, and macros in the `log` crate.)
 
 
 # Motivation
@@ -185,7 +185,7 @@ For example, Python 3's `.format()` method is on the surface extremely similar t
     "hello {}".format(person)
     "hello {person}".format(person=person)
 
-However, Python 3 cannot improve the ergonomics of these functions in the same way that this RFC proposes to use implicit named arguments. This is for technical reasons: Python simply does not have a language mechanism which could be used to add implicit named arguments to the `.format()` method. As a result, offering improved ergonomics in Python would neccesitate the introduction of a language-level interpolation syntax.
+However, Python 3 cannot improve the ergonomics of these functions in the same way that this RFC proposes to use implicit named arguments. This is for technical reasons: Python simply does not have a language mechanism which could be used to add implicit named arguments to the `.format()` method. As a result, offering improved ergonomics in Python necessitated the introduction of a language-level interpolation syntax (f-strings, described in the [prior art](#prior-art) section).
 
 (Note, the closest Python 3's `.format()` can get to implicit named arguments is this:
 
@@ -257,8 +257,8 @@ The following code would be the equivalent way to produce a new string combining
 
     // Scala
     s"$greeting $person"
-    
-    // PHP
+
+    // Perl and PHP
     "$greeting $person"
 
 It is the RFC author's experience that these interpolating mechanisms read easily from left-to-right and it is clear where each variable is being substituted into the format string.
@@ -272,7 +272,7 @@ Implementing implicit named arguments in the fashion suggested in this RFC would
 
 It should be noted, however, that other languages' string interpolation mechanisms allow substitution of a wide variety of expressions beyond the simple identifier case that this RFC is focussed on.
 
-Please see the discusison on [interpolation](#interpolation) as an alternative to this RFC.
+Please see the discussion on [interpolation](#interpolation) as an alternative to this RFC.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/0000-format-args-implicit-identifiers.md
+++ b/text/0000-format-args-implicit-identifiers.md
@@ -331,10 +331,14 @@ It is not clear how significant a change this might require to `format_args!`'s 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-The main alternative raised by this RFC is interpolation, which is a superset of the functionality offered by implicit named arguments.
+The main alternative raised by this RFC is interpolation, which is a superset of the functionality offered by implicit named arguments. However, for reasons discussed above, interpolation is not the objective of this RFC.
 
 Accepting the addition of implicit named arguments now is not incompatible with adding interpolation at a later date.
 
-In particular the RFC author expects that more than once in the future he'll be frustrated that formatting macro invocations which involve field access will require significantly more typing than invocations receiving implicit named arguments!
+Future discussion on this topic may also focus on adding interpolation for just a subset of possible expressions, for example `dotted.paths`. We noted in debate for this RFC that particularly for formatting parameters the existing dollar syntax appears problematic for both parsing and reading, for example `{self.x:self.width$.self.precision$}`.
 
-However, for reasons discussed above, interpolation is not the objective of this RFC.
+The conclusion we came to in the RFC discussion is that adding even just interpolations for `dotted.paths` will therefore want a new syntax, which we nominally chose as the `{(expr)}` syntax already suggested in the [interpolation](#interpolation) alternative section of this RFC.
+
+Using this parentheses syntax, for example, we might one day accept `{(self.x):(self.width).(self.precision)}` to support `dotted.paths` and a few other simple expressions. The choice of whether to support an expanded subset, support interpolation of all expressions, or not to add any further complexity to this macro is deferred to the future.
+
+A future proposal for extending interpolation support might wish to explore alternative syntaxes to `{(expr)}` parentheses which can also be parsed and read comfortably.

--- a/text/0000-format-args-implicit-identifiers.md
+++ b/text/0000-format-args-implicit-identifiers.md
@@ -255,8 +255,11 @@ The following code would be the equivalent way to produce a new string combining
     // Ruby
     "#{greeting} #{person}"
 
-    // Scala / PHP
+    // Scala
     s"$greeting $person"
+    
+    // PHP
+    "$greeting $person"
 
 It is the RFC author's experience that these interpolating mechanisms read easily from left-to-right and it is clear where each variable is being substituted into the format string.
 


### PR DESCRIPTION
[Rendered](https://github.com/davidhewitt/rfcs/blob/format-args-implicit-identifiers/text/0000-format-args-implicit-identifiers.md)

Proposes the ability to pass **implicit named arguments** to formatting macros, for example:

    let person = "Charlie";
    print!("Hello, {person}!");    // implicit named argument `person`

A follow up to internals discussion https://internals.rust-lang.org/t/println-use-named-arguments-from-scope/10633 and WIP PR https://github.com/rust-lang/rust/pull/65338