### PR TITLE
RFC - cargo templates

### DIFF
--- a/text/0000-cargo-templates.md
+++ b/text/0000-cargo-templates.md
@@ -153,7 +153,7 @@ In addition, there was a lot of discussion both from the Cargo team and the comm
 
 # What lessons can we learn from what other communities have done here?
 
-There are pros and cons to having templates or some type of template ecosystem. I think the biggest question is **who will maintain them?**It may not be directly related, but it's an important point to consider should templates be added to `cargo new` .
+There are pros and cons to having templates or some type of template ecosystem. I think the biggest question is **who will maintain them?** It may not be directly related, but it's an important point to consider should templates be added to `cargo new` .
 
 If we return to our examples from the JavaScript industry, there are two that stick out:
 

--- a/text/0000-cargo-templates.md
+++ b/text/0000-cargo-templates.md
@@ -145,7 +145,7 @@ A [similar RFC](https://internals.rust-lang.org/t/pre-rfc-cargo-templates/5056) 
 
 The community has also created two crates that solve similar problems:
 
-* [cargo-generate](<https://crates.io/crates/cargo-generate>): a developer tool to help you get up and running quickly with a new Rust project by leveraging a pre-existing git repository as a template
+* [cargo-generate](https://crates.io/crates/cargo-generate): a developer tool to help you get up and running quickly with a new Rust project by leveraging a pre-existing git repository as a template
 * [kickstart](https://github.com/Keats/kickstart): created by @Keats described as "A scaffolding tool to get new projects up and running quickly"
 * [cookiecutter](https://github.com/cookiecutter/cookiecutter) : not a Rust project, but "A command-line utility that creates projects from cookiecutters (project templates)"
 

--- a/text/0000-cargo-templates.md
+++ b/text/0000-cargo-templates.md
@@ -147,7 +147,7 @@ The community has also created two crates that solve similar problems:
 
 * [cargo-generate](<https://crates.io/crates/cargo-generate>): a developer tool to help you get up and running quickly with a new Rust project by leveraging a pre-existing git repository as a template
 * [kickstart](https://github.com/Keats/kickstart): created by @Keats described as "A scaffolding tool to get new projects up and running quickly"
-* [cookiecutter](<https://github.com/cookiecutter/cookiecutter>) : not a Rust project, but "A command-line utility that creates projects from cookiecutters (project templates)"
+* [cookiecutter](https://github.com/cookiecutter/cookiecutter) : not a Rust project, but "A command-line utility that creates projects from cookiecutters (project templates)"
 
 In addition, there was a lot of discussion both from the Cargo team and the community on [this issue](https://github.com/rust-lang/cargo/issues/3506). It has been decided that there [still remains disagreement](https://github.com/rust-lang/cargo/pull/8029#issuecomment-604756599) among both the Cargo team and the community on how to solve this, hence why this RFC seems to be the logical next step.
 

--- a/text/0000-cargo-templates.md
+++ b/text/0000-cargo-templates.md
@@ -64,8 +64,8 @@ Note: the same examples could be used with `cargo init` as well.
 
 To summarize, the following is the syntax for using a template
 
-* `cargo new <project-name> --template <crate-name>/<template-name>`
-* `cargo init <project-name> --template <crate-name>/<template-name>`
+* `cargo new <path> --template <crate-name>/<template-name>`
+* `cargo init <path> --template <crate-name>/<template-name>`
 
 # Drawbacks
 


### PR DESCRIPTION
### [🖼️ Rendered](https://github.com/jsjoeio/rfcs/blob/master/text/0000-cargo-templates.md)

### 📝 Summary 
RFC for the following new feature:
> Add the ability to reference a template when running `cargo new` or `cargo init`

Example using a template from the `rocket` crate:
```
cargo new my-rocket-app --template rocket/hello-world
```


### 💁 Additional Notes
This RFC went through two Pre-RFCs, which can be viewed here:
- [v1](https://internals.rust-lang.org/t/pre-rfc-cargo-new-templates/12060/10)
- [v2](https://internals.rust-lang.org/t/pre-rfc-cargo-new-templates-v2/12089)