### PR TITLE
Fix syntax in RFC 2145

### DIFF
--- a/text/2145-type-privacy.md
+++ b/text/2145-type-privacy.md
@@ -387,7 +387,7 @@ sufficiently smart type inference.
 mod m {
     struct Priv;
     pub struct Pub<T>(T);
-    pub Trait { type A; }
+    pub trait Trait { type A; }
 
     // This is a private impl because `Pub<Priv>` is a private type
     impl Pub<Priv> {


### PR DESCRIPTION
Change `pub Trait` to `pub trait Trait`