### PR TITLE
Make generate-book.sh work on macOS.

### DIFF
--- a/generate-book.sh
+++ b/generate-book.sh
@@ -8,7 +8,7 @@ fi
 
 printf '[Introduction](introduction.md)\n\n' > src/SUMMARY.md
 
-find ./text ! -type d -print0 | xargs -0 -I {} ln -frs {} -t src/
+find ./text ! -type d -print0 | xargs -0 -I {} ln -fs ../{} src
 
 find ./text ! -type d -name '*.md' -print0 \
   | sort -z \
@@ -17,6 +17,6 @@ do
     printf -- '- [%s](%s)\n' "$(basename "$file" ".md")" "$(basename "$file")" 
 done >> src/SUMMARY.md
 
-ln -frs README.md src/introduction.md
+ln -fs ../README.md src/introduction.md
 
 mdbook build


### PR DESCRIPTION
The macOS `ln` command does not support the `-r` or `-t` flags.  This changes it so that it should work on all platforms.