### PR TITLE
Add tracking issue for #!feature(async_closure)]

### DIFF
--- a/text/2394-async_await.md
+++ b/text/2394-async_await.md
@@ -1,7 +1,9 @@
 - Feature Name: async_await
 - Start Date: 2018-03-30
 - RFC PR: [rust-lang/rfcs#2394](https://github.com/rust-lang/rfcs/pull/2394)
-- Rust Issue: [rust-lang/rust#50547](https://github.com/rust-lang/rust/issues/50547)
+- Rust Issues: 
+  - [rust-lang/rust#50547](https://github.com/rust-lang/rust/issues/50547)
+  - [rust-lang/rust#62290](https://github.com/rust-lang/rust/issues/62290) - #!feature(async_closure)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
This RFC isn't fully implemented, but tracking bug is closed. 
This PR adds a tracking bug I found for part of the RFC that is not implemented.
There may be other open tracking bugs. This PR is intended to be an improvement,
may not be a complete fix for issue:  https://github.com/rust-lang/rust/issues/66909