### PR TITLE
RFC 2582: fix implicit auto-deref of raw pointers

### DIFF
--- a/text/2582-raw-reference-mir-operator.md
+++ b/text/2582-raw-reference-mir-operator.md
@@ -198,14 +198,14 @@ This has the side-effect of being able to entirely remove reference-to-pointer-*
 
 ```rust
 let x: *mut Struct = NonNull::dangling().as_ptr();
-let field: *mut Field = &mut x.field;
+let field: *mut Field = &mut (*x).field;
 ```
 
 The lint as described in this RFC would nudge people to instead write
 
 ```rust
 let x: *mut Struct = NonNull::dangling().as_ptr();
-let field: *mut Field = &raw mut x.field;
+let field: *mut Field = &raw mut (x*).field;
 ```
 
 which is better, but still UB: we emit a `getelementptr inbounds` for the `.field` offset computation.

--- a/text/2582-raw-reference-mir-operator.md
+++ b/text/2582-raw-reference-mir-operator.md
@@ -205,7 +205,7 @@ The lint as described in this RFC would nudge people to instead write
 
 ```rust
 let x: *mut Struct = NonNull::dangling().as_ptr();
-let field: *mut Field = &raw mut (x*).field;
+let field: *mut Field = &raw mut (*x).field;
 ```
 
 which is better, but still UB: we emit a `getelementptr inbounds` for the `.field` offset computation.


### PR DESCRIPTION
The code as given wouldn't even compile.