### PR TITLE
consolidated usage of feature-name header field

### DIFF
--- a/text/0320-nonzeroing-dynamic-drop.md
+++ b/text/0320-nonzeroing-dynamic-drop.md
@@ -1,4 +1,4 @@
-- Feature Name: (none for the bulk of RFC); unsafe_no_drop_flag
+- Feature Name: `(none for the bulk of RFC); unsafe_no_drop_flag`
 - Start Date: 2014-09-24
 - RFC PR: [rust-lang/rfcs#320](https://github.com/rust-lang/rfcs/pull/320)
 - Rust Issue: [rust-lang/rust#5016](https://github.com/rust-lang/rust/issues/5016)

--- a/text/0320-nonzeroing-dynamic-drop.md
+++ b/text/0320-nonzeroing-dynamic-drop.md
@@ -1,4 +1,4 @@
-- Feature Name: `(none for the bulk of RFC); unsafe_no_drop_flag`
+- Feature Name: `unsafe_no_drop_flag` (none for the bulk of RFC)
 - Start Date: 2014-09-24
 - RFC PR: [rust-lang/rfcs#320](https://github.com/rust-lang/rfcs/pull/320)
 - Rust Issue: [rust-lang/rust#5016](https://github.com/rust-lang/rust/issues/5016)

--- a/text/0529-conversion-traits.md
+++ b/text/0529-conversion-traits.md
@@ -1,4 +1,4 @@
-- Feature Name: convert
+- Feature Name: `convert`
 - Start Date: 2014-11-21
 - RFC PR: [rust-lang/rfcs#529](https://github.com/rust-lang/rfcs/pull/529)
 - Rust Issue: [rust-lang/rust#23567](https://github.com/rust-lang/rust/issues/23567)

--- a/text/0809-box-and-in-for-stdlib.md
+++ b/text/0809-box-and-in-for-stdlib.md
@@ -1,4 +1,4 @@
-- Feature Name: box_syntax, placement_in_syntax
+- Feature Name: `box_syntax`, `placement_in_syntax`
 - Start Date: 2015-02-04
 - RFC PR: [rust-lang/rfcs#809](https://github.com/rust-lang/rfcs/pull/809)
 - Rust Issue: [rust-lang/rust#22181](https://github.com/rust-lang/rust/issues/22181)

--- a/text/0823-hash-simplification.md
+++ b/text/0823-hash-simplification.md
@@ -1,4 +1,4 @@
-- Feature Name: hash
+- Feature Name: `hash`
 - Start Date: 2015-02-17
 - RFC PR: [rust-lang/rfcs#823](https://github.com/rust-lang/rfcs/pull/823)
 - Rust Issue: [rust-lang/rust#22467](https://github.com/rust-lang/rust/issues/22467)

--- a/text/0832-from-elem-with-love.md
+++ b/text/0832-from-elem-with-love.md
@@ -1,4 +1,4 @@
-- Feature Name: direct to stable, because it modifies a stable macro
+- Feature Name: `direct to stable`, `because it modifies a stable macro`
 - Start Date: 2015-02-11
 - RFC PR: [rust-lang/rfcs#832](https://github.com/rust-lang/rfcs/pull/832)
 - Rust Issue: [rust-lang/rust#22414](https://github.com/rust-lang/rust/issues/22414)

--- a/text/0839-embrace-extend-extinguish.md
+++ b/text/0839-embrace-extend-extinguish.md
@@ -1,4 +1,4 @@
-- Feature Name: embrace-extend-extinguish
+- Feature Name: `embrace-extend-extinguish`
 - Start Date: 2015-02-13
 - RFC PR: [rust-lang/rfcs#839](https://github.com/rust-lang/rfcs/pull/839)
 - Rust Issue: [rust-lang/rust#25976](https://github.com/rust-lang/rust/issues/25976)

--- a/text/0840-no-panic-in-c-string.md
+++ b/text/0840-no-panic-in-c-string.md
@@ -1,4 +1,4 @@
-- Feature Name: non_panicky_cstring
+- Feature Name: `non_panicky_cstring`
 - Start Date: 2015-02-13
 - RFC PR: [rust-lang/rfcs#840](https://github.com/rust-lang/rfcs/pull/840)
 - Rust Issue: [rust-lang/rust#22470](https://github.com/rust-lang/rust/issues/22470)

--- a/text/0873-type-macros.md
+++ b/text/0873-type-macros.md
@@ -1,4 +1,4 @@
-- Feature Name: macros_in_type_positions
+- Feature Name: `macros_in_type_positions`
 - Start Date: 2015-02-16
 - RFC PR: [rust-lang/rfcs#873](https://github.com/rust-lang/rfcs/pull/873)
 - Rust Issue: [rust-lang/rust#27245](https://github.com/rust-lang/rust/issues/27245)

--- a/text/0879-small-base-lexing.md
+++ b/text/0879-small-base-lexing.md
@@ -1,4 +1,4 @@
-- Feature Name: stable, it only restricts the language
+- Feature Name: `stable`, `it only restricts the language`
 - Start Date: 2015-02-17
 - RFC PR: [rust-lang/rfcs#879](https://github.com/rust-lang/rfcs/pull/879)
 - Rust Issue: [rust-lang/rust#23872](https://github.com/rust-lang/rust/pull/23872)

--- a/text/0888-compiler-fence-intrinsics.md
+++ b/text/0888-compiler-fence-intrinsics.md
@@ -1,4 +1,4 @@
-- Feature Name: compiler_fence_intrinsics
+- Feature Name: `compiler_fence_intrinsics`
 - Start Date: 2015-02-19
 - RFC PR: [rust-lang/rfcs#888](https://github.com/rust-lang/rfcs/pull/888)
 - Rust Issue: [rust-lang/rust#24118](https://github.com/rust-lang/rust/issues/24118)

--- a/text/0909-move-thread-local-to-std-thread.md
+++ b/text/0909-move-thread-local-to-std-thread.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-02-25
 - RFC PR: [rust-lang/rfcs#909](https://github.com/rust-lang/rfcs/pull/909)
 - Rust Issue: [rust-lang/rust#23547](https://github.com/rust-lang/rust/issues/23547)

--- a/text/0911-const-fn.md
+++ b/text/0911-const-fn.md
@@ -1,4 +1,4 @@
-- Feature Name: const_fn
+- Feature Name: `const_fn`
 - Start Date: 2015-02-25
 - RFC PR: [rust-lang/rfcs#911](https://github.com/rust-lang/rfcs/pull/911)
 - Rust Issue: [rust-lang/rust#24111](https://github.com/rust-lang/rust/issues/24111)

--- a/text/0921-entry_v3.md
+++ b/text/0921-entry_v3.md
@@ -1,4 +1,4 @@
-- Feature Name: entry_v3
+- Feature Name: `entry_v3`
 - Start Date: 2015-03-01
 - RFC PR: [rust-lang/rfcs#921](https://github.com/rust-lang/rfcs/pull/921)
 - Rust Issue: [rust-lang/rust#23508](https://github.com/rust-lang/rust/issues/23508)

--- a/text/0953-op-assign.md
+++ b/text/0953-op-assign.md
@@ -1,4 +1,4 @@
-- Feature Name: op_assign
+- Feature Name: `op_assign`
 - Start Date: 2015-03-08
 - RFC PR: [rust-lang/rfcs#953](https://github.com/rust-lang/rfcs/pull/953)
 - Rust Issue: [rust-lang/rust#28235](https://github.com/rust-lang/rust/issues/28235)

--- a/text/0968-closure-return-type-syntax.md
+++ b/text/0968-closure-return-type-syntax.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-03-16
 - RFC PR: [rust-lang/rfcs#968](https://github.com/rust-lang/rfcs/pull/968)
 - Rust Issue: [rust-lang/rust#23420](https://github.com/rust-lang/rust/issues/23420)

--- a/text/0979-align-splitn-with-other-languages.md
+++ b/text/0979-align-splitn-with-other-languages.md
@@ -1,4 +1,4 @@
-- Feature Name: n/a
+- Feature Name: `n/a`
 - Start Date: 2015-03-15
 - RFC PR: [rust-lang/rfcs#979](https://github.com/rust-lang/rfcs/pull/979)
 - Rust Issue: [rust-lang/rust#23911](https://github.com/rust-lang/rust/issues/23911)

--- a/text/0980-read-exact.md
+++ b/text/0980-read-exact.md
@@ -1,4 +1,4 @@
-- Feature Name: read_exact
+- Feature Name: `read_exact`
 - Start Date: 2015-03-15
 - RFC PR: [rust-lang/rfcs#980](https://github.com/rust-lang/rfcs/pull/980)
 - Rust Issue: [rust-lang/rust#27585](https://github.com/rust-lang/rust/issues/27585)

--- a/text/0982-dst-coercion.md
+++ b/text/0982-dst-coercion.md
@@ -1,4 +1,4 @@
-- Feature Name: dst_coercions
+- Feature Name: `dst_coercions`
 - Start Date: 2015-03-16
 - RFC PR: [rust-lang/rfcs#982](https://github.com/rust-lang/rfcs/pull/982)
 - Rust Issue: [rust-lang/rust#18598](https://github.com/rust-lang/rust/issues/18598)

--- a/text/1011-process.exit.md
+++ b/text/1011-process.exit.md
@@ -1,4 +1,4 @@
-- Feature Name: exit
+- Feature Name: `exit`
 - Start Date: 2015-03-24
 - RFC PR: [rust-lang/rfcs#1011](https://github.com/rust-lang/rfcs/pull/1011)
 - Rust Issue: (leave this empty)

--- a/text/1030-prelude-additions.md
+++ b/text/1030-prelude-additions.md
@@ -1,4 +1,4 @@
-- Feature Name: NA
+- Feature Name: `NA`
 - Start Date: 2015-04-03
 - RFC PR: [rust-lang/rfcs#1030](https://github.com/rust-lang/rfcs/pull/1030)
 - Rust Issue: [rust-lang/rust#24538](https://github.com/rust-lang/rust/issues/24538)

--- a/text/1040-duration-reform.md
+++ b/text/1040-duration-reform.md
@@ -1,4 +1,4 @@
-- Feature Name: duration
+- Feature Name: `duration`
 - Start Date: 2015-03-24
 - RFC PR: [rust-lang/rfcs#1040](https://github.com/rust-lang/rfcs/pull/1040)
 - Rust Issue: [rust-lang/rust#24874](https://github.com/rust-lang/rust/issues/24874)

--- a/text/1054-str-words.md
+++ b/text/1054-str-words.md
@@ -1,4 +1,4 @@
-- Feature Name: str-words
+- Feature Name: `str-words`
 - Start Date: 2015-04-10
 - RFC PR: [rust-lang/rfcs#1054](https://github.com/rust-lang/rfcs/pull/1054)
 - Rust Issue: [rust-lang/rust#24543](https://github.com/rust-lang/rust/issues/24543)

--- a/text/1066-safe-mem-forget.md
+++ b/text/1066-safe-mem-forget.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-04-15
 - RFC PR: [rust-lang/rfcs#1066](https://github.com/rust-lang/rfcs/pull/1066)
 - Rust Issue: [rust-lang/rust#25186](https://github.com/rust-lang/rust/issues/25186)

--- a/text/1068-rust-governance.md
+++ b/text/1068-rust-governance.md
@@ -1,4 +1,4 @@
-- Feature Name: not applicable
+- Feature Name: `N/A`
 - Start Date: 2015-02-27
 - RFC PR: [rust-lang/rfcs#1068](https://github.com/rust-lang/rfcs/pull/1068)
 - Rust Issue: N/A

--- a/text/1096-remove-static-assert.md
+++ b/text/1096-remove-static-assert.md
@@ -1,4 +1,4 @@
-- Feature Name: remove-static-assert
+- Feature Name: `remove-static-assert`
 - Start Date: 2015-04-28        
 - RFC PR: [rust-lang/rfcs#1096](https://github.com/rust-lang/rfcs/pull/1096)
 - Rust Issue: https://github.com/rust-lang/rust/pull/24910

--- a/text/1105-api-evolution.md
+++ b/text/1105-api-evolution.md
@@ -1,4 +1,4 @@
-- Feature Name: not applicable
+- Feature Name: `not applicable`
 - Start Date: 2015-05-04
 - RFC PR: [rust-lang/rfcs#1105](https://github.com/rust-lang/rfcs/pull/1105)
 - Rust Issue: N/A

--- a/text/1122-language-semver.md
+++ b/text/1122-language-semver.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-05-07
 - RFC PR: [rust-lang/rfcs#1122](https://github.com/rust-lang/rfcs/pull/1122)
 - Rust Issue: N/A

--- a/text/1131-likely-intrinsic.md
+++ b/text/1131-likely-intrinsic.md
@@ -1,4 +1,4 @@
-- Feature Name: expect_intrinsic
+- Feature Name: `expect_intrinsic`
 - Start Date: 2015-05-20
 - RFC PR: [rust-lang/rfcs#1131](https://github.com/rust-lang/rfcs/pull/1131)
 - Rust Issue: [rust-lang/rust#26179](https://github.com/rust-lang/rust/issues/26179)

--- a/text/1135-raw-pointer-comparisons.md
+++ b/text/1135-raw-pointer-comparisons.md
@@ -1,4 +1,4 @@
-- Feature Name: raw-pointer-comparisons
+- Feature Name: `raw-pointer-comparisons`
 - Start Date: 2015-05-27
 - RFC PR: [rust-lang/rfcs#1135](https://github.com/rust-lang/rfcs/pull/1135)
 - Rust Issue: [rust-lang/rust#28235](https://github.com/rust-lang/rust/issues/28236)

--- a/text/1156-adjust-default-object-bounds.md
+++ b/text/1156-adjust-default-object-bounds.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-06-4
 - RFC PR: [rust-lang/rfcs#1156](https://github.com/rust-lang/rfcs/pull/1156)
 - Rust Issue: [rust-lang/rust#26438](https://github.com/rust-lang/rust/issues/26438)

--- a/text/1174-into-raw-fd-socket-handle-traits.md
+++ b/text/1174-into-raw-fd-socket-handle-traits.md
@@ -1,4 +1,4 @@
-- Feature Name: into-raw-fd-socket-handle-traits
+- Feature Name: `into-raw-fd-socket-handle-traits`
 - Start Date: 2015-06-24
 - RFC PR: [rust-lang/rfcs#1174](https://github.com/rust-lang/rfcs/pull/1174)
 - Rust Issue: [rust-lang/rust#27062](https://github.com/rust-lang/rust/issues/27062)

--- a/text/1184-stabilize-no_std.md
+++ b/text/1184-stabilize-no_std.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-06-26
 - RFC PR: [rust-lang/rfcs#1184](https://github.com/rust-lang/rfcs/pull/1184)
 - Rust Issue: [rust-lang/rust#27394](https://github.com/rust-lang/rust/issues/27394)

--- a/text/1191-hir.md
+++ b/text/1191-hir.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-07-06
 - RFC PR: [rust-lang/rfcs#1191](https://github.com/rust-lang/rfcs/pull/1191)
 - Rust Issue: N/A

--- a/text/1192-inclusive-ranges.md
+++ b/text/1192-inclusive-ranges.md
@@ -1,4 +1,4 @@
-- Feature Name: inclusive_range_syntax
+- Feature Name: `inclusive_range_syntax`
 - Start Date: 2015-07-07
 - RFC PR: [rust-lang/rfcs#1192](https://github.com/rust-lang/rfcs/pull/1192)
 - Rust Issue: [rust-lang/rust#28237](https://github.com/rust-lang/rust/issues/28237)

--- a/text/1193-cap-lints.md
+++ b/text/1193-cap-lints.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-07-07
 - RFC PR: [rust-lang/rfcs#1193](https://github.com/rust-lang/rfcs/pull/1193)
 - Rust Issue: [rust-lang/rust#27259](https://github.com/rust-lang/rust/issues/27259)

--- a/text/1199-simd-infrastructure.md
+++ b/text/1199-simd-infrastructure.md
@@ -1,4 +1,4 @@
-- Feature Name: repr_simd, platform_intrinsics, cfg_target_feature
+- Feature Name: `repr_simd`, `platform_intrinsics`, `cfg_target_feature`
 - Start Date: 2015-06-02
 - RFC PR: [rust-lang/rfcs#1199](https://github.com/rust-lang/rfcs/pull/1199)
 - Rust Issue: [rust-lang/rust#27731](https://github.com/rust-lang/rust/issues/27731)

--- a/text/1200-cargo-install.md
+++ b/text/1200-cargo-install.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-07-10
 - RFC PR: [rust-lang/rfcs#1200](https://github.com/rust-lang/rfcs/pull/1200)
 - Rust Issue: N/A

--- a/text/1210-impl-specialization.md
+++ b/text/1210-impl-specialization.md
@@ -1,4 +1,4 @@
-- Feature Name: specialization
+- Feature Name: `specialization`
 - Start Date: 2015-06-17
 - RFC PR: [rust-lang/rfcs#1210](https://github.com/rust-lang/rfcs/pull/1210)
 - Rust Issue: [rust-lang/rust#31844](https://github.com/rust-lang/rust/issues/31844)

--- a/text/1211-mir.md
+++ b/text/1211-mir.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: [rust-lang/rfcs#1211](https://github.com/rust-lang/rfcs/pull/1211)
 - Rust Issue: [rust-lang/rust#27840](https://github.com/rust-lang/rust/issues/27840)

--- a/text/1214-projections-lifetimes-and-wf.md
+++ b/text/1214-projections-lifetimes-and-wf.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: [rust-lang/rfcs#1214](https://github.com/rust-lang/rfcs/pull/1214)
 - Rust Issue: [rust-lang/rust#27579](https://github.com/rust-lang/rust/issues/27579)

--- a/text/1216-bang-type.md
+++ b/text/1216-bang-type.md
@@ -1,4 +1,4 @@
-- Feature Name: bang_type
+- Feature Name: `bang_type`
 - Start Date: 2015-07-19
 - RFC PR: [rust-lang/rfcs#1216](https://github.com/rust-lang/rfcs/pull/1216)
 - Rust Issue: [rust-lang/rust#35121](https://github.com/rust-lang/rust/issues/35121)

--- a/text/1219-use-group-as.md
+++ b/text/1219-use-group-as.md
@@ -1,4 +1,4 @@
-- Feature Name: use_group_as
+- Feature Name: `use_group_as`
 - Start Date: 2015-02-15
 - RFC PR: [rust-lang/rfcs#1219](https://github.com/rust-lang/rfcs/pull/1219)
 - Rust Issue: [rust-lang/rust#27578](https://github.com/rust-lang/rust/issues/27578)

--- a/text/1228-placement-left-arrow.md
+++ b/text/1228-placement-left-arrow.md
@@ -1,4 +1,4 @@
-- Feature Name: place_left_arrow_syntax
+- Feature Name: `place_left_arrow_syntax`
 - Start Date: 2015-07-28
 - RFC PR: [rust-lang/rfcs#1228](https://github.com/rust-lang/rfcs/pull/1228)
 - Rust Issue: [rust-lang/rust#27779](https://github.com/rust-lang/rust/issues/27779)

--- a/text/1229-compile-time-asserts.md
+++ b/text/1229-compile-time-asserts.md
@@ -1,4 +1,4 @@
-- Feature Name: compile_time_asserts
+- Feature Name: `compile_time_asserts`
 - Start Date: 2015-07-30
 - RFC PR: [rust-lang/rfcs#1229](https://github.com/rust-lang/rfcs/pull/1229)
 - Rust Issue: [rust-lang/rust#28238](https://github.com/rust-lang/rust/issues/28238)

--- a/text/1238-nonparametric-dropck.md
+++ b/text/1238-nonparametric-dropck.md
@@ -1,4 +1,4 @@
-- Feature Name: dropck_parametricity
+- Feature Name: `dropck_parametricity`
 - Start Date: 2015-08-05
 - RFC PR: [rust-lang/rfcs#1238](https://github.com/rust-lang/rfcs/pull/1238)/
 - Rust Issue: [rust-lang/rust#28498](https://github.com/rust-lang/rust/issues/28498)

--- a/text/1240-repr-packed-unsafe-ref.md
+++ b/text/1240-repr-packed-unsafe-ref.md
@@ -1,4 +1,4 @@
-- Feature Name: NA
+- Feature Name: `NA`
 - Start Date: 2015-08-06
 - RFC PR: [rust-lang/rfcs#1240](https://github.com/rust-lang/rfcs/pull/1240)
 - Rust Issue: [rust-lang/rust#27060](https://github.com/rust-lang/rust/issues/27060)

--- a/text/1241-no-wildcard-deps.md
+++ b/text/1241-no-wildcard-deps.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-07-23
 - RFC PR: [rust-lang/rfcs#1241](https://github.com/rust-lang/rfcs/pull/1241)
 - Rust Issue: [rust-lang/rust#28628](https://github.com/rust-lang/rust/issues/28628)

--- a/text/1242-rust-lang-crates.md
+++ b/text/1242-rust-lang-crates.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-07-29
 - RFC PR: [rust-lang/rfcs#1242](https://github.com/rust-lang/rfcs/pull/1242)
 - Rust Issue: N/A

--- a/text/1257-drain-range-2.md
+++ b/text/1257-drain-range-2.md
@@ -1,4 +1,4 @@
-- Feature Name: drain-range
+- Feature Name: `drain-range`
 - Start Date: 2015-08-14
 - RFC PR: [rust-lang/rfcs#1257](https://github.com/rust-lang/rfcs/pull/1257)
 - Rust Issue: [rust-lang/rust#27711](https://github.com/rust-lang/rust/issues/27711)

--- a/text/1260-main-reexport.md
+++ b/text/1260-main-reexport.md
@@ -1,4 +1,4 @@
-- Feature Name: main_reexport
+- Feature Name: `main_reexport`
 - Start Date: 2015-08-19
 - RFC PR: [rust-lang/rfcs#1260](https://github.com/rust-lang/rfcs/pull/1260)
 - Rust Issue: [rust-lang/rust#28937](https://github.com/rust-lang/rust/issues/28937)

--- a/text/1270-deprecation.md
+++ b/text/1270-deprecation.md
@@ -1,4 +1,4 @@
-- Feature Name: Public Stability
+- Feature Name: `Public Stability`
 - Start Date: 2015-09-03
 - RFC PR: [rust-lang/rfcs#1270](https://github.com/rust-lang/rfcs/pull/1270)
 - Rust Issue: [rust-lang/rust#29935](https://github.com/rust-lang/rust/issues/29935)

--- a/text/1291-promote-libc.md
+++ b/text/1291-promote-libc.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-09-21
 - RFC PR: [rust-lang/rfcs#1291](https://github.com/rust-lang/rfcs/pull/1291)
 - Rust Issue: N/A

--- a/text/1298-incremental-compilation.md
+++ b/text/1298-incremental-compilation.md
@@ -1,4 +1,4 @@
-- Feature Name: incremental-compilation
+- Feature Name: `incremental-compilation`
 - Start Date: 2015-08-04
 - RFC PR: (leave this empty)
 - Rust Issue: (leave this empty)

--- a/text/1300-intrinsic-semantics.md
+++ b/text/1300-intrinsic-semantics.md
@@ -1,4 +1,4 @@
-- Feature Name: intrinsic-semantics
+- Feature Name: `intrinsic-semantics`
 - Start Date: 2015-09-29
 - RFC PR: [rust-lang/rfcs#1300](https://github.com/rust-lang/rfcs/pull/1300)
 - Rust Issue: N/A

--- a/text/1317-ide.md
+++ b/text/1317-ide.md
@@ -1,4 +1,4 @@
-- Feature Name: n/a
+- Feature Name: `n/a`
 - Start Date: 2015-10-13
 - RFC PR: [rust-lang/rfcs#1317](https://github.com/rust-lang/rfcs/pull/1317)
 - Rust Issue: [rust-lang/rust#31548](https://github.com/rust-lang/rust/issues/31548)

--- a/text/1327-dropck-param-eyepatch.md
+++ b/text/1327-dropck-param-eyepatch.md
@@ -1,4 +1,4 @@
-- Feature Name: dropck_eyepatch, generic_param_attrs
+- Feature Name: `dropck_eyepatch`, `generic_param_attrs`
 - Start Date: 2015-10-19
 - RFC PR: [rust-lang/rfcs#1327](https://github.com/rust-lang/rfcs/pull/1327)
 - Rust Issue: [rust-lang/rust#34761](https://github.com/rust-lang/rust/issues/34761)

--- a/text/1331-grammar-is-canonical.md
+++ b/text/1331-grammar-is-canonical.md
@@ -1,4 +1,4 @@
-- Feature Name: grammar
+- Feature Name: `grammar`
 - Start Date: 2015-10-21
 - RFC PR: [rust-lang/rfcs#1331](https://github.com/rust-lang/rfcs/pull/1331)
 - Rust Issue: [rust-lang/rust#30942](https://github.com/rust-lang/rust/issues/30942)

--- a/text/1361-cargo-cfg-dependencies.md
+++ b/text/1361-cargo-cfg-dependencies.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-11-10
 - RFC PR: [rust-lang/rfcs#1361](https://github.com/rust-lang/rfcs/pull/1361)
 - Rust Issue: N/A

--- a/text/1398-kinds-of-allocators.md
+++ b/text/1398-kinds-of-allocators.md
@@ -1,4 +1,4 @@
-- Feature Name: allocator_api
+- Feature Name: `allocator_api`
 - Start Date: 2015-12-01
 - RFC PR: [rust-lang/rfcs#1398](https://github.com/rust-lang/rfcs/pull/1398)
 - Rust Issue: [rust-lang/rust#32838](https://github.com/rust-lang/rust/issues/32838)

--- a/text/1414-rvalue_static_promotion.md
+++ b/text/1414-rvalue_static_promotion.md
@@ -1,4 +1,4 @@
-- Feature Name: rvalue_static_promotion
+- Feature Name: `rvalue_static_promotion`
 - Start Date: 2015-12-18
 - RFC PR: [#1414](https://github.com/rust-lang/rfcs/pull/1414)
 - Rust Issue: [#38865](https://github.com/rust-lang/rust/issues/38865)

--- a/text/1415-trim-std-os.md
+++ b/text/1415-trim-std-os.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-12-18
 - RFC PR: [rust-lang/rfcs#1415](https://github.com/rust-lang/rfcs/pull/1415)
 - Rust Issue: [rust-lang/rust#31549](https://github.com/rust-lang/rust/issues/31549)

--- a/text/1419-slice-copy.md
+++ b/text/1419-slice-copy.md
@@ -1,4 +1,4 @@
-- Feature Name: slice\_copy\_from
+- Feature Name: `slice\_copy\_from`
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: [rust-lang/rfcs#1419](https://github.com/rust-lang/rfcs/pull/1419)
 - Rust Issue: [rust-lang/rust#31755](https://github.com/rust-lang/rust/issues/31755)

--- a/text/1419-slice-copy.md
+++ b/text/1419-slice-copy.md
@@ -1,4 +1,4 @@
-- Feature Name: `slice\_copy\_from`
+- Feature Name: `slice_copy_from`
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: [rust-lang/rfcs#1419](https://github.com/rust-lang/rfcs/pull/1419)
 - Rust Issue: [rust-lang/rust#31755](https://github.com/rust-lang/rust/issues/31755)

--- a/text/1422-pub-restricted.md
+++ b/text/1422-pub-restricted.md
@@ -1,4 +1,4 @@
-- Feature Name: pub_restricted
+- Feature Name: `pub_restricted`
 - Start Date: 2015-12-18
 - RFC PR: [rust-lang/rfcs#1422](https://github.com/rust-lang/rfcs/pull/1422)
 - Rust Issue: [rust-lang/rust#32409](https://github.com/rust-lang/rust/issues/32409)

--- a/text/1432-replace-slice.md
+++ b/text/1432-replace-slice.md
@@ -1,4 +1,4 @@
-- Feature Name: splice
+- Feature Name: `splice`
 - Start Date: 2015-12-28
 - RFC PR: [rust-lang/rfcs#1432](https://github.com/rust-lang/rfcs/pull/1432)
 - Rust Issue: [rust-lang/rust#32310](https://github.com/rust-lang/rust/issues/32310)

--- a/text/1467-volatile.md
+++ b/text/1467-volatile.md
@@ -1,4 +1,4 @@
-- Feature Name: volatile
+- Feature Name: `volatile`
 - Start Date: 2016-01-18
 - RFC PR: [rust-lang/rfcs#1467](https://github.com/rust-lang/rfcs/pull/1467)
 - Rust Issue: [rust-lang/rust#31756](https://github.com/rust-lang/rust/issues/31756)

--- a/text/1492-dotdot-in-patterns.md
+++ b/text/1492-dotdot-in-patterns.md
@@ -1,4 +1,4 @@
-- Feature Name: dotdot_in_patterns
+- Feature Name: `dotdot_in_patterns`
 - Start Date: 2016-02-06
 - RFC PR: [rust-lang/rfcs#1492](https://github.com/rust-lang/rfcs/pull/1492)
 - Rust Issue: [rust-lang/rust#33627](https://github.com/rust-lang/rust/issues/33627)

--- a/text/1504-int128.md
+++ b/text/1504-int128.md
@@ -1,4 +1,4 @@
-- Feature Name: int128
+- Feature Name: `int128`
 - Start Date: 21-02-2016
 - RFC PR: [rust-lang/rfcs#1504](https://github.com/rust-lang/rfcs/pull/1504)
 - Rust Issue: [rust-lang/rust#35118](https://github.com/rust-lang/rust/issues/35118)

--- a/text/1506-adt-kinds.md
+++ b/text/1506-adt-kinds.md
@@ -1,4 +1,4 @@
-- Feature Name: clarified_adt_kinds
+- Feature Name: `clarified_adt_kinds`
 - Start Date: 2016-02-07
 - RFC PR: [rust-lang/rfcs#1506](https://github.com/rust-lang/rfcs/pull/1506)
 - Rust Issue: [rust-lang/rust#35626](https://github.com/rust-lang/rust/issues/35626)

--- a/text/1510-cdylib.md
+++ b/text/1510-cdylib.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-02-23
 - RFC PR: [rust-lang/rfcs#1510](https://github.com/rust-lang/rfcs/pull/1510)
 - Rust Issue: [rust-lang/rust#33132](https://github.com/rust-lang/rust/issues/33132)

--- a/text/1521-copy-clone-semantics.md
+++ b/text/1521-copy-clone-semantics.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 01 March, 2016
 - RFC PR: [rust-lang/rfcs#1521](https://github.com/rust-lang/rfcs/pull/1521)
 - Rust Issue: [rust-lang/rust#33416](https://github.com/rust-lang/rust/issues/33416)

--- a/text/1522-conservative-impl-trait.md
+++ b/text/1522-conservative-impl-trait.md
@@ -1,4 +1,4 @@
-- Feature Name: conservative_impl_trait
+- Feature Name: `conservative_impl_trait`
 - Start Date: 2016-01-31
 - RFC PR: [rust-lang/rfcs#1522](https://github.com/rust-lang/rfcs/pull/1522)
 - Rust Issue: [rust-lang/rust#34511](https://github.com/rust-lang/rust/issues/34511)

--- a/text/1525-cargo-workspace.md
+++ b/text/1525-cargo-workspace.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2015-09-15
 - RFC PR: [rust-lang/rfcs#1525](https://github.com/rust-lang/rfcs/pull/1525)
 - Rust Issue: [rust-lang/cargo#2122](https://github.com/rust-lang/cargo/issues/2122)

--- a/text/1535-stable-overflow-checks.md
+++ b/text/1535-stable-overflow-checks.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-03-09
 - RFC PR: [rust-lang/rfcs#1535](https://github.com/rust-lang/rfcs/pull/1535)
 - Rust Issue: [rust-lang/rust#33134](https://github.com/rust-lang/rust/issues/33134)

--- a/text/1548-global-asm.md
+++ b/text/1548-global-asm.md
@@ -1,4 +1,4 @@
-- Feature Name: global_asm
+- Feature Name: `global_asm`
 - Start Date: 2016-03-18
 - RFC PR: [rust-lang/rfcs#1548](https://github.com/rust-lang/rfcs/pull/1548)
 - Rust Issue: [rust-lang/rust#35119](https://github.com/rust-lang/rust/issues/35119)

--- a/text/1558-closure-to-fn-coercion.md
+++ b/text/1558-closure-to-fn-coercion.md
@@ -1,4 +1,4 @@
-- Feature Name: closure_to_fn_coercion
+- Feature Name: `closure_to_fn_coercion`
 - Start Date: 2016-03-25
 - RFC PR: [rust-lang/rfcs#1558](https://github.com/rust-lang/rfcs/pull/1558)
 - Rust Issue: [rust-lang/rust#39817](https://github.com/rust-lang/rust/issues/39817)

--- a/text/1559-attributes-with-literals.md
+++ b/text/1559-attributes-with-literals.md
@@ -1,4 +1,4 @@
-- Feature Name: attributes_with_literals
+- Feature Name: `attributes_with_literals`
 - Start Date: 2016-03-28
 - RFC PR: [rust-lang/rfcs#1559](https://github.com/rust-lang/rfcs/pull/1559)
 - Rust Issue: [rust-lang/rust#34981](https://github.com/rust-lang/rust/issues/34981)

--- a/text/1560-name-resolution.md
+++ b/text/1560-name-resolution.md
@@ -1,4 +1,4 @@
-- Feature Name: item_like_imports
+- Feature Name: `item_like_imports`
 - Start Date: 2016-02-09
 - RFC PR: [rust-lang/rfcs#1560](https://github.com/rust-lang/rfcs/pull/1560)
 - Rust Issue: [rust-lang/rust#35120](https://github.com/rust-lang/rust/issues/35120)

--- a/text/1561-macro-naming.md
+++ b/text/1561-macro-naming.md
@@ -1,4 +1,4 @@
-- Feature Name: `N/A (part of other unstable features)`
+- Feature Name: `N/A` (part of other unstable features)
 - Start Date: 2016-02-11
 - RFC PR: [rust-lang/rfcs#1561](https://github.com/rust-lang/rfcs/pull/1561)
 - Rust Issue: [rust-lang/rust#35896](https://github.com/rust-lang/rust/issues/35896)

--- a/text/1561-macro-naming.md
+++ b/text/1561-macro-naming.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A (part of other unstable features)
+- Feature Name: `N/A (part of other unstable features)`
 - Start Date: 2016-02-11
 - RFC PR: [rust-lang/rfcs#1561](https://github.com/rust-lang/rfcs/pull/1561)
 - Rust Issue: [rust-lang/rust#35896](https://github.com/rust-lang/rust/issues/35896)

--- a/text/1566-proc-macros.md
+++ b/text/1566-proc-macros.md
@@ -1,4 +1,4 @@
-- Feature Name: procedural_macros
+- Feature Name: `procedural_macros`
 - Start Date: 2016-02-15
 - RFC PR: [rust-lang/rfcs#1566](https://github.com/rust-lang/rfcs/pull/1566)
 - Rust Issue: [rust-lang/rust#38356](https://github.com/rust-lang/rust/issues/38356)

--- a/text/1574-more-api-documentation-conventions.md
+++ b/text/1574-more-api-documentation-conventions.md
@@ -1,4 +1,4 @@
-- Feature Name: More API Documentation Conventions
+- Feature Name: `More API Documentation Conventions`
 - Start Date: 2016-03-31
 - RFC PR: [rust-lang/rfcs#1574](https://github.com/rust-lang/rfcs/pull/1574)
 - Rust Issue: N/A

--- a/text/1576-macros-literal-matcher.md
+++ b/text/1576-macros-literal-matcher.md
@@ -1,4 +1,4 @@
-- Feature Name: macros-literal-match
+- Feature Name: `macros-literal-match`
 - Start Date: 2016-04-08
 - RFC PR: [rust-lang/rfcs#1576](https://github.com/rust-lang/rfcs/pull/1576)
 - Rust Issue: [rust-lang/rust#35625](https://github.com/rust-lang/rust/issues/35625)

--- a/text/1581-fused-iterator.md
+++ b/text/1581-fused-iterator.md
@@ -1,4 +1,4 @@
-- Feature Name: fused
+- Feature Name: `fused`
 - Start Date: 2016-04-15
 - RFC PR: [rust-lang/rfcs#1581](https://github.com/rust-lang/rfcs/pull/1581)
 - Rust Issue: [rust-lang/rust#35602](https://github.com/rust-lang/rust/issues/35602)

--- a/text/1584-macros.md
+++ b/text/1584-macros.md
@@ -1,4 +1,4 @@
-- Feature Name: macro_2_0
+- Feature Name: `macro_2_0`
 - Start Date: 2016-04-17
 - RFC PR: [1584](https://github.com/rust-lang/rfcs/pull/1584)
 - Rust Issue: [39412](https://github.com/rust-lang/rust/issues/39412)

--- a/text/1589-rustc-bug-fix-procedure.md
+++ b/text/1589-rustc-bug-fix-procedure.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-04-22
 - RFC PR: [rust-lang/rfcs#1589](https://github.com/rust-lang/rfcs/pull/1589)
 - Rust Issue: N/A

--- a/text/1590-macro-lifetimes.md
+++ b/text/1590-macro-lifetimes.md
@@ -1,4 +1,4 @@
-- Feature Name: Allow `lifetime` specifiers to be passed to macros
+- Feature Name: `Allow `lifetime` specifiers to be passed to macros`
 - Start Date: 2016-04-22
 - RFC PR: [rust-lang/rfcs#1590](https://github.com/rust-lang/rfcs/pull/1590)
 - Rust Issue: [rust-lang/rust#34303](https://github.com/rust-lang/rust/issues/34303)

--- a/text/1590-macro-lifetimes.md
+++ b/text/1590-macro-lifetimes.md
@@ -1,4 +1,4 @@
-- Feature Name: `Allow `lifetime` specifiers to be passed to macros`
+- Feature Name: `Allow lifetime specifiers to be passed to macros`
 - Start Date: 2016-04-22
 - RFC PR: [rust-lang/rfcs#1590](https://github.com/rust-lang/rfcs/pull/1590)
 - Rust Issue: [rust-lang/rust#34303](https://github.com/rust-lang/rust/issues/34303)

--- a/text/1598-generic_associated_types.md
+++ b/text/1598-generic_associated_types.md
@@ -1,4 +1,4 @@
-- Feature Name: generic_associated_types
+- Feature Name: `generic_associated_types`
 - Start Date: 2016-04-29
 - RFC PR: [rust-lang/rfcs#1598](https://github.com/rust-lang/rfcs/pull/1598)
 - Rust Issue: [rust-lang/rust#44265](https://github.com/rust-lang/rust/issues/44265)

--- a/text/1607-style-rfcs.md
+++ b/text/1607-style-rfcs.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-04-21
 - RFC PR: [rust-lang/rfcs#1607](https://github.com/rust-lang/rfcs/pull/1607)
 - Rust Issue: N/A

--- a/text/1618-ergonomic-format-args.md
+++ b/text/1618-ergonomic-format-args.md
@@ -1,4 +1,4 @@
-- Feature Name: (not applicable)
+- Feature Name: `(not applicable)`
 - Start Date: 2016-05-17
 - RFC PR: [rust-lang/rfcs#1618](https://github.com/rust-lang/rfcs/pull/1618)
 - Rust Issue: [rust-lang/rust#33642](https://github.com/rust-lang/rust/pull/33642)

--- a/text/1620-regex-1.0.md
+++ b/text/1620-regex-1.0.md
@@ -1,4 +1,4 @@
-- Feature Name: regex-1.0
+- Feature Name: `regex-1.0`
 - Start Date: 2016-05-11
 - RFC PR: [rust-lang/rfcs#1620](https://github.com/rust-lang/rfcs/pull/1620)
 - Rust Issue: N/A

--- a/text/1623-static.md
+++ b/text/1623-static.md
@@ -1,4 +1,4 @@
-- Feature Name: static_lifetime_in_statics
+- Feature Name: `static_lifetime_in_statics`
 - Start Date: 2016-05-20
 - RFC PR: [rust-lang/rfcs#1623](https://github.com/rust-lang/rfcs/pull/1623)
 - Rust Issue: [rust-lang/rust#35897](https://github.com/rust-lang/rust/issues/35897)

--- a/text/1624-loop-break-value.md
+++ b/text/1624-loop-break-value.md
@@ -1,4 +1,4 @@
-- Feature Name: loop_break_value
+- Feature Name: `loop_break_value`
 - Start Date: 2016-05-20
 - RFC PR: [rust-lang/rfcs#1624](https://github.com/rust-lang/rfcs/pull/1624)
 - Rust Issue: [rust-lang/rust#37339](https://github.com/rust-lang/rust/issues/37339)

--- a/text/1636-document_all_features.md
+++ b/text/1636-document_all_features.md
@@ -1,4 +1,4 @@
-- Feature Name: document_all_features
+- Feature Name: `document_all_features`
 - Start Date: 2016-06-03
 - RFC PR: [rust-lang/rfcs#1636](https://github.com/rust-lang/rfcs/pull/1636)
 - Rust Issue: https://github.com/rust-lang-nursery/reference/issues/9

--- a/text/1643-memory-model-strike-team.md
+++ b/text/1643-memory-model-strike-team.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-06-07
 - RFC PR: [rust-lang/rfcs#1643](https://github.com/rust-lang/rfcs/pull/1643)
 - Rust Issue: N/A

--- a/text/1649-atomic-access.md
+++ b/text/1649-atomic-access.md
@@ -1,4 +1,4 @@
-q- Feature Name: atomic_access
+q- Feature Name: `atomic_access`
 - Start Date: 2016-06-15
 - RFC PR: [rust-lang/rfcs#1649](https://github.com/rust-lang/rfcs/pull/1649)
 - Rust Issue: [rust-lang/rust#35603](https://github.com/rust-lang/rust/issues/35603)

--- a/text/1651-movecell.md
+++ b/text/1651-movecell.md
@@ -1,4 +1,4 @@
-- Feature Name: move_cell
+- Feature Name: `move_cell`
 - Start Date: 2016-06-15
 - RFC PR: [rust-lang/rfcs#1651](https://github.com/rust-lang/rfcs/pull/1651)
 - Rust Issue: [rust-lang/rust#39264](https://github.com/rust-lang/rust/issues/39264)

--- a/text/1653-assert_ne.md
+++ b/text/1653-assert_ne.md
@@ -1,4 +1,4 @@
-- Feature Name: `Assert Not Equals Macro (`assert_ne`)`
+- Feature Name: `assert_ne` (Assert Not Equals Macro)
 - Start Date: (2016-06-17)
 - RFC PR: [rust-lang/rfcs#1653](https://github.com/rust-lang/rfcs/pull/1653)
 - Rust Issue: [rust-lang/rust#35073](https://github.com/rust-lang/rust/issues/35073)

--- a/text/1653-assert_ne.md
+++ b/text/1653-assert_ne.md
@@ -1,4 +1,4 @@
-- Feature Name: Assert Not Equals Macro (`assert_ne`)
+- Feature Name: `Assert Not Equals Macro (`assert_ne`)`
 - Start Date: (2016-06-17)
 - RFC PR: [rust-lang/rfcs#1653](https://github.com/rust-lang/rfcs/pull/1653)
 - Rust Issue: [rust-lang/rust#35073](https://github.com/rust-lang/rust/issues/35073)

--- a/text/1665-windows-subsystem.md
+++ b/text/1665-windows-subsystem.md
@@ -1,4 +1,4 @@
-- Feature Name: Windows Subsystem
+- Feature Name: `Windows Subsystem`
 - Start Date: 2016-07-03
 - RFC PR: [rust-lang/rfcs#1665](https://github.com/rust-lang/rfcs/pull/1665)
 - Rust Issue: [rust-lang/rust#37499](https://github.com/rust-lang/rust/issues/37499)

--- a/text/1682-field-init-shorthand.md
+++ b/text/1682-field-init-shorthand.md
@@ -1,4 +1,4 @@
-- Feature Name: field-init-shorthand
+- Feature Name: `field-init-shorthand`
 - Start Date: 2016-07-18
 - RFC PR: [rust-lang/rfcs#1682](https://github.com/rust-lang/rfcs/pull/1682)
 - Rust Issue: [rust-lang/rust#37340](https://github.com/rust-lang/rust/issues/37340)

--- a/text/1683-docs-team.md
+++ b/text/1683-docs-team.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-07-21
 - RFC PR: [rust-lang/rfcs#1683](https://github.com/rust-lang/rfcs/pull/1683)
 - Rust Issue: N/A

--- a/text/1685-deprecate-anonymous-parameters.md
+++ b/text/1685-deprecate-anonymous-parameters.md
@@ -1,4 +1,4 @@
-- Feature Name: deprecate_anonymous_parameters
+- Feature Name: `deprecate_anonymous_parameters`
 - Start Date: 2016-07-19
 - RFC PR: [rust-lang/rfcs#1685](https://github.com/rust-lang/rfcs/pull/1685)
 - Rust Issue: [rust-lang/rust#41686](https://github.com/rust-lang/rust/issues/41686)

--- a/text/1695-add-error-macro.md
+++ b/text/1695-add-error-macro.md
@@ -1,4 +1,4 @@
-- Feature Name: compile\_error\_macro
+- Feature Name: `compile\_error\_macro`
 - Start Date: 2016-08-01
 - RFC PR: [rust-lang/rfcs#1695](https://github.com/rust-lang/rfcs/pull/1695)
 - Rust Issue: [rust-lang/rust#40872](https://github.com/rust-lang/rust/issues/40872)

--- a/text/1695-add-error-macro.md
+++ b/text/1695-add-error-macro.md
@@ -1,4 +1,4 @@
-- Feature Name: `compile\_error\_macro`
+- Feature Name: `compile_error_macro`
 - Start Date: 2016-08-01
 - RFC PR: [rust-lang/rfcs#1695](https://github.com/rust-lang/rfcs/pull/1695)
 - Rust Issue: [rust-lang/rust#40872](https://github.com/rust-lang/rust/issues/40872)

--- a/text/1696-discriminant.md
+++ b/text/1696-discriminant.md
@@ -1,4 +1,4 @@
-- Feature Name: discriminant
+- Feature Name: `discriminant`
 - Start Date: 2016-08-01
 - RFC PR: [rust-lang/rfcs#1696](https://github.com/rust-lang/rfcs/pull/1696)
 - Rust Issue: [#24263](https://github.com/rust-lang/rust/pull/24263), [#34785](https://github.com/rust-lang/rust/pull/34785)

--- a/text/1717-dllimport.md
+++ b/text/1717-dllimport.md
@@ -1,4 +1,4 @@
-- Feature Name: dllimport
+- Feature Name: `dllimport`
 - Start Date: 2016-08-13
 - RFC PR: [rust-lang/rfcs#1717](https://github.com/rust-lang/rfcs/pull/1717)
 - Rust Issue: [rust-lang/rust#37403](https://github.com/rust-lang/rust/issues/37403)

--- a/text/1728-north-star.md
+++ b/text/1728-north-star.md
@@ -1,4 +1,4 @@
-- Feature Name: north_star
+- Feature Name: `north_star`
 - Start Date: 2016-08-07
 - RFC PR: #1728
 - Rust Issue: N/A

--- a/text/1733-trait-alias.md
+++ b/text/1733-trait-alias.md
@@ -1,4 +1,4 @@
-- Feature Name: Trait alias
+- Feature Name: `Trait alias`
 - Start Date: 2016-08-31
 - RFC PR: [rust-lang/rfcs#1733](https://github.com/rust-lang/rfcs/pull/1733)
 - Rust Issue: [rust-lang/rust#41517](https://github.com/rust-lang/rust/issues/41517)

--- a/text/1774-roadmap-2017.md
+++ b/text/1774-roadmap-2017.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-10-04
 - RFC PR: [rust-lang/rfcs#1774](https://github.com/rust-lang/rfcs/pull/1774)
 - Rust Issue: N/A

--- a/text/1789-as-cell.md
+++ b/text/1789-as-cell.md
@@ -1,4 +1,4 @@
-- Feature Name: as_cell
+- Feature Name: `as_cell`
 - Start Date: 2016-11-13
 - RFC PR: [rust-lang/rfcs#1789](https://github.com/rust-lang/rfcs/pull/1789)
 - Rust Issue: [rust-lang/rust#43038](https://github.com/rust-lang/rust/issues/43038)

--- a/text/1824-crates.io-default-ranking.md
+++ b/text/1824-crates.io-default-ranking.md
@@ -1,4 +1,4 @@
-- Feature Name: crates_io_default_ranking
+- Feature Name: `crates_io_default_ranking`
 - Start Date: 2016-12-19
 - RFC PR: [rust-lang/rfcs#1824](https://github.com/rust-lang/rfcs/pull/1824)
 - Rust Issue: [rust-lang/rust#41616](https://github.com/rust-lang/rust/issues/41616)

--- a/text/1826-change-doc-default-urls.md
+++ b/text/1826-change-doc-default-urls.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-12-22
 - RFC PR: [rust-lang/rfcs#1826](https://github.com/rust-lang/rfcs/pull/1826)
 - Rust Issue: [rust-lang/rust#44687](https://github.com/rust-lang/rust/issues/44687)

--- a/text/1828-rust-bookshelf.md
+++ b/text/1828-rust-bookshelf.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2016-12-25
 - RFC PR: [rust-lang/rfcs#1828](https://github.com/rust-lang/rfcs/pull/1828)
 - Rust Issue: [rust-lang/rust#39588](https://github.com/rust-lang/rust/issues/39588)

--- a/text/1849-non-static-type-id.md
+++ b/text/1849-non-static-type-id.md
@@ -1,4 +1,4 @@
-- Feature Name: non_static_type_id
+- Feature Name: `non_static_type_id`
 - Start Date: 2017-01-08
 - RFC PR: [rust-lang/rfcs#1849](https://github.com/rust-lang/rfcs/pull/1849)
 - Rust Issue: [rust-lang/rust#41875](https://github.com/rust-lang/rust/issues/41875)

--- a/text/1857-stabilize-drop-order.md
+++ b/text/1857-stabilize-drop-order.md
@@ -1,4 +1,4 @@
-- Feature Name: stable_drop_order
+- Feature Name: `stable_drop_order`
 - Start Date: 2017-01-19
 - RFC PR: [rust-lang/rfcs#1857](https://github.com/rust-lang/rfcs/pull/1857)
 - Rust Issue: [rust-lang/rust#43034](https://github.com/rust-lang/rust/issues/43034)

--- a/text/1861-extern-types.md
+++ b/text/1861-extern-types.md
@@ -1,4 +1,4 @@
-- Feature Name: extern_types
+- Feature Name: `extern_types`
 - Start Date: 2017-01-18
 - RFC PR: [rust-lang/rfcs#1861](https://github.com/rust-lang/rfcs/pull/1861)
 - Rust Issue: [rust-lang/rust#43467](https://github.com/rust-lang/rust/issues/43467)

--- a/text/1866-more-readable-assert-eq.md
+++ b/text/1866-more-readable-assert-eq.md
@@ -1,4 +1,4 @@
-- Feature Name: more-readable-assert-eq
+- Feature Name: `more-readable-assert-eq`
 - Start Date: 2017-01-23
 - RFC PR: [rust-lang/rfcs#1866](https://github.com/rust-lang/rfcs/pull/1866)
 - Rust Issue: [rust-lang/rust#41615](https://github.com/rust-lang/rust/issues/41615)

--- a/text/1868-portability-lint.md
+++ b/text/1868-portability-lint.md
@@ -1,4 +1,4 @@
-- Feature Name: nonportable
+- Feature Name: `nonportable`
 - Start Date: 2016-11-15
 - RFC PR: [rust-lang/rfcs#1868](https://github.com/rust-lang/rfcs/pull/1868)
 - Rust Issue: [rust-lang/rust#41619](https://github.com/rust-lang/rust/issues/41619)

--- a/text/1869-eprintln.md
+++ b/text/1869-eprintln.md
@@ -1,4 +1,4 @@
-- Feature Name: eprintln
+- Feature Name: `eprintln`
 - Start Date: 2017-01-23
 - RFC PR: [rust-lang/rfcs#1869](https://github.com/rust-lang/rfcs/pull/1869)
 - Rust Issue: [rust-lang/rust#40528](https://github.com/rust-lang/rust/issues/40528)

--- a/text/1909-unsized-rvalues.md
+++ b/text/1909-unsized-rvalues.md
@@ -1,4 +1,4 @@
-- Feature Name: unsized_locals
+- Feature Name: `unsized_locals`
 - Start Date: 2017-02-11
 - RFC PR: [rust-lang/rfcs#1909](https://github.com/rust-lang/rfcs/pull/1909)
 - Rust Issue: [rust-lang/rust#48055](https://github.com/rust-lang/rust/issues/48055)

--- a/text/1937-ques-in-main.md
+++ b/text/1937-ques-in-main.md
@@ -1,4 +1,4 @@
-- Feature Name: ques_in_main
+- Feature Name: `ques_in_main`
 - Start Date: 2017-02-22
 - RFC PR: [rust-lang/rfcs#1937](https://github.com/rust-lang/rfcs/pull/1937)
 - Rust Issue: [rust-lang/rust#43301](https://github.com/rust-lang/rust/issues/43301)

--- a/text/1940-must-use-functions.md
+++ b/text/1940-must-use-functions.md
@@ -1,4 +1,4 @@
-- Feature Name: none?
+- Feature Name: `none?`
 - Start Date: 2015-02-18
 - RFC PR: [rust-lang/rfcs#1940](https://github.com/rust-lang/rfcs/pull/1940)
 - Rust Issue: [rust-lang/rust#43302](https://github.com/rust-lang/rust/issues/43302)

--- a/text/1951-expand-impl-trait.md
+++ b/text/1951-expand-impl-trait.md
@@ -1,4 +1,4 @@
-- Feature Name: expanded_impl_trait
+- Feature Name: `expanded_impl_trait`
 - Start Date: 2017-03-12
 - RFC PR: [rust-lang/rfcs#1951](https://github.com/rust-lang/rfcs/pull/1951)
 - Rust Issue: [rust-lang/rust#42183](https://github.com/rust-lang/rust/issues/42183)

--- a/text/1961-clamp.md
+++ b/text/1961-clamp.md
@@ -1,4 +1,4 @@
-- Feature Name: clamp functions
+- Feature Name: `clamp functions`
 - Start Date: 2017-03-26
 - RFC PR: [rust-lang/rfcs#1961](https://github.com/rust-lang/rfcs/pull/1961)/
 - Rust Issue: [rust-lang/rust#44095](https://github.com/rust-lang/rust/issues/44095)

--- a/text/1966-unsafe-pointer-reform.md
+++ b/text/1966-unsafe-pointer-reform.md
@@ -1,4 +1,4 @@
-- Feature Name: Unsafe Pointer ~~Reform~~ Methods
+- Feature Name: `Unsafe Pointer ~~Reform~~ Methods`
 - Start Date: 2015-08-01
 - RFC PR: [rust-lang/rfcs#1966](https://github.com/rust-lang/rfcs/pull/1966)
 - Rust Issue: [rust-lang/rust#43941](https://github.com/rust-lang/rust/issues/43941)

--- a/text/1969-cargo-prepublish.md
+++ b/text/1969-cargo-prepublish.md
@@ -1,4 +1,4 @@
-- Feature Name: prepublish
+- Feature Name: `prepublish`
 - Start Date: 2017-03-22
 - RFC PR: [rust-lang/rfcs#1969](https://github.com/rust-lang/rfcs/pull/1969)
 - Rust Issue: N/A

--- a/text/1983-nursery-deprecation.md
+++ b/text/1983-nursery-deprecation.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2017-04-26
 - RFC PR: [rust-lang/rfcs#1983](https://github.com/rust-lang/rfcs/pull/1983)
 - Rust Issue: N/A

--- a/text/1985-tiered-browser-support.md
+++ b/text/1985-tiered-browser-support.md
@@ -1,4 +1,4 @@
-- Feature Name: tiered_browser_support
+- Feature Name: `tiered_browser_support`
 - Start Date: 2017-04-25
 - RFC PR: [rust-lang/rfcs#1985](https://github.com/rust-lang/rfcs/pull/1985)
 - Rust Issue: [rust-lang/rust#43035](https://github.com/rust-lang/rust/issues/43035)

--- a/text/1990-external-doc-attribute.md
+++ b/text/1990-external-doc-attribute.md
@@ -9,7 +9,7 @@
 -- except according to those terms.
 -->
 
-- Feature Name: external_doc
+- Feature Name: `external_doc`
 - Start Date: 2017-04-26
 - RFC PR: [rust-lang/rfcs#1990](https://github.com/rust-lang/rfcs/pull/1990)
 - Rust Issue: [rust-lang/rust#44732](https://github.com/rust-lang/rust/issues/44732)

--- a/text/2000-const-generics.md
+++ b/text/2000-const-generics.md
@@ -1,4 +1,4 @@
-- Feature Name: const_generics
+- Feature Name: `const_generics`
 - Start Date: 2017-05-01
 - RFC PR: [rust-lang/rfcs#2000](https://github.com/rust-lang/rfcs/pull/2000)
 - Rust Issue: [rust-lang/rust#44580](https://github.com/rust-lang/rust/issues/44580)

--- a/text/2005-match-ergonomics.md
+++ b/text/2005-match-ergonomics.md
@@ -1,4 +1,4 @@
-- Feature Name: pattern-binding-modes
+- Feature Name: `pattern-binding-modes`
 - Start Date: 2016-08-12
 - RFC PR: [rust-lang/rfcs#2005](https://github.com/rust-lang/rfcs/pull/2005)
 - Rust Issue: [rust-lang/rust#42640](https://github.com/rust-lang/rust/issues/42640)

--- a/text/2008-non-exhaustive.md
+++ b/text/2008-non-exhaustive.md
@@ -1,4 +1,4 @@
-- Feature Name: non_exhaustive
+- Feature Name: `non_exhaustive`
 - Start Date: 2017-05-24
 - RFC PR: [rust-lang/rfcs#2008](https://github.com/rust-lang/rfcs/pull/2008)
 - Rust Issue: [rust-lang/rust#44109](https://github.com/rust-lang/rust/issues/44109)

--- a/text/2025-nested-method-calls.md
+++ b/text/2025-nested-method-calls.md
@@ -1,4 +1,4 @@
-- Feature Name: nested_method_call
+- Feature Name: `nested_method_call`
 - Start Date: 2017-06-06
 - RFC PR: [rust-lang/rfcs#2025](https://github.com/rust-lang/rfcs/pull/2025)
 - Rust Issue: [rust-lang/rust#44100](https://github.com/rust-lang/rust/issues/44100)

--- a/text/2027-object_safe_for_dispatch.md
+++ b/text/2027-object_safe_for_dispatch.md
@@ -1,4 +1,4 @@
-- Feature Name: object_safe_for_dispatch
+- Feature Name: `object_safe_for_dispatch`
 - Start Date: 2017-06-10
 - RFC PR: [rust-lang/rfcs#2027](https://github.com/rust-lang/rfcs/pull/2027)
 - Rust Issue: [rust-lang/rust#43561](https://github.com/rust-lang/rust/issues/43561)

--- a/text/2043-is-aligned-intrinsic.md
+++ b/text/2043-is-aligned-intrinsic.md
@@ -1,4 +1,4 @@
-- Feature Name: align_to_intrinsic
+- Feature Name: `align_to_intrinsic`
 - Start Date: 2017-06-20
 - RFC PR: [rust-lang/rfcs#2043](https://github.com/rust-lang/rfcs/pull/2043)
 - Rust Issue: [rust-lang/rust#44488](https://github.com/rust-lang/rust/issues/44488)

--- a/text/2044-license-rfcs.md
+++ b/text/2044-license-rfcs.md
@@ -1,4 +1,4 @@
-- Feature Name: license_rfcs
+- Feature Name: `license_rfcs`
 - Start Date: 2017-06-26
 - RFC PR: [rust-lang/rfcs#2044](https://github.com/rust-lang/rfcs/pull/2044)
 - Rust Issue: [rust-lang/rust#43461](https://github.com/rust-lang/rust/issues/43461)

--- a/text/2045-target-feature.md
+++ b/text/2045-target-feature.md
@@ -1,4 +1,4 @@
-- Feature Name: `target_feature` / `cfg_target_feature` / `cfg_feature_enabled`
+- Feature Name: `target_feature`, `cfg_target_feature`, `cfg_feature_enabled`
 - Start Date: 2017-06-26
 - RFC PR: [rust-lang/rfcs#2045](https://github.com/rust-lang/rfcs/pull/2045)
 - Rust Issue: [rust-lang/rust#44839](https://github.com/rust-lang/rust/issues/44839)

--- a/text/2046-label-break-value.md
+++ b/text/2046-label-break-value.md
@@ -1,4 +1,4 @@
-- Feature Name: label_break_value
+- Feature Name: `label_break_value`
 - Start Date: 2017-06-26
 - RFC PR: [rust-lang/rfcs#2046](https://github.com/rust-lang/rfcs/pull/2046)
 - Rust Issue: [rust-lang/rust#48594](https://github.com/rust-lang/rust/issues/48594)

--- a/text/2052-epochs.md
+++ b/text/2052-epochs.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2017-06-26
 - RFC PR: [rust-lang/rfcs#2052](https://github.com/rust-lang/rfcs/pull/2052)
 - Rust Issue: [rust-lang/rust#44581](https://github.com/rust-lang/rust/issues/44581)

--- a/text/2057-refcell-replace.md
+++ b/text/2057-refcell-replace.md
@@ -1,4 +1,4 @@
-- Feature Name: refcell-replace
+- Feature Name: `refcell-replace`
 - Start Date: 2017-06-09
 - RFC PR: [rust-lang/rfcs#2057](https://github.com/rust-lang/rfcs/pull/2057)
 - Rust Issue: [rust-lang/rust#43570](https://github.com/rust-lang/rust/issues/43570)

--- a/text/2070-panic-implementation.md
+++ b/text/2070-panic-implementation.md
@@ -1,4 +1,4 @@
-- Feature Name: panic_implementation
+- Feature Name: `panic_implementation`
 - Start Date: 2017-07-19
 - RFC PR: [rust-lang/rfcs#2070](https://github.com/rust-lang/rfcs/pull/2070)
 - Rust Issue: [rust-lang/rust#44489](https://github.com/rust-lang/rust/issues/44489)

--- a/text/2071-impl-trait-existential-types.md
+++ b/text/2071-impl-trait-existential-types.md
@@ -1,4 +1,4 @@
-- Feature Name: impl-trait-existential-types
+- Feature Name: `impl-trait-existential-types`
 - Start Date: 2017-07-20
 - RFC PR: [rust-lang/rfcs#2071](https://github.com/rust-lang/rfcs/pull/2071)
 - Rust Issue: [rust-lang/rust#63063](https://github.com/rust-lang/rust/issues/63063) (existential types)

--- a/text/2086-allow-if-let-irrefutables.md
+++ b/text/2086-allow-if-let-irrefutables.md
@@ -1,4 +1,4 @@
-- Feature Name: allow_if_let_irrefutables
+- Feature Name: `allow_if_let_irrefutables`
 - Start Date: 2017-07-27
 - RFC PR: [rust-lang/rfcs#2086](https://github.com/rust-lang/rfcs/pull/2086)
 - Rust Issue: [rust-lang/rust#44495](https://github.com/rust-lang/rust/issues/44495)

--- a/text/2094-nll.md
+++ b/text/2094-nll.md
@@ -1,4 +1,4 @@
-- Feature Name: nll
+- Feature Name: `nll`
 - Start Date: 2017-08-02
 - RFC PR: [rust-lang/rfcs#2094](https://github.com/rust-lang/rfcs/pull/2094)
 - Rust Issue: [rust-lang/rust#44928](https://github.com/rust-lang/rust/issues/44928)

--- a/text/2103-tool-attributes.md
+++ b/text/2103-tool-attributes.md
@@ -1,4 +1,4 @@
-- Feature Name: tool_attributes, tool_lints
+- Feature Name: `tool_attributes`, `tool_lints`
 - Start Date: 2016-09-22
 - RFC PR: [rust-lang/rfcs#2103](https://github.com/rust-lang/rfcs/pull/2103)
 - Rust Issue: [rust-lang/rust#44690](https://github.com/rust-lang/rust/issues/44690)

--- a/text/2113-dyn-trait-syntax.md
+++ b/text/2113-dyn-trait-syntax.md
@@ -1,4 +1,4 @@
-- Feature Name: dyn-trait-syntax
+- Feature Name: `dyn-trait-syntax`
 - Start Date: 2017-08-17
 - RFC PR: [rust-lang/rfcs#2113](https://github.com/rust-lang/rfcs/pull/2113)
 - Rust Issue: [rust-lang/rust#44662](https://github.com/rust-lang/rust/issues/44662)

--- a/text/2115-argument-lifetimes.md
+++ b/text/2115-argument-lifetimes.md
@@ -1,4 +1,4 @@
-- Feature Name: argument_lifetimes
+- Feature Name: `argument_lifetimes`
 - Start Date: 2017-08-17
 - RFC PR: [rust-lang/rfcs#2115](https://github.com/rust-lang/rfcs/pull/2115)
 - Rust Issue: [rust-lang/rust#44524](https://github.com/rust-lang/rust/issues/44524)

--- a/text/2116-alloc-me-maybe.md
+++ b/text/2116-alloc-me-maybe.md
@@ -1,4 +1,4 @@
-- Feature Name: fallible_collection_alloc
+- Feature Name: `fallible_collection_alloc`
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: [rust-lang/rfcs#2116](https://github.com/rust-lang/rfcs/pull/2116)
 - Rust Issue: [rust-lang/rust#48043](https://github.com/rust-lang/rust/issues/48043)

--- a/text/2124-option-filter.md
+++ b/text/2124-option-filter.md
@@ -1,4 +1,4 @@
-- Feature Name: option_filter
+- Feature Name: `option_filter`
 - Start Date: 2017-08-21
 - RFC PR: [rust-lang/rfcs#2124](https://github.com/rust-lang/rfcs/pull/2124)
 - Rust Issue: [rust-lang/rust#45860](https://github.com/rust-lang/rust/issues/45860)

--- a/text/2126-path-clarity.md
+++ b/text/2126-path-clarity.md
@@ -1,4 +1,4 @@
-- Feature Name: TBD
+- Feature Name: `TBD`
 - Start Date: 2017-08-24
 - RFC PR: [rust-lang/rfcs#2126](https://github.com/rust-lang/rfcs/pull/2126)
 - Rust Issue: [rust-lang/rust#44660](https://github.com/rust-lang/rust/issues/44660)

--- a/text/2128-use-nested-groups.md
+++ b/text/2128-use-nested-groups.md
@@ -1,4 +1,4 @@
-- Feature Name: use_nested_groups
+- Feature Name: `use_nested_groups`
 - Start Date: 2017-08-25
 - RFC PR: [rust-lang/rfcs#2128](https://github.com/rust-lang/rfcs/pull/2128)
 - Rust Issue: [rust-lang/rust#44494](https://github.com/rust-lang/rust/issues/44494)

--- a/text/2136-build-systems.md
+++ b/text/2136-build-systems.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2017-09-01
 - RFC PR: [rust-lang/rfcs#2136](https://github.com/rust-lang/rfcs/pull/2136)
 - Rust Issue: N/A

--- a/text/2137-variadic.md
+++ b/text/2137-variadic.md
@@ -1,4 +1,4 @@
-- Feature Name: variadic
+- Feature Name: `variadic`
 - Start Date: 2017-08-21
 - RFC PR: [rust-lang/rfcs#2137](https://github.com/rust-lang/rfcs/pull/2137)
 - Rust Issue: [rust-lang/rust#44930](https://github.com/rust-lang/rust/issues/44930)

--- a/text/2141-alternative-registries.md
+++ b/text/2141-alternative-registries.md
@@ -1,4 +1,4 @@
-- Feature Name: cargo_alternative_registries
+- Feature Name: `cargo_alternative_registries`
 - Start Date: 2017-09-06
 - RFC PR: [rust-lang/rfcs#2141](https://github.com/rust-lang/rfcs/pull/2141)
 - Rust Issue: [rust-lang/rust#44931](https://github.com/rust-lang/rust/issues/44931)

--- a/text/2145-type-privacy.md
+++ b/text/2145-type-privacy.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2017-09-09
 - RFC PR: [rust-lang/rfcs#2145](https://github.com/rust-lang/rfcs/pull/2145)
 - Rust Issue: [rust-lang/rust#48054](https://github.com/rust-lang/rust/issues/48054)

--- a/text/2166-impl-only-use.md
+++ b/text/2166-impl-only-use.md
@@ -1,4 +1,4 @@
-- Feature Name: impl-only-use
+- Feature Name: `impl-only-use`
 - Start Date: 2017-10-01
 - RFC PR: [rust-lang/rfcs#2166](https://github.com/rust-lang/rfcs/pull/2166)
 - Rust Issue: [rust-lang/rust#48216](https://github.com/rust-lang/rust/issues/48216)

--- a/text/2175-if-while-or-patterns.md
+++ b/text/2175-if-while-or-patterns.md
@@ -1,4 +1,4 @@
-- Feature Name: if_while_or_patterns
+- Feature Name: `if_while_or_patterns`
 - Start Date: 2017-10-16
 - RFC PR: [rust-lang/rfcs#2175](https://github.com/rust-lang/rfcs/pull/2175)
 - Rust Issue: [rust-lang/rust#48215](https://github.com/rust-lang/rust/issues/48215)

--- a/text/2195-really-tagged-unions.md
+++ b/text/2195-really-tagged-unions.md
@@ -1,4 +1,4 @@
-- Feature Name: really_tagged_unions
+- Feature Name: `really_tagged_unions`
 - Start Date: 2017-10-30
 - RFC PR: [rust-lang/rfcs#2195](https://github.com/rust-lang/rfcs/pull/2195)
 - Rust Issue: N/A

--- a/text/2226-fmt-debug-hex.md
+++ b/text/2226-fmt-debug-hex.md
@@ -1,4 +1,4 @@
-- Feature Name: fmt-debug-hex
+- Feature Name: `fmt-debug-hex`
 - Start Date: 2017-11-24
 - RFC PR: [rust-lang/rfcs#2226](https://github.com/rust-lang/rfcs/pull/2226)
 - Rust Issue: [rust-lang/rust#48584](https://github.com/rust-lang/rust/issues/48584)

--- a/text/2230-bury-description.md
+++ b/text/2230-bury-description.md
@@ -1,4 +1,4 @@
-- Feature Name: optional_error_description
+- Feature Name: `optional_error_description`
 - Start Date: 2017-11-29
 - RFC PR: [rust-lang/rfcs#2230](https://github.com/rust-lang/rfcs/pull/2230)
 - Rust Issue: (leave this empty)

--- a/text/2250-finalize-impl-dyn-syntax.md
+++ b/text/2250-finalize-impl-dyn-syntax.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2017-12-16
 - RFC PR: [rust-lang/rfcs#2250](https://github.com/rust-lang/rfcs/pull/2250)
 - Rust Issue: [rust-lang/rust#34511](https://github.com/rust-lang/rust/issues/34511)

--- a/text/2282-profile-dependencies.md
+++ b/text/2282-profile-dependencies.md
@@ -1,4 +1,4 @@
-- Feature Name: profile_dependencies
+- Feature Name: `profile_dependencies`
 - Start Date: 2018-01-08
 - RFC PR: [rust-lang/rfcs#2282](https://github.com/rust-lang/rfcs/pull/2282)
 - Rust Issue: [rust-lang/rust#48683](https://github.com/rust-lang/rust/issues/48683)

--- a/text/2314-roadmap-2018.md
+++ b/text/2314-roadmap-2018.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2018-01-23
 - RFC PR: [rust-lang/rfcs#2314](https://github.com/rust-lang/rfcs/pull/2314)
 - Rust Issue: N/A

--- a/text/2394-async_await.md
+++ b/text/2394-async_await.md
@@ -1,4 +1,4 @@
-- Feature Name: async_await
+- Feature Name: `async_await`
 - Start Date: 2018-03-30
 - RFC PR: [rust-lang/rfcs#2394](https://github.com/rust-lang/rfcs/pull/2394)
 - Rust Issues: 

--- a/text/2436-style-guide.md
+++ b/text/2436-style-guide.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2018-05-04
 - RFC PR: #2436
 - Rust Issue: N/A

--- a/text/2523-cfg-path-version.md
+++ b/text/2523-cfg-path-version.md
@@ -1,4 +1,4 @@
-- Feature Name: `cfg_version` and `cfg_accessible`
+- Feature Name: `cfg_version`, `cfg_accessible`
 - Start Date: 2018-08-12
 - RFC PR: [rust-lang/rfcs#2523](https://github.com/rust-lang/rfcs/pull/2523)
 - Rust Issue: [rust-lang/rust#64796](https://github.com/rust-lang/rust/issues/64796) and [rust-lang/rust#64797](https://github.com/rust-lang/rust/issues/64797)

--- a/text/2603-rust-symbol-name-mangling-v0.md
+++ b/text/2603-rust-symbol-name-mangling-v0.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2018-11-27
 - RFC PR: [rust-lang/rfcs#2603](https://github.com/rust-lang/rfcs/pull/2603)
 - Rust Issue: [rust-lang/rust#60705](https://github.com/rust-lang/rust/issues/60705)

--- a/text/2657-roadmap-2019.md
+++ b/text/2657-roadmap-2019.md
@@ -1,6 +1,6 @@
 # 2019 Roadmap
 
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2019-03-07
 - RFC PR: [rust-lang/rfcs#2657](https://github.com/rust-lang/rfcs/pull/2657)
 - Rust Issue: N/A

--- a/text/2689-compiler-team-contributors.md
+++ b/text/2689-compiler-team-contributors.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2019-04-18
 - RFC PR: [rust-lang/rfcs#2689](https://github.com/rust-lang/rfcs/pull/2689)
 - Rust Issue: N/A

--- a/text/2789-sparse-index.md
+++ b/text/2789-sparse-index.md
@@ -1,4 +1,4 @@
-- Feature Name: sparse_index
+- Feature Name: `sparse_index`
 - Start Date: 2019-10-18
 - RFC PR: [rust-lang/rfcs#2789](https://github.com/rust-lang/rfcs/pull/2789)
 - Tracking Issue: [rust-lang/rust#9069](https://github.com/rust-lang/cargo/issues/9069)

--- a/text/2834-cargo-report-future-incompat.md
+++ b/text/2834-cargo-report-future-incompat.md
@@ -1,4 +1,4 @@
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2019-12-10
 - RFC PR: [rust-lang/rfcs#2834](https://github.com/rust-lang/rfcs/pull/2834)
 - Rust Issue: [rust-lang/rust#71249](https://github.com/rust-lang/rust/issues/71249)

--- a/text/2857-roadmap-2020.md
+++ b/text/2857-roadmap-2020.md
@@ -1,6 +1,6 @@
 # Rust 2020 Roadmap
 
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2020-01-22
 - RFC PR: [rust-lang/rfcs#2857](https://github.com/rust-lang/rfcs/pull/2857)
 - Rust Issue: N/A

--- a/text/2867-isa-attribute.md
+++ b/text/2867-isa-attribute.md
@@ -1,4 +1,4 @@
-- Feature Name: isa_attribute
+- Feature Name: `isa_attribute`
 - Start Date: 2020-02-16
 - RFC PR: [rust-lang/rfcs#2867](https://github.com/rust-lang/rfcs/pull/2867)
 - Rust Issue: [rust-lang/rust#74727](https://github.com/rust-lang/rust/issues/74727)

--- a/text/2904-compiler-major-change-process.md
+++ b/text/2904-compiler-major-change-process.md
@@ -1,6 +1,6 @@
 # Major Change Proposal RFC
 
-- Feature Name: N/A
+- Feature Name: `N/A`
 - Start Date: 2020-05-07
 - RFC PR: [rust-lang/rfcs#2904](https://github.com/rust-lang/rfcs/pull/2904)
 - Rust Issue: N/A

--- a/text/2912-rust-analyzer.md
+++ b/text/2912-rust-analyzer.md
@@ -1,3 +1,4 @@
+- Feature Name: `N/A`
 - Start Date: 2020-04-20
 - RFC PR: [rust-lang/rfcs#2912](https://github.com/rust-lang/rfcs/pull/2912)
 - Rust Issue: [rust-analyzer/rust-analyzer#4224](https://github.com/rust-analyzer/rust-analyzer/issues/4224)

--- a/text/2912-rust-analyzer.md
+++ b/text/2912-rust-analyzer.md
@@ -1,4 +1,4 @@
-- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+- Feature Name: `(fill me in with a unique ident`, ``my_awesome_feature`)`
 - Start Date: 2020-04-20
 - RFC PR: [rust-lang/rfcs#2912](https://github.com/rust-lang/rfcs/pull/2912)
 - Rust Issue: [rust-analyzer/rust-analyzer#4224](https://github.com/rust-analyzer/rust-analyzer/issues/4224)

--- a/text/2912-rust-analyzer.md
+++ b/text/2912-rust-analyzer.md
@@ -1,4 +1,3 @@
-- Feature Name: `(fill me in with a unique ident`, ``my_awesome_feature`)`
 - Start Date: 2020-04-20
 - RFC PR: [rust-lang/rfcs#2912](https://github.com/rust-lang/rfcs/pull/2912)
 - Rust Issue: [rust-analyzer/rust-analyzer#4224](https://github.com/rust-analyzer/rust-analyzer/issues/4224)

--- a/text/2930-read-buf.md
+++ b/text/2930-read-buf.md
@@ -1,4 +1,4 @@
-- Feature Name: read_buf
+- Feature Name: `read_buf`
 - Start Date: 2020/05/18
 - RFC PR: [rust-lang/rfcs#2930](https://github.com/rust-lang/rfcs/pull/2930)
 - Rust Issue: [rust-lang/rust#78485](https://github.com/rust-lang/rust/issues/78485)

--- a/text/2965-project-error-handling.md
+++ b/text/2965-project-error-handling.md
@@ -1,4 +1,4 @@
-- Feature Name: error_handling_project_group
+- Feature Name: `error_handling_project_group`
 - Start Date: 2020-07-23
 - RFC PR: [rust-lang/rfcs#2965](https://github.com/rust-lang/rfcs/pull/2965)
 - Rust Issue: [rust-lang/libs-team#3](https://github.com/rust-lang/libs-team/issues/3)

--- a/text/2977-stdsimd.md
+++ b/text/2977-stdsimd.md
@@ -1,4 +1,4 @@
-- Feature Name: stdsimd_project_group
+- Feature Name: `stdsimd_project_group`
 - Start Date: 2020-08-28
 - RFC PR: [rust-lang/rfcs#2977](https://github.com/rust-lang/rfcs/pull/2977)
 - Rust Issue: [rust-lang/rust-libs#4](https://github.com/rust-lang/libs-team/issues/4)

--- a/text/3027-infallible-promotion.md
+++ b/text/3027-infallible-promotion.md
@@ -1,4 +1,4 @@
-- Feature Name: infallible_lifetime_extension
+- Feature Name: `infallible_lifetime_extension`
 - Start Date: 2020-11-08
 - RFC PR: [rust-lang/rfcs#3027](https://github.com/rust-lang/rfcs/pull/3027)
 - Rust Issue: [rust-lang/rust#80619](https://github.com/rust-lang/rust/issues/80619)

--- a/text/3028-cargo-binary-dependencies.md
+++ b/text/3028-cargo-binary-dependencies.md
@@ -1,4 +1,4 @@
-- Feature Name: (`bindeps`)
+- Feature Name: `(`bindeps`)`
 - Start Date: 2020-11-30
 - RFC PR: [rust-lang/rfcs#3028](https://github.com/rust-lang/rfcs/pull/3028)
 - Tracking Issue: [rust-lang/cargo#9096](https://github.com/rust-lang/cargo/issues/9096)

--- a/text/3028-cargo-binary-dependencies.md
+++ b/text/3028-cargo-binary-dependencies.md
@@ -1,4 +1,4 @@
-- Feature Name: `(`bindeps`)`
+- Feature Name: `bindeps`
 - Start Date: 2020-11-30
 - RFC PR: [rust-lang/rfcs#3028](https://github.com/rust-lang/rfcs/pull/3028)
 - Tracking Issue: [rust-lang/cargo#9096](https://github.com/rust-lang/cargo/issues/9096)


### PR DESCRIPTION
I have made the way the feature-names are written in every rfc compliant to the 0000-template.
They MUST now all specify that field (if applicable/filled) with the feature names encapsulated in backticks. Also, they should be listed correctly by separating the feature-names (in backticks) via commas.