### PR TITLE
Fix RFC 243 code blocks and add note

### DIFF
--- a/text/0243-trait-based-exception-handling.md
+++ b/text/0243-trait-based-exception-handling.md
@@ -160,6 +160,8 @@ enclosing block specified by `'a`, which then evaluates to the value `EXPR` (of
 course, the type of `EXPR` must unify with the type of the last expression in
 that block). This works for any block, not only loops.
 
+\[Note: This was since added in [RFC 2046](https://github.com/rust-lang/rfcs/blob/master/text/2046-label-break-value.md)]
+
 A completely artificial example:
 
 ```rust
@@ -296,7 +298,7 @@ as follows:
     }
     ```
 
-  Shallow:
+   Shallow:
 
     ```rust
     match (catch {


### PR DESCRIPTION
This fixes the code blocks that broke in my previous commit and adds a note about RFC 2046 `label-break-value`