### PR TITLE
rustdoc edit links

### DIFF
--- a/text/0000-doc-edit-links.md
+++ b/text/0000-doc-edit-links.md
@@ -70,5 +70,4 @@ Cons:
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-This requires close integration with corresponding commands in `cargo doc`
-and adoption in docs.rs builder to support this.
+docs.rs could use the new flags in all new generated documentation.


### PR DESCRIPTION
Adds an edit button to rustdoc-generated pages

Related: https://github.com/rust-lang/docs.rs/issues/1007

[Rendered](https://github.com/SOF3/rust-rfcs/blob/doc-edit-link/text/0000-doc-edit-links.md)