### PR TITLE
Add `oneof` configuration predicate to support exclusive features

### DIFF
--- a/text/0000-cfg-oneof.md
+++ b/text/0000-cfg-oneof.md
@@ -1,0 +1,94 @@
+- Feature Name: `config_oneof`
+- Start Date: 2020-07-18
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Addition of `oneof` to existing `all`, `any`, `not` configuration predicates in `#[cfg!()]` macros
+
+# Motivation
+[motivation]: #motivation
+
+In a number of situations (particularly involving `no_std` and cross-target applications) it is useful to ensure that only one of a set of features are enabled.
+It is important to enforce this due to the additive behaviour of features (ie. dependencies may include the same sub-dependencie with different features enabled the result is a union of the enabled features), and difficult to specify for larger feature sets using existing predicates as the complexity for this increases exponentially with the number of exclusive features.
+
+The desired outcome of this is the ability to specify `#[cfg(not(oneof(feature="a", feature="b")))] compile_error!(...)` to define compilation failures without manually defining all possible valid/invalid combinations for exclusive subsets of features, and simplify other configurations that benefit from the `oneof` predicate.
+This allows authors of crates with exclusive feature sets to communicate this to consumers without requiring users to infer the feature issue from compiler errors.
+
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Additions to existing [guide](https://doc.rust-lang.org/reference/conditional-compilation.html)
+
+``` 
+ConfigurationOneof
+   oneof ( ConfigurationPredicateList )
+   
+...
+
+oneof() with a comma separated list of configuration predicates. It is true if at exactly one predicate is true. In other situations it is false.
+```
+
+Using an existing implementation from [rust-rand-facade](https://github.com/ryankurte/rust-rand-facade/blob/master/src/lib.rs) expressing all possible combinations for a set of three exclusive features (`std`, `cortex_m`, and `os_rng`).
+
+Using existing predicates:
+
+```rust
+#[cfg(all(feature = "std", feature = "cortex_m"))]
+compile_error!("Only one of 'std', 'os_rng', or 'cortex_m' features may be enabled");
+
+#[cfg(all(feature = "std", feature = "os_rng"))]
+compile_error!("Only one of 'std', 'os_rng', or 'cortex_m' features may be enabled");
+
+#[cfg(all(feature = "cortex_m", feature = "os_rng"))]
+compile_error!("Only one of 'std', 'os_rng', or 'cortex_m' features may be enabled");
+
+#[cfg(not(any(feature = "std", feature = "cortex_m", feature = "os_rng")))]
+compile_error!("One of 'os_rng', 'std', 'cortex_m' features must be enabled");
+```
+
+Using the `oneof` predicate:
+```rust
+#[cfg(not(oneof(feature = "std", feature = "cortex_m", feature = "os_rng")))]
+compile_error!("One of 'os_rng', 'std', 'cortex_m' features must be enabled");
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+- I do not believe this has significant interaction with other features, or requires any significant changes
+- Implementation should be straightforward, requiring the addition of a config predicate to `rustc` based on existing configuration predicates
+- I do not believe there are significant corner cases to be considered
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+I do not forsee any drawbacks to the addition of this predicate
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- This provides a useful improvement to the expressiveness of `#[cfg()]` macros and allows crate authors to provide actionable errors rather than depending on compiler failures
+- An alternative to `not(oneof(...))` could be `notoneof(...)` or similar, however, this is less consistent with existing predicates
+- Not implementing this means crate authors must either hand-define all variants or rely on symbol errors to enforce feature exclusivity, and users must continue to infer the _cause_ of these failures rather than being directly signalled.
+
+# Prior art
+[prior-art]: #prior-art
+
+A common mechanism for managing the _at least one_ requirement involves adding a meta-feature that is included by each target feature.
+This is common in embedded-hal device implementations such as [stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal/blob/master/Cargo.toml).
+As this does not encompass _at most one_, enabling multiple exclusive features causes errors due to symbol duplication rather than a useful error message.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+There are no obvious unresolved questions
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+There are no obvious future possibilities
+

--- a/text/0000-cfg-oneof.md
+++ b/text/0000-cfg-oneof.md
@@ -14,7 +14,7 @@ Addition of `oneof` to existing `all`, `any`, `not` configuration predicates in 
 In a number of situations (particularly involving `no_std` and cross-target applications) it is useful to ensure that only one of a set of features are enabled.
 It is important to enforce this due to the additive behaviour of features (ie. dependencies may include the same sub-dependencie with different features enabled the result is a union of the enabled features), and difficult to specify for larger feature sets using existing predicates as the complexity for this increases exponentially with the number of exclusive features.
 
-The desired outcome of this is the ability to specify `#[cfg(not(oneof(feature="a", feature="b")))] compile_error!(...)` to define compilation failures without manually defining all possible valid/invalid combinations for exclusive subsets of features, and simplify other configurations that benefit from the `oneof` predicate.
+The desired outcome of this is the ability to specify `#[cfg(oneof(feature="a", feature="b"))] do_something()` and `#[cfg(not(oneof(feature="a", feature="b")))] compile_error!(...)` to specify exclusive features without manually defining all possible valid/invalid combinations for the exclusive subset of features, and simplify other configurations that benefit from the `oneof` predicate.
 This allows authors of crates with exclusive feature sets to communicate this to consumers without requiring users to infer the feature issue from compiler errors.
 
 
@@ -29,7 +29,7 @@ ConfigurationOneof
    
 ...
 
-oneof() with a comma separated list of configuration predicates. It is true if at exactly one predicate is true. In other situations it is false.
+oneof() with a comma separated list of configuration predicates. It is true if at one and only one predicate is true. In all other situations it is false.
 ```
 
 Using an existing implementation from [rust-rand-facade](https://github.com/ryankurte/rust-rand-facade/blob/master/src/lib.rs) expressing all possible combinations for a set of three exclusive features (`std`, `cortex_m`, and `os_rng`).
@@ -56,23 +56,25 @@ Using the `oneof` predicate:
 compile_error!("One of 'os_rng', 'std', 'cortex_m' features must be enabled");
 ```
 
+The latter is significantly more simple, and does not introduce additional complexity when adding further exclusive feature(s).
+
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-- I do not believe this has significant interaction with other features, or requires any significant changes
+- I do not believe this has significant interaction with other features, or requires any significant changes to the tooling or language
 - Implementation should be straightforward, requiring the addition of a config predicate to `rustc` based on existing configuration predicates
 - I do not believe there are significant corner cases to be considered
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-I do not forsee any drawbacks to the addition of this predicate
+N/A
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 - This provides a useful improvement to the expressiveness of `#[cfg()]` macros and allows crate authors to provide actionable errors rather than depending on compiler failures
-- An alternative to `not(oneof(...))` could be `notoneof(...)` or similar, however, this is less consistent with existing predicates
+- An alternative to `not(oneof(...))` could be `notoneof(...)` or similar, however, this is less generally useful and less consistent with existing predicates
 - Not implementing this means crate authors must either hand-define all variants or rely on symbol errors to enforce feature exclusivity, and users must continue to infer the _cause_ of these failures rather than being directly signalled.
 
 # Prior art
@@ -85,10 +87,10 @@ As this does not encompass _at most one_, enabling multiple exclusive features c
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-There are no obvious unresolved questions
+N/A
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-There are no obvious future possibilities
+N/A
 

--- a/text/0000-cfg-oneof.md
+++ b/text/0000-cfg-oneof.md
@@ -15,7 +15,7 @@ In a number of situations (particularly involving `no_std` and cross-target appl
 It is important to enforce this due to the additive behaviour of features (i.e. dependencies may include the same sub-dependency with different features enabled. The result is a union of the enabled features), and difficult to specify for larger feature sets using existing predicates as the complexity for this increases exponentially with the number of exclusive features.
 
 The desired outcome is the ability to specify `#[cfg(oneof(feature = "a", feature = "b"))] do_something()` and `#[cfg(not(oneof(feature = "a", feature = "b")))] compile_error!(...)` to specify exclusive features without manually defining all possible valid/invalid combinations for the exclusive subset of features, and simplify other configurations that benefit from the `oneof` predicate.
-This allows authors of crates with exclusive feature sets to communicate this to consumers without requiring users to infer the feature issue from compiler errors.
+This allows authors of crates with exclusive feature sets specify this in a maintainable manner, and to communicate this to consumers without requiring users to infer the feature issue from compiler errors.
 
 
 # Guide-level explanation
@@ -29,8 +29,10 @@ ConfigurationOneof
    
 ...
 
-oneof() with a comma separated list of configuration predicates. It is true if at one and only one predicate is true. In all other situations it is false.
+oneof() with a comma separated list of configuration predicates. It is true if at least one and only one predicate is true. In all other situations it is false.
 ```
+
+## An Example
 
 Using an existing implementation from [rust-rand-facade](https://github.com/ryankurte/rust-rand-facade/blob/master/src/lib.rs) expressing all possible combinations for a set of three exclusive features (`std`, `cortex_m`, and `os_rng`).
 

--- a/text/0000-cfg-oneof.md
+++ b/text/0000-cfg-oneof.md
@@ -34,7 +34,7 @@ oneof() with a comma separated list of configuration predicates. It is true if a
 
 ## An Example
 
-Using an existing implementation from [rust-rand-facade](https://github.com/ryankurte/rust-rand-facade/blob/master/src/lib.rs) expressing all possible combinations for a set of three exclusive features (`std`, `cortex_m`, and `os_rng`).
+Using an existing implementation from [rust-rand-facade](https://github.com/ryankurte/rust-rand-facade/blob/master/src/lib.rs) expressing all possible combinations for a set of three exclusive features (`std`, `cortex_m`, and `os_rng`). This is a reasonably small example, it is worth noting that it is common for embedded crates to have [tens of exclusive features](https://github.com/stm32-rs/stm32f4xx-hal/blob/master/Cargo.toml#L67).
 
 Using existing predicates:
 
@@ -77,7 +77,7 @@ N/A
 
 - This provides a useful improvement to the expressiveness of `#[cfg()]` macros and allows crate authors to provide actionable errors rather than depending on compiler failures
 - An alternative to `not(oneof(...))` could be `notoneof(...)` or similar, however, this is less generally useful and less consistent with existing predicates
-- Not implementing this means crate authors must either hand-define all variants or rely on symbol errors to enforce feature exclusivity, and users must continue to infer the _cause_ of these failures rather than being directly signaled.
+- Not implementing this means crate authors must either hand-define all possible variants (which is demonstrably neither commonplace or practicable with larger numbers of exclusive features) or rely on symbol errors to enforce feature exclusivity, and thus users will continue to need to infer the _cause_ of these failures without direct / explicit signals.
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/0000-cfg-oneof.md
+++ b/text/0000-cfg-oneof.md
@@ -12,9 +12,9 @@ Addition of `oneof` to existing `all`, `any`, `not` configuration predicates in 
 [motivation]: #motivation
 
 In a number of situations (particularly involving `no_std` and cross-target applications) it is useful to ensure that only one of a set of features are enabled.
-It is important to enforce this due to the additive behaviour of features (ie. dependencies may include the same sub-dependencie with different features enabled the result is a union of the enabled features), and difficult to specify for larger feature sets using existing predicates as the complexity for this increases exponentially with the number of exclusive features.
+It is important to enforce this due to the additive behaviour of features (i.e. dependencies may include the same sub-dependency with different features enabled. The result is a union of the enabled features), and difficult to specify for larger feature sets using existing predicates as the complexity for this increases exponentially with the number of exclusive features.
 
-The desired outcome of this is the ability to specify `#[cfg(oneof(feature="a", feature="b"))] do_something()` and `#[cfg(not(oneof(feature="a", feature="b")))] compile_error!(...)` to specify exclusive features without manually defining all possible valid/invalid combinations for the exclusive subset of features, and simplify other configurations that benefit from the `oneof` predicate.
+The desired outcome is the ability to specify `#[cfg(oneof(feature = "a", feature = "b"))] do_something()` and `#[cfg(not(oneof(feature = "a", feature = "b")))] compile_error!(...)` to specify exclusive features without manually defining all possible valid/invalid combinations for the exclusive subset of features, and simplify other configurations that benefit from the `oneof` predicate.
 This allows authors of crates with exclusive feature sets to communicate this to consumers without requiring users to infer the feature issue from compiler errors.
 
 
@@ -75,7 +75,7 @@ N/A
 
 - This provides a useful improvement to the expressiveness of `#[cfg()]` macros and allows crate authors to provide actionable errors rather than depending on compiler failures
 - An alternative to `not(oneof(...))` could be `notoneof(...)` or similar, however, this is less generally useful and less consistent with existing predicates
-- Not implementing this means crate authors must either hand-define all variants or rely on symbol errors to enforce feature exclusivity, and users must continue to infer the _cause_ of these failures rather than being directly signalled.
+- Not implementing this means crate authors must either hand-define all variants or rely on symbol errors to enforce feature exclusivity, and users must continue to infer the _cause_ of these failures rather than being directly signaled.
 
 # Prior art
 [prior-art]: #prior-art
@@ -93,4 +93,3 @@ N/A
 [future-possibilities]: #future-possibilities
 
 N/A
-


### PR DESCRIPTION
This RFC adds a `oneof` to existing `all`, `any`, `not` configuration predicates in `#[cfg!()]` macros to support specification of exclusive feature subsets, a common issue when supporting different targets or runtimes in `no_std` contexts.

This would appear to be a minor addition to existing functionality, however, as it does not improve an `objective, numerical quality criteria` here we are ^_^

[rendered](https://github.com/ryankurte/rfcs/blob/0000-config-oneof/text/0000-cfg-oneof.md)