### PR TITLE
RFC: let-else statements

### DIFF
--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -220,7 +220,21 @@ is assigned to the surrounding scope rather than the block's scope.
 # Reference-level explanations
 [reference-level-explanation]: #reference-level-explanation
 
-let-else is syntactical sugar for either `if let { assignment } else {}` or `match`, where the non-matched case diverges.
+let-else is syntactical sugar for `match` where the non-matched case diverges.
+```rust
+let pattern = expr else {
+    /* diverging expr */
+};
+```
+desugars to
+```rust
+let (each, binding) = match expr { 
+    pattern => (each, binding),
+    _ => { 
+        /* diverging expr */
+    }
+};
+```
 
 Any expression may be put into the expression position except an `if {} else {}` as explain below in [drawbacks][].
 While `if {} else {}` is technically feasible this RFC proposes it be disallowed for programmer clarity to avoid an `... else {} else {}` situation.

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -222,7 +222,7 @@ Any refutable pattern that could be put into if-let's pattern position can be pu
 
 If the pattern is irrefutable, rustc will emit the `irrefutable_let_patterns` warning lint, as it does with an irrefutable pattern in an `if let`.
 
-The `else` block must _diverge_, meaning the `else` block must return the [never type (`!`)][never type]).
+The `else` block must _diverge_, meaning the `else` block must return the [never type (`!`)][never-type]).
 This could be a keyword which diverges (returns `!`), or a panic.
 
 If the pattern does not match, the expression is not consumed, and so any existing variables from the surrounding scope are

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -1,6 +1,6 @@
 - Feature Name: `let-else`
 - Start Date: 2021-05-31
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3137](https://github.com/rust-lang/rfcs/pull/3137)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -248,6 +248,12 @@ This could be a keyword which diverges (returns `!`), or a panic.
 If the pattern does not match, the expression is not consumed, and so any existing variables from the surrounding scope are
 accessible as they would normally be.
 
+For patterns which match multiple variants, such as through the `|` (or) syntax, all variants must produce the same bindings (ignoring additional bindings in uneven patterns),
+and those bindings must all be names the same. Valid example:
+```rust
+let Some(x) | MyEnum::VarientA(_, _, x) | MyEnum::VarientB { x, .. } = a else { return; };
+```
+
 let-else does not combine with the `let` from if-let, as if-let is not actually a _let statement_.
 If you ever try to write something like `if let p = e else { } { }`, instead use a regular if-else by writing `if let p = e { } else { }`.
 

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -293,9 +293,9 @@ such functions do not exist automatically on custom enum types and require non-o
 to `Option`/`Result`-style functions at all (especially for enums where the "success" variant is contextual and there are many variants).
 These functions will also not work for code which wishes to return something other than `Option` or `Result`.
 
-### Naming of `else` (`let ... unless { ... }`)
+### Naming of `else` (`let ... otherwise { ... }`)
 
-One often proposed alternative is to use a different keyword than `else`.
+One often proposed alternative is to use a different keyword than `else`, such as `otherwise`.
 This is supposed to help disambiguate let-else statements from other code with blocks and `else`.
 
 This RFC avoids this as it would mean loosing symmetry with if-else & if-let-else, 

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -225,7 +225,7 @@ Any refutable pattern that could be put into if-let's pattern position can be pu
 If the pattern is irrefutable, rustc will emit the `irrefutable_let_patterns` warning lint, as it does with an irrefutable pattern in an `if let`.
 
 The `else` block must _diverge_, meaning the `else` block must return the [never type (`!`)][never-type]).
-This could be a keyword which diverges (returns `!`), or a panic.
+This could be a keyword which diverges (returns `!`), such as `return`, `break`, `continue` or `loop { ... }`, a diverging function like `std::process::abort` or `std::process::exit`, or a panic.
 
 If the pattern does not match, the expression is not consumed, and so any existing variables from the surrounding scope are
 accessible as they would normally be.
@@ -315,6 +315,8 @@ While this feature can partly be covered by functions such `or_or`/`ok_or_else` 
 such functions do not exist automatically on custom enum types and require non-obvious and non-trivial implementation, and may not be map-able
 to `Option`/`Result`-style functions at all (especially for enums where the "success" variant is contextual and there are many variants).
 These functions will also not work for code which wishes to return something other than `Option` or `Result`.
+Moreover, this does not cover diverging blocks that do something other than return with an error or target an enclosing `try` block,
+for example if the diverging expression is `continue e` or `break 'outer_loop e`.
 
 ### Naming of `else` (`let ... otherwise { ... }`)
 
@@ -445,7 +447,7 @@ let Enum::Var1(x) = a || b || { return anyhow!("Bad x"); } && let Some(z) = x ||
 // Complex. Both x and z are now in scope.
 ```
 
-This is not a simple construct, and could be quite confusing to newcomers
+This is not a simple construct, and could be quite confusing to newcomers.
 
 That said, such a thing is not perfectly obvious to write today, and might be just as confusing to read:
 ```rust

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -248,6 +248,9 @@ This could be a keyword which diverges (returns `!`), or a panic.
 If the pattern does not match, the expression is not consumed, and so any existing variables from the surrounding scope are
 accessible as they would normally be.
 
+let-else does not combine with the `let` from if-let, as if-let is not actually a _let statement_.
+If you ever try to write something like `if let p = e else { } { }`, instead use a regular if-else by writing `if let p = e { } else { }`.
+
 ## Desugaring example
 
 ```rust
@@ -582,13 +585,18 @@ let Ok(a) = x else match {
 
 ## let-else within if-let
 
-Conceivable. This RFC makes no judgement, even if the author does.
+This RFC naturally brings with it the question of if let-else should be allowable in the `let` position within if-let,
+creating a potentially confusing and poorly reading construct:
 
 ```rust
 if let Some(x) = y else { return; } {
     // I guess this RFC had it coming for it
 }
 ```
+
+However, since the `let` within if-let is part of the if-let expression and is not an actual `let` statement, this would have to be
+explicitly allowed. This RFC does not propose we allow this. Rather, rust should avoid ever allowing this,
+because it is confusing to read syntactically, and it is functionally similar to `if let p = e { } else { }` but with more drawbacks.
 
 [`const`]: https://doc.rust-lang.org/reference/items/constant-items.html
 [`static`]: https://doc.rust-lang.org/reference/items/static-items.html

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -293,7 +293,7 @@ let b = false;
 
 // The RFC proposes boolean matches like this be either:
 // - Made into a compile error, or
-// - Made to be parsed like if-let-chains: `(true = a) && b`
+// - Made to be parsed internally like if-let-chains: `(let true = a) && b else { ... };`
 let true = a && b else {
     return;
 };
@@ -442,7 +442,7 @@ let b = false;
 
 // The RFC proposes boolean matches like this be either:
 // - Made into a compile error, or
-// - Made to be parsed like if-let-chains: `(true = a) && b`
+// - Made to be parsed internally like if-let-chains: `(let true = a) && b else { ... };`
 let true = a && b else {
     return;
 };

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -10,7 +10,7 @@ Introduce a new `let PATTERN = EXPRESSION_WITHOUT_BLOCK else DIVERGING_BLOCK;` c
 **let-else statement**), the counterpart of if-let expressions.
 
 If the pattern match from the assigned expression succeeds, its bindings are introduced *into the
-surrounding scope*. If it does not succeed, it must diverge (e.g. return or break).
+surrounding scope*. If it does not succeed, it must diverge (return `!`, e.g. return or break).
 Technically speaking, let-else statements are refutable `let` statements.
 
 This RFC is a modernization of a [2015 RFC (pull request 1303)][old-rfc] for an almost identical feature.
@@ -135,28 +135,10 @@ impl ActionView {
 }
 ```
 
-## Versus `match`
+## A practical refactor with `match`
 
 It is possible to use `match` expressions to emulate this today, but at a
-significant cost in length and readability. For example, this real-world code
-from Servo:
-
-```rust
-let subpage_layer_info = match layer_properties.subpage_layer_info {
-    Some(ref subpage_layer_info) => *subpage_layer_info,
-    None => return,
-};
-```
-
-is equivalent to this much simpler let-else statement:
-
-```rust
-let Some(ref subpage_layer_info) = layer_properties.subpage_layer_info else {
-    return
-}
-```
-
-## A practical refactor
+significant cost in length and readability.
 
 A refactor on an http server codebase in part written by the author to move some if-let conditionals to early-return `match` expressions
 yielded 4 changes of large if-let blocks over `Option`s to use `ok_or_else` + `?`, and 5 changed to an early-return `match`.
@@ -179,7 +161,7 @@ let features = match geojson {
 };
 ```
 
-However, with if-let this could be very succinct:
+However, with if-let this could be more succinct & clear:
 
 ```rust
 let GeoJson::FeatureCollection(features) = geojson else {

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -209,15 +209,13 @@ let (each, binding) = match expr {
 ```
 
 Most expressions may be put into the expression position with two restrictions:
-1. May not include a block outside of parenthesis.
-    - Must be an [`ExpressionWithoutBlock`][expressions].
-    - [`GroupedExpression`][grouped-expr]-s ending with a `}` are additionally not allowed and must be put in parenthesis.
+1. May not end with a `}` (before macro expansion). (Such things must be put in parenthesis.)
 2. May not be just a lazy boolean expression (`&&` or `||`). (Must not be a [`LazyBooleanExpression`][lazy-boolean-operators].)
 
 While allowing e.g. `if {} else {}` directly in the expression position is technically feasible this RFC proposes it be
 disallowed for programmer clarity so as to avoid `... else {} else {}` situations as discussed in the [drawbacks][] section.
 Boolean matches are not useful with let-else and so lazy boolean expressions are disallowed for reasons noted in [future-possibilities][].
-These types of expressions can still be used when combined in a less ambiguous manner with parenthesis, thus forming a [`GroupedExpression`][grouped-expr],
+These types of expressions can still be used when combined in a less ambiguous manner with parenthesis,
 which is allowed under the two expression restrictions.
 
 Any refutable pattern that could be put into if-let's pattern position can be put into let-else's pattern position.
@@ -278,7 +276,7 @@ because the compiler won't interpret it as `let PATTERN = (if y { a }) else { b 
 This can be overcome by making a raw if-else in the expression position a compile error and instead requiring that parentheses are inserted to disambiguate:
 `let PATTERN = (if { a } else { b }) else { c };`.
 
-Rust already provides us with such a restriction, and so the expression can be restricted to be a [`ExpressionWithoutBlock`][expressions].
+This restriction can be made by checking if the expression ends in `}` after parsing but _before_ macro expansion.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -304,7 +302,7 @@ let true = a && b else {
 };
 ```
 
-The expression can be any [`ExpressionWithoutBlock`][expressions], in order to prevent `else {} else {}` confusion, as noted in [drawbacks][#drawbacks].
+The expression must not end with a `}`, in order to prevent `else {} else {}` (and similar) confusion, as noted in [drawbacks][#drawbacks].
 
 The `else` must be followed by a block, as in `if {} else {}`. This else block must be diverging as the outer
 context cannot be guaranteed to continue soundly without assignment, and no alternate assignment syntax is provided.
@@ -643,7 +641,6 @@ because it is confusing to read syntactically, and it is functionally similar to
 [`const`]: https://doc.rust-lang.org/reference/items/constant-items.html
 [`static`]: https://doc.rust-lang.org/reference/items/static-items.html
 [expressions]: https://doc.rust-lang.org/reference/expressions.html#expressions
-[grouped-expr]: https://doc.rust-lang.org/reference/expressions/grouped-expr.html
 [guard-crate]: https://crates.io/crates/guard
 [guard-repo]: https://github.com/durka/guard
 [if-let]: https://rust-lang.github.io/rfcs/0160-if-let.html

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -217,6 +217,8 @@ disallowed for programmer clarity so as to avoid `... else {} else {}` situation
 Boolean matches are not useful with let-else and so lazy boolean expressions are disallowed for reasons noted in [future-possibilities][].
 These types of expressions can still be used when combined in a less ambiguous manner with parenthesis,
 which is allowed under the two expression restrictions.
+Invisible groupings from macros expansions are also allowed, however macro expansion representations to humans should include parenthesis
+around the expression output in this position if it ends in a `}` where possible (or otherwise show the invisible grouping).
 
 Any refutable pattern that could be put into if-let's pattern position can be put into let-else's pattern position.
 

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -251,7 +251,7 @@ accessible as they would normally be.
 For patterns which match multiple variants, such as through the `|` (or) syntax, all variants must produce the same bindings (ignoring additional bindings in uneven patterns),
 and those bindings must all be names the same. Valid example:
 ```rust
-let Some(x) | MyEnum::VarientA(_, _, x) | MyEnum::VarientB { x, .. } = a else { return; };
+let Some(x) | MyEnum::VariantA(_, _, x) | MyEnum::VariantB { x, .. } = a else { return; };
 ```
 
 let-else does not combine with the `let` from if-let, as if-let is not actually a _let statement_.

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -600,6 +600,15 @@ let Ok(a) = x else match {
 }
 ```
 
+## `||` in pattern-matching
+
+A variant of `||` in pattern-matching could still be a non-conflicting addition if it was allowed to be refutable, ending up with constructs similar to the
+above mentioned let-else-else-chains. In this way it would add to let-else rather than replace it.
+
+```rust
+let Some(x) = a || b else { return; };
+```
+
 ## let-else within if-let
 
 This RFC naturally brings with it the question of if let-else should be allowable in the `let` position within if-let,

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -456,18 +456,14 @@ let Enum::Var1(x) = a || b || { return anyhow!("Bad x"); } && let Some(z) = x ||
 
 This is not a simple construct, and could be quite confusing to newcomers
 
-That being said, such a thing would be very non-trivial to write today, and might be just as confusing to read:
+That being said, such a thing is not perfectly obvious to write today, and might be just as confusing to read:
 ```rust
-let x = match a {
-    Enum::Var1(x) => x,
-    _ => {
-        match b {
-            Enum::Var1(x) => x,
-            _ => { 
-                return anyhow!("Bad x"); 
-            },
-        }
-    }
+let x = if let Enum::Var1(v) = a {
+    v
+} else if let Enum::Var1(v) = b {
+    v
+} else {
+    anyhow!("Bad x")
 };
 let z = match x {
     Some(z) => z,

--- a/text/0000-let-else.md
+++ b/text/0000-let-else.md
@@ -293,9 +293,18 @@ such functions do not exist automatically on custom enum types and require non-o
 to `Option`/`Result`-style functions at all (especially for enums where the "success" variant is contextual and there are many variants).
 These functions will also not work for code which wishes to return something other than `Option` or `Result`.
 
+### Naming of `else` (`let ... unless { ... }`)
+
+One often proposed alternative is to use a different keyword than `else`.
+This is supposed to help disambiguate let-else statements from other code with blocks and `else`.
+
+This RFC avoids this as it would mean loosing symmetry with if-else & if-let-else, 
+and would require adding a new keyword.
+Adding a new keyword could mean more to teach and could promote even more special casing around let-else's semantics.
+
 ### `unless let ... {}` / `try let ... {}`
 
-An often proposed alternative is to add an extra keyword to the beginning of the let-else statement, to denote that it is different than a regular `let` statement.
+Another often proposed alternative is to add an extra keyword to the beginning of the let-else statement, to denote that it is different than a regular `let` statement.
 
 One possible benefit of adding a keyword is that it could make a possible future extension for similarity to the (yet unimplemented) [if-let-chains][] feature more straightforward.
 However, as mentioned in the [future-possibilities][] section, this is likely not necessary.


### PR DESCRIPTION
Introduce a new `let PATTERN: TYPE = EXPRESSION else DIVERGING_BLOCK;` construct (informally called a
**let-else statement**), the counterpart of if-let expressions.

If the pattern match from the assigned expression succeeds, its bindings are introduced *into the
surrounding scope*. If it does not succeed, it must diverge (return `!`, e.g. return or break).
Technically speaking, let-else statements are refutable `let` statements.
The expression has some restrictions, notably it may not be an `ExpressionWithBlock` or `LazyBooleanExpression`.

This RFC is a modernization of a [2015 RFC (pull request 1303)][old-rfc] for an almost identical feature.

[**Rendered**](https://github.com/Fishrock123/rfcs/blob/let-else/text/0000-let-else.md)

[old-rfc]: https://github.com/rust-lang/rfcs/pull/1303

-----

Thanks to all the folks on Zulip who were willing to discuss this proposal once again and helped me draft this RFC.
In particular: Josh Triplett, scottmcm, Mario Carneiro, Frank Steffahn, Dirkjan Ochtman, and bstrie.

Zulip topic: https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/.60let.20pattern.20.3D.20expr.20else.20.7B.20.2E.2E.2E.20.7D.60.20statements