### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,17 +252,17 @@ consensus and community norms, not impose more structure than necessary.
 
 
 [official Discord server]: https://discord.gg/rust-lang
-[developer discussion forum]: http://internals.rust-lang.org/
-[RFC repository]: http://github.com/rust-lang/rfcs
-[sub-team]: http://www.rust-lang.org/team.html
+[developer discussion forum]: https://internals.rust-lang.org/
+[RFC repository]: https://github.com/rust-lang/rfcs
+[sub-team]: https://www.rust-lang.org/team.html
 
 ## License
 [License]: #license
 
 This repository is currently in the process of being licensed under either of:
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option. Some parts of the repository are already licensed according to those terms. For more see [RFC 2044](https://github.com/rust-lang/rfcs/pull/2044) and its [tracking issue](https://github.com/rust-lang/rust/issues/43461).
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ language is evolving in.
   - [Opening](#rust-rfcs)
   - [Table of Contents]
   - [When you need to follow this process]
+  - [Sub-team specific guidelines]
   - [Before creating an RFC]
   - [What the process is]
   - [The RFC life-cycle]
@@ -29,6 +30,7 @@ language is evolving in.
   - [RFC Postponement]
   - [Help this is all too informal!]
   - [License]
+  - [Contributions]
 
 
 ## When you need to follow this process
@@ -265,5 +267,6 @@ This repository is currently in the process of being licensed under either of:
 at your option. Some parts of the repository are already licensed according to those terms. For more see [RFC 2044](https://github.com/rust-lang/rfcs/pull/2044) and its [tracking issue](https://github.com/rust-lang/rust/issues/43461).
 
 ### Contributions
+[Contributions]: #contributions
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -253,11 +253,6 @@ circumstances. As usual, we are trying to let the process be driven by
 consensus and community norms, not impose more structure than necessary.
 
 
-[official Discord server]: https://discord.gg/rust-lang
-[developer discussion forum]: https://internals.rust-lang.org/
-[RFC repository]: https://github.com/rust-lang/rfcs
-[sub-team]: https://www.rust-lang.org/team.html
-
 ## License
 [License]: #license
 
@@ -268,7 +263,14 @@ This repository is currently in the process of being licensed under either of:
 
 at your option. Some parts of the repository are already licensed according to those terms. For more see [RFC 2044](https://github.com/rust-lang/rfcs/pull/2044) and its [tracking issue](https://github.com/rust-lang/rust/issues/43461).
 
+
 ### Contributions
 [Contributions]: #contributions
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+
+[official Discord server]: https://discord.gg/rust-lang
+[developer discussion forum]: https://internals.rust-lang.org/
+[RFC repository]: https://github.com/rust-lang/rfcs
+[sub-team]: https://www.rust-lang.org/team.html

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ merged into the RFC repository as a markdown file. At that point the RFC is
   - Submit a pull request. As a pull request the RFC will receive design
     feedback from the larger community, and the author should be prepared to
     revise it in response.
+  - Now that your RFC has an open pull request, use the issue number of the PR
+    to update your `0000-` prefix to that number.
   - Each pull request will be labeled with the most relevant [sub-team], which
     will lead to its being triaged by that team in a future meeting and assigned
     to a member of the subteam.


### PR DESCRIPTION
This PR provides a few small fixes for the README:

* move global links to the end of the document
* clarify how the 0000 gets replaced with the PR issue number
* use https for all links
* adding missing ToC entries

For "clarify how the 0000 gets replaced with the PR issue number" I looked at how the rename was made in practice, since I couldn't find any instruction for it. I hope this captures it well enough.

I noticed these while adopting this RFC process for Nushell, under the MIT License: https://github.com/nushell/rfcs/pull/1 I've added an Acknowledgements section to reflect the copy we started with. If there's a problem with this approach, please let us know.