### PR TITLE
New rustc and Cargo options to allow path sanitisation by default

### DIFF
--- a/text/3127-trim-path.md
+++ b/text/3127-trim-path.md
@@ -95,7 +95,7 @@ If using MSVC toolchain, path to the .pdb file containing debug information are 
 information.
 
 With `trim-path` option disabled, the embedding of path to the source files of the standard and core library will depend on if `rust-src` component is present. If it is, then the real path pointing to a copy of the source files on your file system will be embedded; if it isn't, then they will
-show up as `/rustc/[rustc version]/library/...` (just like when `trim-path` is enabled). Path to all other source files will not be affected.
+show up as `/rustc/[rustc version]/library/...` (just like when `trim-path` is enabled). Paths to all other source files will not be affected.
 
 Note that this will not affect any hard-coded paths in the source code.
 

--- a/text/3127-trim-path.md
+++ b/text/3127-trim-path.md
@@ -130,7 +130,7 @@ The virtualisation of sysroot files to `/rustc/[SHA1 hash]/library/...` was done
 At `rustc` runtime (i.e. compiling some code), we try to correlate this virtual path to a real path pointing to the file on the local file system.
 Currently the result is represented internally as if the path was remapped by `--remap-path-prefix`, holding both the virtual name and local path.
 Only the virtual name is ever emitted for metadata or codegen. We want to change this behaviour such that, when `rust-src` source files can be
-discovered, the virutal path is discarded and therefore will be embedded unless being remapped by `--remap-path-prefix` in the usual way. The relevant part of the code is here:
+discovered, the virtual path is discarded and therefore will be embedded unless being remapped by `--remap-path-prefix` in the usual way. The relevant part of the code is here:
 https://github.com/rust-lang/rust/blob/d8af907491e20339e41d048d6a32b41ddfa91dfe/compiler/rustc_metadata/src/rmeta/decoder.rs#L1637-L1765
 
 We would also like to change the virtualisation of sysroot to `/rustc/[rustc version]/library/...`, instead of the rustc commit hash. This is shorter and more helpful as an identifier, and makes `trim-path` easier to implement: to make the embedded path the same whether or not `rust-src` is installed, we need to emit the same sysroot virutalisation as was done during bootstrapping. Getting the version number is easier than getting the commit hash. The relevant part of the code is here: https://github.com/rust-lang/rust/blob/d8af907491e20339e41d048d6a32b41ddfa91dfe/src/bootstrap/lib.rs#L831-L834 

--- a/text/3127-trim-path.md
+++ b/text/3127-trim-path.md
@@ -1,0 +1,192 @@
+- Feature Name: trim-path
+- Start Date: 2021-05-24
+- RFC PR: [rust-lang/rfcs#3127](https://github.com/rust-lang/rfcs/pull/3127)
+- Rust Issue: N/A
+
+# Summary
+[summary]: #summary
+
+Cargo should have a [profile setting](https://doc.rust-lang.org/cargo/reference/profiles.html#profile-settings) named `trim-path`
+to sanitise absolute paths introduced during compilation that may be embedded in the compilation output. This should be enabled by default for 
+`release` profile.
+
+# Motivation
+[motivation]: #motivation
+
+## Sanitising local paths that are currently embedded
+Currently, executables and libraies built by Cargo have a lot of embedded absolute paths. They most frequently appear in debug information and
+panic messages (pointing to the panic location source file). As an example, consider the following package:
+
+`Cargo.toml`:
+
+```toml
+[package]
+name = "rfc"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+rand = "0.8.0"
+```
+`src/main.rs`
+
+```rust
+use rand::prelude::*;
+    
+fn main() {
+    let r: f64 = rand::thread_rng().gen();
+    println!("{}", r);
+}
+```
+
+Then run
+
+```bash
+$ cargo build --release
+$ strings target/release/rfc | grep $HOME
+```
+
+We will see some absolute paths pointing to dependency crates downloaded by Cargo, containing our username:
+
+```
+could not initialize thread_rng: /home/username/.cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.8.3/src/rngs/thread.rs
+/home/username/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_chacha-0.3.0/src/guts.rsdescription() is deprecated; use Display
+/home/username/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.2/src/util_libc.rs
+```
+
+This is undesirable for the following reasons:
+
+1. **Privacy**. `release` binaries may be distributed, and anyone could then see the builder's local OS account username.
+   Additionally, some CI (such as [GitLab CI](https://docs.gitlab.com/runner/best_practice/#build-directory)) checks out the repo under a path where
+   it may include things that really aren't meant to be public. Without sanitising the path by default, this may be inadvertently leaked.
+2. **Build reproducibility**. We would like to make it easier to reproduce binary equivalent builds. While it is not required to maintain
+   reproducibility across different environments, removing environment-sensitive information from the build will increase tolerance on the inevitable
+   environment differences when trying to verify builds.
+
+## Handling sysroot paths
+At the moment, paths to the source files of standard and core libraries, even when they are present, always begin with a virtual prefix in the form
+of `/rustc/[SHA1 hash]/library`. This is not an issue when the source files are not present (i.e. when `rust-src` component is not installed), but
+when a user installs `rust-src` they expect the path to their local copy of source files to be visible. Hence the user should be given an option for
+the local paths to show up in panic messages and backtraces.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+`trim-path` is a profile setting which can be set to either `true` or `false`. This is enabled by default when you do a release build,
+such as via `cargo build --release`. You can also manually override it by specifying this option in `Cargo.toml`:
+```toml
+[profile.dev]
+trim-path = true
+
+[profile.release]
+trim-path = false
+```
+
+With `trim-path` option enabled, the compilation process will not introduce any absolute paths into the build output. Instead, paths containing
+certain prefixes will be replaced with something stable by the following rules:
+
+1. Path to the source files of the standard and core library will begin with `/rustc/[rustc version]`.
+   E.g. `/home/username/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs` -> 
+   `/rustc/1.52.1/library/core/src/result.rs`
+2. Path to the working directory will be replaced with `.`. E.g. `/home/username/crate/src/lib.rs` -> `./src/lib.rs`.
+3. Path to packages outside of the working directory will be replaced with `[package name]-[version]`. E.g. `/home/username/deps/foo/src/lib.rs` -> `foo-0.1.0/src/lib.rs`
+
+If using MSVC toolchain, path to the .pdb file containing debug information are be embedded as the file name of the .pdb file only, wihtout any path
+information.
+
+With `trim-path` option disabled, the embedding of path to the source files of the standard and core library will depend on if `rust-src` component is present. If it is, then the real path pointing to a copy of the source files on your file system will be embedded; if it isn't, then they will
+show up as `/rustc/[rustc version]/library/...` (just like when `trim-path` is enabled). Path to all other source files will not be affected.
+
+Note that this will not affect any hard-coded paths in the source code.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+## `trim-path` implementation in Cargo
+We only need to change the behaviour for `Test` and `Build` compile modes. 
+
+If `trim-path` is enabled, Cargo will emit two `--remap-path-prefix` arguments to `rustc` for each compilation unit. One mapping is from the path of 
+the local sysroot to `/rustc/[rust version]`. The other mapping depends on if the package containing the compilation unit is under the working
+directory. If it is, then the mapping is from the absolute path to the working directory to `.`. If it's outside the working directory, then the
+mapping is from the absolute path of the package root to `[package name]-[package version]`.
+
+Some interactions with compiler-intrinstic macros need to be considered, though these are entirely down to `rustc`'s implementation of
+`--remap-path-prefix`:
+1. Path (of the current file) introduced by [`file!()`](https://doc.rust-lang.org/std/macro.file.html) *will* be remapped. **Things may break** if
+   the code interacts with its own source file at runtime by using this macro.
+2. Path introduced by [`include!()`](https://doc.rust-lang.org/std/macro.include.html) *will* be remapped, given that the included file is under
+   the current working directory or a dependency package.
+
+If the user further supplies custom `--remap-path-prefix` arguments via `RUSTFLAGS` or similar mechanisms, they will take precedence over the one
+supplied by `trim-path`. This means that the user-defined `--remap-path-prefix`s must be supplied *after* Cargo's own remapping.
+
+Additionally, when using MSVC linker, Cargo should emit `/PDBALTPATH:%_PDB%` to the linker via `-C link-arg`. This makes the linker embed
+only the file name of the .pdb file without the path to it.
+
+## Changing handling of sysroot path
+The virtualisation of sysroot files to `/rustc/[SHA1 hash]/library/...` was done at compiler bootstraping, specifically when 
+`remap-debuginfo = true` in `config.toml`. This is done for Rust distribution on all channels.
+
+At `rustc` runtime (i.e. compiling some code), we try to correlate this virtual path to a real path pointing to the file on the local file system.
+Currently the result is represented internally as if the path was remapped by `--remap-path-prefix`, holding both the virtual name and local path.
+Only the virtual name is ever emitted for metadata or codegen. We want to change this behaviour such that, when `rust-src` source files can be
+discovered, the virutal path is discarded and therefore will be embedded unless being remapped by `--remap-path-prefix` in the usual way. The relevant part of the code is here:
+https://github.com/rust-lang/rust/blob/d8af907491e20339e41d048d6a32b41ddfa91dfe/compiler/rustc_metadata/src/rmeta/decoder.rs#L1637-L1765
+
+We would also like to change the virtualisation of sysroot to `/rustc/[rustc version]/library/...`, instead of the rustc commit hash. This is shorter and more helpful as an identifier, and makes `trim-path` easier to implement: to make the embedded path the same whether or not `rust-src` is installed, we need to emit the same sysroot virutalisation as was done during bootstrapping. Getting the version number is easier than getting the commit hash. The relevant part of the code is here: https://github.com/rust-lang/rust/blob/d8af907491e20339e41d048d6a32b41ddfa91dfe/src/bootstrap/lib.rs#L831-L834 
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+With `trim-path` enabled, if the `debug` option is simultaneously not `false` (it is turned off by default under `release` profile), paths in
+debuginfo will also be remapped. Debuggers will no longer be able to automatically discover and load source files outside of the working directory. 
+This can be remidated by [debugger features](https://lldb.llvm.org/use/map.html#miscellaneous) remapping the path back to a filesystem path.
+
+The user also will not be able to `Ctrl+click` on any paths provided in panic messages or backtraces outside of the working directory. But
+there shouldn't be any confusion as the combination of pacakge name and version can be used to pinpoint the file.
+
+As mentioned above, `trim-path` may break code that relies on `file!()` to evaluate to an accessible path to the file. Hence enabling
+it by default for release builds may be a technically breaking change. Occurances of such use should be extremely rare but should be investigated
+via a Crater run. In case this breakage is unacceptable, `trim-path` can be made an opt-in option rather than default in any build profile.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+There has been an issue (https://github.com/rust-lang/rust/issues/40552) asking for path sanitisation to be implemented and enabled by default for 
+release builds. It has, over the past 4 years, gained a decent amount of popular support. The remapping rule proposed here is very simple to 
+implement.
+
+Path to sysroot crates are specially handled by `rustc`. Due to this, the behaviour we currently have is that all such paths are virtualised.
+Although good for privacy and reproducibility, some people find it a hinderance for debugging: https://github.com/rust-lang/rust/issues/85463.
+Hence the user should be given control on if they want the virtual or local path.
+
+One alternative for the sysroot handling is to keep the logic in `rustc` largely the same, always emitting the virutalised path by default, and
+then introduce an extra option named `--embed-local-sysroot` to embed the local paths if the source files can be found. This inovles adding an extra
+option to `rustc` and prevents any uniformity in `--remap-path-prefix`'s handling over sysroot paths, compared to other paths (it currently doesn't
+affect sysroot paths at all).
+
+# Prior art
+[prior-art]: #prior-art
+
+The name `trim-path` came from the [similar feature](https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies) in Go. An alternative name
+`sanitize-paths` was first considered but the spelling of "sanitise" differs across the pond and down under. It is also not as short and concise.
+
+Go does not enable this by default. Since Go does not differ between debug and release builds, removing absolute paths for all build would be
+a hassle for debugging. However this is not an issue for Rust as we have separate debug build profile.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- Should the option be called `trim-paths` (plural) instead of `trim-path`? Quite a few other option names are plural, such as `debug-assertions`
+  and `overflow-checks`.
+- Should we treat the current working directory the same as other packages? We could have one fewer remapping rule by remapping all
+  package roots to `[package name]-[version]`. A minor downside to this is not being able to `Ctrl+click` on paths to files the user is working
+  on from panic messages.
+- Should we use a slightly more complex remapping rule, like distinguishing packages from registry, git and path, as mentioned in https://github.com/rust-lang/rust/issues/40552?
+- Will these cover all potentially embedded paths? Have we missed anything?
+- Should we make this affect more `CompileMode`s, such as `Check`, where the emitted `rmeta` file will also contain absolute paths?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+N/A

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -102,6 +102,8 @@ This flag accepts a comma-separated list of values and may be specified multiple
 
 Debug information are written to split files when the separate codegen option `-C split-debuginfo=packed` or `unpacked` (whether by default or explicitly set).
 
+Note: this RFC is not a commitment to stabilizing all of these options; stabilization will evaluate each option and see if that option carries enough value to stabilize.
+
 ## Cargo
 
 `trim-paths` is a profile setting which enables and controls the sanitisation of file paths in build outputs. It is a simplified version of rustc's `--remap-path-scope`. It takes a comma separated list of the following values:
@@ -111,6 +113,8 @@ Debug information are written to split files when the separate codegen option `-
 - `diagnostics` - sanitise paths in printed compiler diagnostics
 - `object` - sanitise paths in compiled executables or libraries
 - `all` and `true` - sanitise paths in all possible locations
+
+Note: this RFC is not a commitment to stabilizing all of these options; stabilization will evaluate each option and see if that option carries enough value to stabilize.
 
 It is defaulted to `none` for debug profiles, and `object` for release profiles. You can manually override it by specifying this option in `Cargo.toml`:
 ```toml

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -202,10 +202,9 @@ Path to sysroot crates are specially handled by `rustc`. Due to this, the behavi
 Although good for privacy and reproducibility, some people find it a hinderance for debugging: https://github.com/rust-lang/rust/issues/85463.
 Hence the user should be given control on if they want the virtual or local path.
 
-An alternative to `--remap-path-scope` is to have individual `--remap-path-prefix`-like flags, one each for macro, debuginfo and diagnostics, requiring
-the full mapping to be given for each context. This is similar to what GCC and Clang does as described below, but we have added a third context
-for diagnostics. This technically enables for even finer grained control, allowing different paths in different
-contexts to be remapped differently. However it will cause the command line to be very verbose under most normal use cases.
+An alternative is to extend the syntax accepted by `--remap-path-prefix` or add a new option called `--remap-path-prefix-scoped` which allows
+scoping rules to be explicitly applied to each remapping. This can co-exist with `--remap-path-scope` so it will be discussed further in
+[Future possibilities](#future-possibilities) section.
 
 # Prior art
 [prior-art]: #prior-art
@@ -233,4 +232,13 @@ the other for only debuginfo: https://reproducible-builds.org/docs/build-path/. 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-N/A
+If it turns out that we want to enable finer grained scoping control on each individual remapping, we could use a `scopes:from=to` syntax.
+E.g. `debuginfo,diagnostics:/path/to/src=src` will remove all references to `/path/to/src` from compiler diagnostics and debug information, but
+they are retained panic messages. This syntax can be used with either a brand new `--remap-path-prefix-scoped` option, or we could extend the
+existing `--remap-path-prefix` option to take in this new syntax.
+
+If we were to extend the existing `--remap-path-prefix`, there may be an ambiguity to whether `:` means a separator between scope list and mapping,
+or is it a part of the path; if the first `:` supplied belongs to the path then it would have to be escaped. This coudl be technically breaking.
+
+In any case, future inclusion of this new syntax will not affect `--remap-path-scope` introduced in this RFC. Scopes specified in `--remap-path-scope`
+will be used as default for all mappings, and explicit scopes for an individual mapping will take precedence on that mapping.

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -90,7 +90,7 @@ should support finer grained control over paths in which contexts should be rema
 
 When the `--remap-path-prefix` option is passed to rustc, source path prefixes in all output will be affected by default.
 The `--remap-path-scope` argument can be used in conjunction with `--remap-path-prefix` to determine paths in which output context should be affected.
-This flag accepts a comma-separated list of values and may be specified multiple times. The valid scopes are:
+This flag accepts a comma-separated list of values and may be specified multiple times, in which case the scopes are aggregated together. The valid scopes are:
 
 - `macro` - apply remappings to the expansion of `std::file!()` macro. This is where paths in embedded panic messages come from
 - `diagnostics` - apply remappings to printed compiler diagnostics

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -147,8 +147,6 @@ This will not affect any hard-coded paths in the source code, such as in strings
 
 ## `trim-paths` implementation in Cargo
 
-We only need to change the behaviour for `Test` and `Build` compile modes. 
-
 If `trim-paths` is `none` (`false`), no extra flag is supplied to `rustc`.
 
 If `trim-paths` is anything else, then its value is supplied directly to `rustc`'s `--remap-path-scope` option, along with two `--remap-path-prefix` arguments:
@@ -241,7 +239,6 @@ the other for only debuginfo: https://reproducible-builds.org/docs/build-path/. 
   package roots to `[package name]-[version]`. A minor downside to this is not being able to `Ctrl+click` on paths to files the user is working
   on from panic messages.
 - Will these cover all potentially embedded paths? Have we missed anything?
-- Should we make this affect more `CompileMode`s, such as `Check`, where the emitted `rmeta` file will also contain absolute paths?
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -145,7 +145,7 @@ If `trim-paths` is `1` or `2` (`true`), then two `--remap-path-prefix` arguments
 
 A further `--remap-path-scope` is also supplied for options `1` and `2`:
 
-If `trim-path` is `1`, then it depends on the setting of `split-debuginfo` (whether the setting is explicitly supplied or from the default)
+If `trim-paths` is `1`, then it depends on the setting of `split-debuginfo` (whether the setting is explicitly supplied or from the default)
 - If `split-debuginfo` is `off`, then `--remap-path-scope=macro,debuginfo`.
 - If `split-debuginfo` is `packed` or `unpacked`, then `--remap-path-scope=macro,split-debuginfo-file`
 
@@ -249,7 +249,7 @@ they are retained panic messages. This syntax can be used with either a brand ne
 existing `--remap-path-prefix` option to take in this new syntax.
 
 If we were to extend the existing `--remap-path-prefix`, there may be an ambiguity to whether `:` means a separator between scope list and mapping,
-or is it a part of the path; if the first `:` supplied belongs to the path then it would have to be escaped. This coudl be technically breaking.
+or is it a part of the path; if the first `:` supplied belongs to the path then it would have to be escaped. This could be technically breaking.
 
 In any case, future inclusion of this new syntax will not affect `--remap-path-scope` introduced in this RFC. Scopes specified in `--remap-path-scope`
 will be used as default for all mappings, and explicit scopes for an individual mapping will take precedence on that mapping.

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -98,7 +98,7 @@ This flag accepts a comma-separated list of values and may be specified multiple
 - `split-debuginfo` - apply remappings to debug information only when they are written to split debug information files, but not in compiled executables or libraries 
 - `split-debuginfo-file` - apply remappings to the paths pointing to split debug information files. Does nothing when these files are not generated.
 - `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-file`. This ensures all paths in compiled executables or libraries are remapped, but not elsewhere.
-- `all` and `true` - an alias for all of the above, also equivalent to supplying `--remap-path-prefix` without this option.
+- `all` and `true` - an alias for all of the above, also equivalent to supplying only `--remap-path-prefix` without `--remap-path-scope`.
 
 Debug information are written to split files when the separate codegen option `-C split-debuginfo=packed` or `unpacked` (whether by default or explicitly set).
 
@@ -119,7 +119,7 @@ The default release profile setting (`object`) sanitises only the paths in emitt
   only if they will be embedded together with the binary (the default on platforms with ELF binaries, such as Linux and windows-gnu),
   but will not touch them if they are in separate files (the default on Windows MSVC and macOS). But the path to these separate files are sanitised.
 
-The following paths are sanitised, if they appear in a covered scope:
+If `trim-paths` is not `none` or `false`, then the following paths are sanitised if they appear in a selected scope:
 
 1. Path to the source files of the standard and core library (sysroot) will begin with `/rustc/[rustc commit hash]`.
    E.g. `/home/username/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs` -> 
@@ -128,7 +128,7 @@ The following paths are sanitised, if they appear in a covered scope:
 3. Path to packages outside of the working directory will be replaced with `[package name]-[version]`. E.g. `/home/username/deps/foo/src/lib.rs` -> `foo-0.1.0/src/lib.rs`
 
 When a path to the source files of the standard and core library is *not* in scope for sanitisation, the emitted path will depend on if `rust-src` component
-is present. If it is, then the real path pointing to a copy of the source files on your file system will be emitted; if it isn't, then they will
+is present. If it is, then the real path pointing to the copy of the source files on your file system will be emitted; if it isn't, then they will
 show up as `/rustc/[rustc commit hash]/library/...` (just like when it is selected for sanitisation). Paths to all other source files will not be affected.
 
 This will not affect any hard-coded paths in the source code, such as in strings.

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -254,3 +254,8 @@ or is it a part of the path; if the first `:` supplied belongs to the path then 
 
 In any case, future inclusion of this new syntax will not affect `--remap-path-scope` introduced in this RFC. Scopes specified in `--remap-path-scope`
 will be used as default for all mappings, and explicit scopes for an individual mapping will take precedence on that mapping.
+
+## Alias for scope options
+`--remap-path-scope` can be made to accept additional options that act as aliases for one or more of the existing options. For instance, `--remap-path-scope=debuginfo` can be made equivalent to `--remap-path-scope=split-debuginfo,unsplit-debuginfo`.
+
+Additionally, `none`, `object` and `all` can be made aliases of what Cargo's `trim-paths` option is supposed to provide, such that Cargo's `trim-paths` option can be directly used as the value of `--remap-path-scope`. This allows the user to write `object,split-debuginfo` in `trim-paths` to remap paths in binaries/executables and split debuginfo files, but not in diagnostics.

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -1,7 +1,7 @@
 - Feature Name: trim-paths
 - Start Date: 2021-05-24
 - RFC PR: [rust-lang/rfcs#3127](https://github.com/rust-lang/rfcs/pull/3127)
-- Rust Issue: N/A
+- Rust Issue: [rust-lang/rust#111540](https://github.com/rust-lang/rust/issues/111540)
 
 # Summary
 [summary]: #summary

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -94,7 +94,7 @@ This flag accepts a comma-separated list of values and may be specified multiple
 
 - `macro` - apply remappings to the expansion of `std::file!()` macro. This is where paths in embedded panic messages come from
 - `diagnostics` - apply remappings to printed compiler diagnostics
-- `unsplit-debuginfo` - apply to remappings to debug information only when they are written to compiled executables or libraries, but not when they are in split files
+- `unsplit-debuginfo` - apply remappings to debug information only when they are written to compiled executables or libraries, but not when they are in split debuginfo files
 - `split-debuginfo` - apply remappings to debug information only when they are written to split debug information files, but not in compiled executables or libraries 
 - `split-debuginfo-file` - apply remappings to the paths pointing to split debug information files. Does nothing when these files are not generated.
 - `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-file`. This ensures all paths in compiled executables or libraries are remapped, but not elsewhere.
@@ -104,7 +104,16 @@ Debug information are written to split files when the separate codegen option `-
 
 ## Cargo
 
-`trim-paths` is a profile setting which enables and controls the sanitisation of file paths in compilation outputs. It corresponds to the `--remap-path-scope` flag of rustc and accepts all valid scope, or combination of scopes that `--remap-path-scope` accepts, in addition to the `none` or `false` option which disables path sanitisation completely.
+`trim-paths` is a profile setting which enables and controls the sanitisation of file paths in compilation outputs. It corresponds to the `--remap-path-scope` flag of rustc and accepts all valid scope, or combination of scopes that `--remap-path-scope` accepts, in addition to the `none` or `false` option which disables path sanitisation completely. Possible values are:
+
+- `none` and `false` - disable path sanitisation
+- `macro` - sanitise paths in the expansion of `std::file!()` macro. This is where paths in embedded panic messages come from
+- `diagnostics` - sanitise paths in printed compiler diagnostics
+- `unsplit-debuginfo` - sanitise paths in debug information in compiled executables or libraries. Does nothing if debug information are in split files
+- `split-debuginfo` - sanitise paths in debug information in split debuginfo files. Does nothing if debug information are in compiled executables or libraries 
+- `split-debuginfo-file` - sanitise paths pointing to split debug information files. Does nothing if these files are not generated.
+- `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-file`. This ensures all paths in compiled executables or libraries are sanitised, but not elsewhere.
+- `all` and `true` - an alias for all of the above
 
 It is defaulted to `none` for debug profiles, and `object` for release profiles. You can manually override it by specifying this option in `Cargo.toml`:
 ```toml

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -94,7 +94,7 @@ This flag accepts a comma-separated list of values and may be specified multiple
 
 - `macro` - apply remappings to the expansion of `std::file!()` macro. This is where paths in embedded panic messages come from
 - `debuginfo` - apply remappings to debug information, wherever they may be written to
-- `split-debuginfo-path` - when `split-debuginfo=packed` or `unpacked`, apply remappings to the paths pointing to these split debug information files
+- `split-debuginfo-file` - when `split-debuginfo=packed` or `unpacked`, apply remappings to the paths pointing to these split debug information files
 - `diagnostics` - apply remappings to printed compiler diagnostics
 
 ## Cargo
@@ -147,11 +147,12 @@ A further `--remap-path-scope` is also supplied for options `1` and `2`:
 
 If `trim-path` is `1`, then it depends on the setting of `split-debuginfo` (whether the setting is explicitly supplied or from the default)
 - If `split-debuginfo` is `off`, then `--remap-path-scope=macro,debuginfo`.
-- If `split-debuginfo` is `packed` or `unpacked`, then `--remap-path-scope=macro,split-debuginfo-path`
+- If `split-debuginfo` is `packed` or `unpacked`, then `--remap-path-scope=macro,split-debuginfo-file`
+
 This is because we always want to remap panic messages as they will always be embedded in executable/library. We need to sanitise debug information
 if they are embedded, but don't need to touch them if they are split. However in case they are split we need to sanitise the paths to these split files 
 
-If `trim-path` is `2` (`true`), all paths will be affected, equivalent to `--remap-path-scope=macro,debuginfo,diagnostics,split-debuginfo-path`
+If `trim-path` is `2` (`true`), all paths will be affected, equivalent to `--remap-path-scope=macro,debuginfo,diagnostics,split-debuginfo-file`
 
 
 Some interactions with compiler-intrinsic macros need to be considered:
@@ -180,7 +181,7 @@ local path to be remapped in the usual way.
 
 When debug information are not embedded in the binary (i.e. `split-debuginfo` is not `off`), absolute paths to various files containing debug
 information are embedded into the binary instead. Such as the absolute path to `.pdb` file (MSVC, `packed`), `.dwo` files (ELF, `unpacked`), 
-and `.o` files (ELF, `packed`). This can be undesirable. As such, `split-debuginfo-path` is made specifically for these embedded paths.
+and `.o` files (ELF, `packed`). This can be undesirable. As such, `split-debuginfo-file` is made specifically for these embedded paths.
 
 On macOS and ELF platforms, these paths are introduced by `rustc` during codegen. With MSVC, however, the path to `.pdb` fil is generated and
 embedded into the binary by the linker `link.exe`. The linker has a `/PDBALTPATH` option allows us to change the embedded path written to the

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -288,6 +288,22 @@ An alternative is to extend the syntax accepted by `--remap-path-prefix` or add 
 scoping rules to be explicitly applied to each remapping. This can co-exist with `--remap-path-scope` so it will be discussed further in
 [Future possibilities](#future-possibilities) section.
 
+## Rationale for the `--remap-path-scope` options
+There are quite a few options available for `--remap-path-scope`. Not all of them are expected to have meaningful use-cases in their own right.
+Some are only added for completeness, that is, the behaviour of `--remap-path-prefix=all` (or the original `--remap-path-prefix` on its own) is
+the same as specifying all individual scopes. In the future, we expect some of the scopes to be removed as independent options, while preserving
+the behaviour of `--remap-path-prefix=all` and the stable `--remap-path-prefix`, which is "Remap source names in all output".
+
+- `macro` is primarily meant for panic messages embedded in binaries.
+- `diagnostics` is unlikely to be used on its own as it only affects console outputs, but is required for completeness. See [#87745](https://github.com/rust-lang/rust/issues/87745).
+- `unsplit-debuginfo` is used to sanitise debuginfo embedded in binaries.
+- `split-debuginfo` is used to sanitise debuginfo separate from binaries. This is may be used when debuginfo files are separate and the author
+still wants to distribute them.
+- `split-debuginfo-path` is used to sanitise the path embedded in binaries pointing to separate debuginfo files. This is likely needed in all
+contexts where `unsplit-debuginfo` is used, but it's technically a separate piece of information inserted by the linker, not rustc.
+- `object` is a shorthand for the most common use-case: sanitise everything in binaries, but nowhere else. 
+- `all` and `true` preserves the documented behaviour of `--remap-path-prefix`.
+
 # Prior art
 [prior-art]: #prior-art
 

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -104,24 +104,21 @@ Debug information are written to split files when the separate codegen option `-
 
 ## Cargo
 
-`trim-paths` is a profile setting which enables and controls the sanitisation of file paths in compilation outputs. It corresponds to the `--remap-path-scope` flag of rustc and accepts all valid scope, or combination of scopes that `--remap-path-scope` accepts, in addition to the `none` or `false` option which disables path sanitisation completely. Possible values are:
+`trim-paths` is a profile setting which enables and controls the sanitisation of file paths in build outputs. It is a simplified version of rustc's `--remap-path-scope`. It takes a comma separated list of the following values:
 
 - `none` and `false` - disable path sanitisation
 - `macro` - sanitise paths in the expansion of `std::file!()` macro. This is where paths in embedded panic messages come from
 - `diagnostics` - sanitise paths in printed compiler diagnostics
-- `unsplit-debuginfo` - sanitise paths in debug information in compiled executables or libraries. Does nothing if debug information are in split files
-- `split-debuginfo` - sanitise paths in debug information in split debuginfo files. Does nothing if debug information are in compiled executables or libraries 
-- `split-debuginfo-path` - sanitise paths pointing to split debug information files. Does nothing if these files are not generated.
-- `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-path`. This ensures all paths in compiled executables or libraries are sanitised, but not elsewhere.
-- `all` and `true` - an alias for all of the above
+- `object` - sanitise paths in compiled executables or libraries
+- `all` and `true` - sanitise paths in all possible locations
 
 It is defaulted to `none` for debug profiles, and `object` for release profiles. You can manually override it by specifying this option in `Cargo.toml`:
 ```toml
 [profile.dev]
-trim-paths = all
+trim-paths = "all"
 
 [profile.release]
-trim-paths = none
+trim-paths = "none"
 ```
 
 The default release profile setting (`object`) sanitises only the paths in emitted executable or library files. It always affects paths from macros such as panic messages, and in debug information

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -14,14 +14,14 @@ the separate debug symbols file (depending on `split-debuginfo` settings).
 it will retain the paths in separate debug symbols file, if one exists, to help debuggers and profilers locate the source files.
 
 To facilitate this, a new flag named `--remap-scope` should be added to `rustc` controlling the behaviour of `--remap-path-prefix`, allowing us to fine
-tune the scope of remapping, speicifying paths under which context (in marco expansion, in debuginfo or in diagnostics)
+tune the scope of remapping, speicifying paths under which context (in macro expansion, in debuginfo or in diagnostics)
 should or shouldn't be remapped. 
 
 # Motivation
 [motivation]: #motivation
 
 ## Sanitising local paths that are currently embedded
-Currently, executables and libraies built by Cargo have a lot of embedded absolute paths. They most frequently appear in debug information and
+Currently, executables and libraries built by Cargo have a lot of embedded absolute paths. They most frequently appear in debug information and
 panic messages (pointing to the panic location source file). As an example, consider the following package:
 
 `Cargo.toml`:
@@ -103,7 +103,7 @@ This flag accepts a comma-separated list of values and may be specified multiple
 - `1`: sanitise only the paths in emitted executable or library binaries. It always affects paths from macros such as panic messages, and in debug information
   only if they will be embedded together with the binary (the default on platforms with ELF binaries, such as Linux and windows-gnu),
   but will not touch them if they are in a separate symbols file (the default on Windows MSVC and macOS)
-- `2` or `ture`: sanitise paths in all compilation outputs, including compiled executable/library, separate symbols file (if one exists), and compiler diagnostics.
+- `2` or `true`: sanitise paths in all compilation outputs, including compiled executable/library, separate symbols file (if one exists), and compiler diagnostics.
 
 The default release profile uses option `1`. You can also manually override it by specifying this option in `Cargo.toml`:
 ```toml
@@ -186,7 +186,7 @@ The user will not be able to `Ctrl+click` on any paths provided in panic message
 there shouldn't be any confusion as the combination of pacakge name and version can be used to pinpoint the file.
 
 As mentioned above, `trim-paths` may break code that relies on `std::file!()` to evaluate to an accessible path to the file. Hence enabling
-it by default for release builds may be a technically breaking change. Occurances of such use should be extremely rare but should be investigated
+it by default for release builds may be a technically breaking change. Occurrences of such use should be extremely rare but should be investigated
 via a Crater run. In case this breakage is unacceptable, `trim-paths` can be made an opt-in option rather than default in any build profile.
 
 # Rationale and alternatives
@@ -200,7 +200,7 @@ Path to sysroot crates are specially handled by `rustc`. Due to this, the behavi
 Although good for privacy and reproducibility, some people find it a hinderance for debugging: https://github.com/rust-lang/rust/issues/85463.
 Hence the user should be given control on if they want the virtual or local path.
 
-An alternative to `--remap-scope` is to have individual `--remap-path-prefxi`-like flags, one each for macro, debuginfo and diagnostics, requiring
+An alternative to `--remap-scope` is to have individual `--remap-path-prefix`-like flags, one each for macro, debuginfo and diagnostics, requiring
 the full mapping to be given for each context. This is similar to what GCC and Clang does as described below, but we have added a third context
 for diagnostics. This technically enables for even finer grained control, allowing different paths in different
 contexts to be remapped differently. However it will cause the command line to be very verbose under most normal use cases.

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -133,8 +133,12 @@ If `trim-paths` is not `none` or `false`, then the following paths are sanitised
 2. Path to the working directory will be stripped. E.g. `/home/username/crate/src/lib.rs` -> `src/lib.rs`.
 3. Path to packages outside of the working directory will be replaced with `[package name]-[version]`. E.g. `/home/username/deps/foo/src/lib.rs` -> `foo-0.1.0/src/lib.rs`
 
+Paths requiring sanitisation can be retrieved by build scripts at their execution time from the environment variable `CARGO_TRIM_PATHS`, in comma-separated format.
+If a build script does anything that may result in these, or any other absolute paths, to be included in compilation outputs, such as by invoking a C compiler, then the build script should make sure they are trimmed.
+Cargo's mapping scheme (what Cargo will map these paths to) is not provided in `CARGO_TRIM_PATHS`, and build scripts are free to decide as long as they are reproducible and privacy preserving.
+
 When a path to the source files of the standard and core library is *not* in scope for sanitisation, the emitted path will depend on if `rust-src` component
-is present. If it is, then the real path pointing to the copy of the source files on your file system will be emitted; if it isn't, then they will
+is present. If it is, then some paths will point to the copy of the source files on your file system; if it isn't, then they will
 show up as `/rustc/[rustc commit hash]/library/...` (just like when it is selected for sanitisation). Paths to all other source files will not be affected.
 
 This will not affect any hard-coded paths in the source code, such as in strings.
@@ -150,6 +154,9 @@ If `trim-paths` is anything else, then its value is supplied directly to `rustc`
 - From the path of the local sysroot to `/rustc/[commit hash]`. 
 - If the compilation unit is under the working directory, from the the working directory absolute path to empty string.
   If it's outside the working directory, from the absolute path of the package root to `[package name]-[package version]`.
+
+If a package in the dependency tree has build scripts, then the absolute path to the package root is supplied by
+the environment variable `CARGO_TRIM_PATHS` when executing build scripts.
 
 The default value of `trim-paths` is `object` for release profile. As a result, panic messages (which are always embedded) are sanitised. If debug information is embedded, then they are sanitised; if they are split then they are kept untouched, but the paths to these split files are sanitised.
 

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -96,8 +96,8 @@ This flag accepts a comma-separated list of values and may be specified multiple
 - `diagnostics` - apply remappings to printed compiler diagnostics
 - `unsplit-debuginfo` - apply remappings to debug information only when they are written to compiled executables or libraries, but not when they are in split debuginfo files
 - `split-debuginfo` - apply remappings to debug information only when they are written to split debug information files, but not in compiled executables or libraries 
-- `split-debuginfo-file` - apply remappings to the paths pointing to split debug information files. Does nothing when these files are not generated.
-- `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-file`. This ensures all paths in compiled executables or libraries are remapped, but not elsewhere.
+- `split-debuginfo-path` - apply remappings to the paths pointing to split debug information files. Does nothing when these files are not generated.
+- `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-path`. This ensures all paths in compiled executables or libraries are remapped, but not elsewhere.
 - `all` and `true` - an alias for all of the above, also equivalent to supplying only `--remap-path-prefix` without `--remap-path-scope`.
 
 Debug information are written to split files when the separate codegen option `-C split-debuginfo=packed` or `unpacked` (whether by default or explicitly set).
@@ -111,8 +111,8 @@ Debug information are written to split files when the separate codegen option `-
 - `diagnostics` - sanitise paths in printed compiler diagnostics
 - `unsplit-debuginfo` - sanitise paths in debug information in compiled executables or libraries. Does nothing if debug information are in split files
 - `split-debuginfo` - sanitise paths in debug information in split debuginfo files. Does nothing if debug information are in compiled executables or libraries 
-- `split-debuginfo-file` - sanitise paths pointing to split debug information files. Does nothing if these files are not generated.
-- `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-file`. This ensures all paths in compiled executables or libraries are sanitised, but not elsewhere.
+- `split-debuginfo-path` - sanitise paths pointing to split debug information files. Does nothing if these files are not generated.
+- `object` - an alias for `macro,unsplit-debuginfo,split-debuginfo-path`. This ensures all paths in compiled executables or libraries are sanitised, but not elsewhere.
 - `all` and `true` - an alias for all of the above
 
 It is defaulted to `none` for debug profiles, and `object` for release profiles. You can manually override it by specifying this option in `Cargo.toml`:
@@ -184,9 +184,9 @@ local path to be remapped in the usual way.
 
 When debug information are not embedded in the binary (i.e. `split-debuginfo` is not `off`), absolute paths to various files containing debug
 information are embedded into the binary instead. Such as the absolute path to `.pdb` file (MSVC, `packed`), `.dwo` files (ELF, `unpacked`), 
-and `.o` files (ELF, `packed`). This can be undesirable. As such, `split-debuginfo-file` is made specifically for these embedded paths.
+and `.o` files (ELF, `packed`). This can be undesirable. As such, `split-debuginfo-path` is made specifically for these embedded paths.
 
-On macOS and ELF platforms, these paths are introduced by `rustc` during codegen. With MSVC, however, the path to `.pdb` fil is generated and
+On macOS and ELF platforms, these paths are introduced by `rustc` during codegen. With MSVC, however, the path to `.pdb` file is generated and
 embedded into the binary by the linker `link.exe`. The linker has a `/PDBALTPATH` option allows us to change the embedded path written to the
 binary, which could be supplied by `rustc`
 

--- a/text/3127-trim-paths.md
+++ b/text/3127-trim-paths.md
@@ -246,7 +246,12 @@ the other for only debuginfo: https://reproducible-builds.org/docs/build-path/. 
 ## Per-mapping scope control
 If it turns out that we want to enable finer grained scoping control on each individual remapping, we could use a `scopes:from=to` syntax.
 E.g. `split-debuginfo,unsplit-debuginfo,diagnostics:/path/to/src=src` will remove all references to `/path/to/src` from compiler diagnostics and debug information, but
-they are retained in panic messages. This syntax can be used with either a brand new `--remap-path-prefix-scoped` option, or we could extend the
+they are retained in panic messages.
+
+How exactly this new syntax will look like is, of course, up to further discussion. Using comma as a separator for scopes may look ambiguous as `macro,diagnostics:/path/from=to` could be interpreted as `macro`
+and `diagnostics:/path/from=to`.
+
+This syntax can be used with either a brand new `--remap-path-prefix-scoped` option, or we could extend the
 existing `--remap-path-prefix` option to take in this new syntax.
 
 If we were to extend the existing `--remap-path-prefix`, there may be an ambiguity to whether `:` means a separator between scope list and mapping,


### PR DESCRIPTION
IRLO pre-RFC thread: https://internals.rust-lang.org/t/pre-rfc-cargo-profile-setting-to-sanitise-host-dependent-absolute-paths-enabled-by-default-for-release-builds/14504

Relevant GitHub issue and discussions: https://github.com/rust-lang/rust/issues/40552

[Rendered](https://github.com/cbeuw/rfcs/blob/trim-path/text/3127-trim-paths.md)