### PR TITLE
Use more common 'tests' module name over 'test' in examples

### DIFF
--- a/text/0505-api-comment-conventions.md
+++ b/text/0505-api-comment-conventions.md
@@ -51,7 +51,7 @@ nothing else. When using `mod` blocks, prefer `///` outside of the block:
 
 ```rust
 /// This module contains tests
-mod test {
+mod tests {
     // ...
 }
 ```
@@ -59,7 +59,7 @@ mod test {
 over
 
 ```rust
-mod test {
+mod tests {
     //! This module contains tests
 
     // ...

--- a/text/1574-more-api-documentation-conventions.md
+++ b/text/1574-more-api-documentation-conventions.md
@@ -350,7 +350,7 @@ nothing else. When using `mod` blocks, prefer `///` outside of the block:
 
 ```rust
 /// This module contains tests
-mod test {
+mod tests {
     // ...
 }
 ```
@@ -358,7 +358,7 @@ mod test {
 over
 
 ```rust
-mod test {
+mod tests {
     //! This module contains tests
 
     // ...


### PR DESCRIPTION
All documentation I could find uses `tests` instead of `test` for an inline module containing `#[test]` functions:

* [The Book](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
* [Rust by Example](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html)