### PR TITLE
Replace #2603's (Rust Symbol Mangling) "v2" with "v0".

### DIFF
--- a/text/2603-rust-symbol-name-mangling-v0.md
+++ b/text/2603-rust-symbol-name-mangling-v0.md
@@ -1,4 +1,4 @@
-- Feature Name: `symbol_name_mangling_v2`
+- Feature Name: N/A
 - Start Date: 2018-11-27
 - RFC PR: [rust-lang/rfcs#2603](https://github.com/rust-lang/rfcs/pull/2603)
 - Rust Issue: [rust-lang/rust#60705](https://github.com/rust-lang/rust/issues/60705)


### PR DESCRIPTION
When #2603 was implemented, we decided on these names (https://github.com/rust-lang/rust/pull/57967#issuecomment-463596992):
* `legacy`, for the pre-#2603 mangling based on the Itanium C++ one
* `v0`, for the #2603 mangling

That differs from the RFC, so I've renamed away the "v2" in the RFC title (https://github.com/rust-lang/rfcs/pull/2603#event-3127804967) and the tracking issue (https://github.com/rust-lang/rust/issues/60705#event-3127801831), and that leaves the file itself.

cc @rust-lang/compiler