### PR TITLE
Mark 2203 as mostly superceeded by 2920

### DIFF
--- a/text/2203-const-repeat-expr.md
+++ b/text/2203-const-repeat-expr.md
@@ -3,6 +3,15 @@
 - RFC PR: [rust-lang/rfcs#2203](https://github.com/rust-lang/rfcs/pull/2203)
 - Rust Issue: [rust-lang/rust#49147](https://github.com/rust-lang/rust/issues/49147)
 
+> ⚠ This RFC has mostly been superceeded ⚠
+>
+> This turned out to be more complicated than expected to detect while being intuitive to the programmer.  As such, it's expected that this problem space will be addressed with the *inline consts* from [RFC 2920] instead, which have syntax to opt-in to the behaviour.
+>
+> However, the simpler case of `[SOME_CONST_ITEM; N]` was kept (stabilized in [rust-lang/rust#49147]).
+
+[RFC 2920]: https://github.com/rust-lang/rfcs/blob/master/text/2920-inline-const.md
+[rust-lang/rust#49147]: https://github.com/rust-lang/rust/issues/49147
+
 # Summary
 [summary]: #summary
 


### PR DESCRIPTION
The tracking issue for 2203 was closed; see https://github.com/rust-lang/rust/issues/49147#issuecomment-775282720