### PR TITLE
RFC: Deprecate FromStr in favor of TryFrom<&str>

### DIFF
--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -56,7 +56,7 @@ impl From<&str> for Dummy {
 struct Dummy<'a>(&'a str);
 
 // This doesn't compile
-impl<'a> FromStr for Dummy<'a> {
+impl<'a> std::str::FromStr for Dummy<'a> {
     type Err = core::convert::Infallible;
     
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -11,7 +11,7 @@ Deprecate [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) in f
 # Motivation
 [motivation]: #motivation
 
-`FromStr` was created when `TryFrom` did not exist, `FromStr` is now superfluous.
+[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) was created when [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) did not exist, [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) is now superfluous.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -56,9 +56,9 @@ assert_eq!(p.unwrap(), Point { x: 1, y: 2 })
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-- Mark `FromStr` as deprecated
-- Mark `str::parse()` as deprecated
-- Make `FromStr` implement `TryFrom<&str>`:
+- Mark [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) as deprecated
+- Mark [`str::parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) as deprecated
+- Make [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) implement `TryFrom<&str>` with [specialization](https://github.com/rust-lang/rfcs/pull/1210):
 ```rust
 impl<T> TryFrom<String> for T
 where

--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -11,9 +11,7 @@ Deprecate [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) in f
 # Motivation
 [motivation]: #motivation
 
-`FromStr` was created when `TryFrom` did not exist.
-
-As such, `FromStr` is now superfluous.
+`FromStr` was created when `TryFrom` did not exist, `FromStr` is now superfluous.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -27,7 +27,7 @@ struct Point {
     y: i32,
 }
 
-impl From<&str> for Point {
+impl TryFrom<&str> for Point {
     type Error = ParseIntError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
@@ -56,14 +56,25 @@ assert_eq!(p.unwrap(), Point { x: 1, y: 2 })
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-- Replace all `FromStr` implementation in `std` with the corresponding `TryFrom<&str>`
-- Rewrite `str::parse()` to use `TryFrom<&str>`
 - Mark `FromStr` as deprecated
+- Mark `std::parse()` as deprecated
+- Make `FromStr` implement `TryFrom<&str>`:
+```rust
+impl<T> TryFrom<String> for T
+where
+    T: FromStr,
+{
+    type Error = <T as FromStr>::Err;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+```
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- Backward compatibility will be broken
 - `TryFrom<&str> for U` implies `TryInto<U> for &str` which may be unwanted
 
 # Rationale and alternatives

--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -1,0 +1,83 @@
+- Feature Name: deprecate_fromstr
+- Start Date: 2020-05-11
+- RFC PR: TBD
+- Rust Issue: TBD
+
+# Summary
+[summary]: #summary
+
+Deprecate [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) in favor of [`TryFrom<&str>`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html)
+
+# Motivation
+[motivation]: #motivation
+
+`FromStr` was created when `TryFrom` did not exist.
+
+As such, `FromStr` is now superfluous.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Basic implementation:
+```rust
+use std::convert::TryFrom;
+use std::num::ParseIntError;
+
+#[derive(Debug, PartialEq)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+impl From<&str> for Point {
+    type Error = ParseIntError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let coords: Vec<&str> = s
+            .trim_matches(|p| p == '(' || p == ')')
+            .split(',')
+            .collect();
+
+        let x_fromstr = i32::try_from(coords[0])?;
+        let y_fromstr = i32::try_from(coords[1])?;
+
+        Ok(Point {
+            x: x_fromstr,
+            y: y_fromstr,
+        })
+    }
+}
+```
+
+Example:
+```rust
+let p = Point::try_from("(1,2)");
+assert_eq!(p.unwrap(), Point { x: 1, y: 2 })
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+- Replace all `FromStr` implementation in `std` with the corresponding `TryFrom<&str>`
+- Rewrite `str::parse()` to use `TryFrom<&str>`
+- Mark `FromStr` as deprecated
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- Backward compatibility will be broken
+- `TryFrom<&str> for U` implies `TryInto<U> for &str` which may be unwanted
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+# Prior art
+[prior-art]: #prior-art
+
+Some discussion about a tangential problem https://github.com/rust-lang/rfcs/issues/2143
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+# Future possibilities
+[future-possibilities]: #future-possibilities

--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -57,7 +57,7 @@ assert_eq!(p.unwrap(), Point { x: 1, y: 2 })
 [reference-level-explanation]: #reference-level-explanation
 
 - Mark `FromStr` as deprecated
-- Mark `std::parse()` as deprecated
+- Mark `str::parse()` as deprecated
 - Make `FromStr` implement `TryFrom<&str>`:
 ```rust
 impl<T> TryFrom<String> for T

--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -6,14 +6,73 @@
 # Summary
 [summary]: #summary
 
-Deprecate [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) in favor of [`TryFrom<&str>`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html)
+Deprecate [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) in favor of [`TryFrom<&str>`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) and [`From<&str>`](https://doc.rust-lang.org/std/convert/trait.From.html).
 
 # Motivation
 [motivation]: #motivation
 
-[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) was created when [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) did not exist.
+[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) was created when [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) didn't exist. Now that it is stable, [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) becomes superfluous. 
 
-However now that [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) is stable [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) become superfluous.
+[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) definition is virtually identical to [`TryFrom<&str>`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html):
+```rust
+pub trait FromStr: Sized {
+    type Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err>;
+}
+
+// Where T is &str
+pub trait TryFrom<T>: Sized {
+    type Error;
+
+    fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+```
+
+Infallible conversions become more idiomatic:
+```rust
+struct Dummy(String);
+
+impl std::str::FromStr for Dummy {
+    type Err = core::convert::Infallible;
+    
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Dummy(s.to_owned()))
+    }
+}
+
+//vs
+
+impl From<&str> for Dummy {
+
+    fn from(s: &str) -> Self {
+        Dummy(s.to_owned())
+    }
+}
+```
+
+[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) limits lifetimes in a way that prevents borrowing the passed string:
+```rust
+struct Dummy<'a>(&'a str);
+
+// This doesn't compile
+impl<'a> FromStr for Dummy<'a> {
+    type Err = core::convert::Infallible;
+    
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Dummy(s))
+    }
+}
+
+//This works
+impl<'a> From<&'a str> for Dummy<'a> {
+
+    fn from(s: &'a str) -> Self {
+        Dummy(s)
+    }
+}
+
+```
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -60,27 +119,17 @@ assert_eq!(p.unwrap(), Point { x: 1, y: 2 })
 
 - Mark [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) as deprecated
 - Mark [`str::parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) as deprecated
-- Create a new blanket implementation for `TryFrom<&str>` (requires [specialization](https://github.com/rust-lang/rfcs/pull/1210)):
-```rust
-impl<T> TryFrom<&str> for T
-where
-    T: FromStr,
-{
-    type Error = <T as FromStr>::Err;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        value.parse()
-    }
-}
-```
+- Implement [`TryFrom<&str>`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) for all types implementing [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html)
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- `TryFrom<&str> for U` implies `TryInto<U> for &str` which may be unwanted
+To be discussed
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
+
+To be discussed
 
 # Prior art
 [prior-art]: #prior-art
@@ -90,5 +139,9 @@ Some discussion about a tangential problem: https://github.com/rust-lang/rfcs/is
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
+To be discussed
+
 # Future possibilities
 [future-possibilities]: #future-possibilities
+
+To be discussed

--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -11,7 +11,9 @@ Deprecate [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) in f
 # Motivation
 [motivation]: #motivation
 
-[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) was created when [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) did not exist, [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) is now superfluous.
+[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) was created when [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) did not exist.
+
+However now that [`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) is stable [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) become superfluous.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -58,9 +60,9 @@ assert_eq!(p.unwrap(), Point { x: 1, y: 2 })
 
 - Mark [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) as deprecated
 - Mark [`str::parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) as deprecated
-- Make [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) implement `TryFrom<&str>` with [specialization](https://github.com/rust-lang/rfcs/pull/1210):
+- Create a new blanket implementation for `TryFrom<&str>` (requires [specialization](https://github.com/rust-lang/rfcs/pull/1210)):
 ```rust
-impl<T> TryFrom<String> for T
+impl<T> TryFrom<&str> for T
 where
     T: FromStr,
 {
@@ -83,7 +85,7 @@ where
 # Prior art
 [prior-art]: #prior-art
 
-Some discussion about a tangential problem https://github.com/rust-lang/rfcs/issues/2143
+Some discussion about a tangential problem: https://github.com/rust-lang/rfcs/issues/2143
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/0000-deprecate-fromstr.md
+++ b/text/0000-deprecate-fromstr.md
@@ -1,6 +1,6 @@
 - Feature Name: deprecate_fromstr
 - Start Date: 2020-05-11
-- RFC PR: TBD
+- RFC PR: [#2924](https://github.com/rust-lang/rfcs/pull/2924)
 - Rust Issue: TBD
 
 # Summary


### PR DESCRIPTION
[Rendered](https://github.com/malobre/rfcs/blob/master/text/0000-deprecate-fromstr.md)

This is a work in progress.