### PR TITLE
Pinned synchronization primitives

### DIFF
--- a/text/0000-pinned-sync.md
+++ b/text/0000-pinned-sync.md
@@ -38,7 +38,7 @@ In all methods of these pinned versions a `self: Pin<&Self>` argument is taken, 
 
 In order to initialize a `pinned::Mutex`, for example, one of these can be used:
 
-```
+```rust
 // Directly initialize using ergonomic constructors
 let boxed_mutex: Pin<Box<Mutex<T>>> = Mutex::boxed(...);
 let arc_mutex: Pin<Arc<Mutex<T>>> = Mutex::arc(...);

--- a/text/0000-pinned-sync.md
+++ b/text/0000-pinned-sync.md
@@ -85,7 +85,7 @@ The std `sys_common` already has a pretty good infrastructure for implementing t
         - No need for atomicity on the initialization flag.
         - As the flag isn't atomic hopefully the compiler could optimize it away (in the moment it doesn't).
     - Cons:
-        - It isn't possible to initialize, for example, `Pin<Arc<(Mutex<T>, Condvar)>>` safely. This a major dealbreaker as it puts one of the major advantages of this change behing unsafety.
+        - It isn't possible to initialize, for example, `Pin<Arc<(Mutex<T>, Condvar)>>` safely. This a major dealbreaker as it puts one of the major advantages of this change behind unsafety.
         - Initialization can not be done via a shared reference, so `static` also needs to be wrapped with `UnsafeCell` or made `mut`, both alternatives being `unsafe` as well.
 - [Replace the primitives with `parking_lot`](https://github.com/rust-lang/rust/pull/56410).
     - Pros:

--- a/text/0000-pinned-sync.md
+++ b/text/0000-pinned-sync.md
@@ -8,6 +8,8 @@
 
 Create a new module `std::sync::pinned` for OS synchronization primitives which make use of the `Pin` dialect instead of relying on boxing.
 
+The `pinned_sync` crate has been created to test this RFC. It is available at https://crates.io/crates/pinned_sync.
+
 # Motivation
 
 [motivation]: #motivation
@@ -85,7 +87,6 @@ The std `sys_common` already has a pretty good infrastructure for implementing t
         - No need for atomicity on the initialization flag.
         - As the flag isn't atomic hopefully the compiler could optimize it away (in the moment it doesn't).
     - Cons:
-        - It isn't possible to initialize, for example, `Pin<Arc<(Mutex<T>, Condvar)>>` safely. This a major dealbreaker as it puts one of the major advantages of this change behind unsafety.
         - Initialization can not be done via a shared reference, so `static` also needs to be wrapped with `UnsafeCell` or made `mut`, both alternatives being `unsafe` as well.
 - [Replace the primitives with `parking_lot`](https://github.com/rust-lang/rust/pull/56410).
     - Pros:

--- a/text/0000-pinned-sync.md
+++ b/text/0000-pinned-sync.md
@@ -1,0 +1,92 @@
+- Feature Name: `pinned-sync`
+- Start Date: 2021-04-29
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+# Summary
+
+[summary]: #summary
+
+Create a new module `std::sync::pinned` for OS synchronization primitives which make use of the `Pin` dialect instead of relying on boxing.
+
+# Motivation
+
+[motivation]: #motivation
+
+The current synchronization primitives at `std::sync` box the OS primitives for some OSes, including all Posix-compliant. This is suboptimal as it increases the possibility of cache misses, and adds overhead to creation of these primitives.
+
+With the new `Pin` type, we can expose the primitives directly and have the functions simply take `self: Pin<&Self>`.
+
+This gives more flexibility as it is possible to have, for example, `Arc<Mutex<T>>` without double-boxing the `Mutex`.
+
+# Guide-level explanation
+
+[guide-level-explanation]: #guide-level-explanation
+
+For the following types:
+
+* `Barrier`
+
+* `Condvar`
+
+* `Mutex<T>`
+
+* `RwLock<T>`
+
+Pinned versions are available at the module `std::sync::pinned`. These versions are all `!Unpin`.
+
+In all methods of these pinned versions a `self: Pin<&Self>` argument is taken, therefore the type must be constructed with, for example, `Arc::pin` or `Box::pin`.
+
+In order to initialize a `pinned::Mutex`, for example, one of these can be used:
+
+```
+// Directly initialize using ergonomic constructors
+let boxed_mutex: Pin<Box<Mutex<T>>> = Mutex::boxed(...);
+let arc_mutex: Pin<Arc<Mutex<T>>> = Mutex::arc(...);
+
+// Explicitly initialize after creation with a custom constructor
+// Nothing here is unsafe, the library checks for initialization
+let mut mutex: Pin<Box<Mutex<T>>> = Box::pin(Mutex::uninit(...));
+mutex.as_mut().init();
+```
+
+# Reference-level explanation
+
+[reference-level-explanation]: #reference-level-explanation
+
+The std `sys_common` already has a pretty good infrastructure for implementing this.
+
+- The explicit initialization is done by first creating the structure using `uninit(value: T) -> Self`, then calling `init(self: Pin<&mut Self>)`.
+- The library adds the necessary assertions to make this pattern safe. Using before `init` causes a `panic!`. In particular, the implementation can use an `Option` to wrap the OS primitive. The assertions can be placed such that they are inlined, so if one method is used after another, the assertion can be optimized away for the second method.
+
+# Drawbacks
+
+[drawbacks]: #drawbacks
+
+- Adds further complexity to the `std` library.
+
+# Rationale and alternatives
+
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Alternative for the explicit initialization: have unsafe `uninit()`. This can remove assertion overhead but can lead to some hard to detect undefined behaviour, as in POSIX - for example - this would cause mutexes to work as normal until a double lock happens, which would cause undefined behaviour.
+- [Replace the primitives with `parking_lot`](https://github.com/rust-lang/rust/pull/56410). This has been proposed in the past and has its fair share of drawbacks, such as non-trivial space overhead which can be a deal breaker for some applications.
+
+# Prior art
+
+[prior-art]: #prior-art
+
+- System languages such as C and C++ expose the OS primitives with thin wrappers, without the boxing our current implementation uses. This is possible without `Pin` as these languages have different move semantics, on which types are not moved by default.
+- https://users.rust-lang.org/t/pin-arc-mutex/41940
+- `sync` package for the Linux kernel: https://github.com/Rust-for-Linux/linux/blob/rust/rust/kernel/sync/mod.rs
+
+# Unresolved questions
+
+[unresolved-questions]: #unresolved-questions
+
+- Should `Once` be moved to `pinned` for consistency? The current implementation does not box any primitives, however if we were to use `pthread_once_t` in the future, it would be necessary.
+
+# Future possibilities
+
+[future-possibilities]: #future-possibilities
+
+- Lints for double boxing (suggesting `Pin<Arc<pinned::Mutex<T>>>` when using `Arc<sync::Mutex<T>>`).


### PR DESCRIPTION
This RFC aims to provide `std::sync::pinned` module, with synchronization primitives which are `!Unpin`. These are better used when something like `Arc<Mutex<T>>` is needed, as they avoid an extra allocation on some platforms, e.g. Linux.

[Previous discussion on internals forum](https://internals.rust-lang.org/t/pre-rfc-pinned-synchronization-primitives/14599)

[Rendered](https://github.com/nicbn/rfcs/blob/pinned-sync/text/0000-pinned-sync.md)