### PR TITLE
Restore copyright notice to MIT License

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,3 +1,5 @@
+Copyright (c) 2014 The Rust Project Developers
+
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the


### PR DESCRIPTION
This reverts the removal of the copyright notice from LICENSE-MIT which was done in 22badf174b66c91d01f270a12c7ae0584b527d7c
The notice is part of the [MIT license](https://opensource.org/licenses/MIT). Since the body text of the license refers to the copyright notice, it is unclear how to conform with the license when redistributing parts of 'THE SOFTWARE' unless it is included here.