### PR TITLE
Fix RFC 1721

### DIFF
--- a/text/1721-crt-static.md
+++ b/text/1721-crt-static.md
@@ -259,7 +259,8 @@ Finally, an example of compiling for MSVC and linking statically to the C
 runtime would look like:
 
 ```
-RUSTFLAGS='-C target-feature=+crt-static' cargo build --target x86_64-pc-windows-msvc
+set RUSTFLAGS=-C target-feature=+crt-static
+cargo build --target x86_64-pc-windows-msvc
 ```
 
 and similarly, compiling for musl but linking dynamically to the C runtime would


### PR DESCRIPTION
This fixes the example of statically linking to msvcrt on Windows to actually work on Windows.
Fixes #3096. 