### PR TITLE
Update 2394-async_await.md

### DIFF
--- a/text/2394-async_await.md
+++ b/text/2394-async_await.md
@@ -89,7 +89,7 @@ async fn print_async() {
 fn main() {
      let future = print_async();
      println!("Hello from main");
-     futures::block_on(future);
+     futures::executor::block_on(future);
 }
 ```
 


### PR DESCRIPTION
'block_on' function might have been moved from futures module to futures::executor module. I wonder if the dependency used there should be state explicitly?