### PR TITLE
Cargo feature migrations

### DIFF
--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -1,0 +1,95 @@
+- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the language and project as a whole in a holistic
+way. Try to use this section as a tool to more fully consider all possible
+interactions with the project and language in your proposal.
+Also consider how this all fits into the roadmap for the project
+and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -223,9 +223,18 @@ This has a lot of nice properties.
 First of all, we don't even need any notion of "default features" anymore for compatability's sake.
 Since there was at least one feature from the get-go, we simply prevent breaking changes by not removing old features.
 When we want to make existing functionality more optional, we just split existing features up:
-the old "everything else" feature gets a dependency on the new optional feature, and the new "everything else" feature, which is correspondingly narrower.
 
-> Example, `everything-else-0` in the old version becomes `std`, `everything-else-1`, and `everything-else-0 = ["std", "everything-else-1"]`.
+> Example: The old "everything else" feature gets a dependency on the new optional feature, and the new "everything else" feature, which is correspondingly narrower:
+>
+> - In code: `#![cfg(everything-else-0)]` attributes become either `#![cfg(std)]` or else `#![cfg(everything-else-1)]`
+>
+> - In `Cargo.toml`:
+>   ```toml
+>   [features]
+>   std = []
+>   everything-else-1 = []
+>   everything-else-0 = ["std", "everything-else-1"]
+>   ```
 
 Importantly, there is no negative reasoning, or opting out, which avoids all the pitfalls of the previous solution.
 

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -296,20 +296,17 @@ It's of a different, but related, sort than mentioned here, but https://arxiv.or
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would
-be and how it would affect the language and project as a whole in a holistic
-way. Try to use this section as a tool to more fully consider all possible
-interactions with the project and language in your proposal.
-Also consider how this all fits into the roadmap for the project
-and of the relevant sub-team.
+In https://github.com/rust-lang/rfcs/pull/3143#issuecomment-868829430 I gave another use-case for `"and(...)"` TOML keys that represent conjunctions of features.
 
-This is also a good place to "dump ideas", if they are out of scope for the
-RFC you are writing but otherwise related.
+Moreover, I think the mathematical framework based around order theory I used when designing this feature will be useful when considering the design of other parts of Cargo and it's interaction with Rust.
+Longstanding unimplemented features like:
 
-If you have tried and cannot think of any future possibilities,
-you may simply state that you cannot think of anything.
+- Compatibility testing (https://github.com/rust-lang/cargo/issues/5500)
 
-Note that having something written down in the future-possibilities section
-is not a reason to accept the current or a future RFC; such notes should be
-in the section on motivation or rationale in this or subsequent RFCs.
-The section merely provides additional information.
+- The portability lint (https://github.com/rust-lang/rfcs/blob/master/text/1868-portability-lint.md)
+
+- Public and private dependencies (https://github.com/rust-lang/rfcs/blob/master/text/1977-public-private-dependencies.md)
+
+are all challenging problems that are amendable to this sort of analysis.
+I am less concerned with whatever "bells and whistles" Cargo has, than that there is some sort of holistic approach for both deciding on a fundamental level what we want from Cargo, and what core functionality should exist in service of that goal.
+I think this sort of theory can help, and this is a far less costly and more urgent problem than those other three with which to evaluate it.

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -316,6 +316,8 @@ The single, canonical way doesn't need to be some notion of "do nothing".
 
 Database migrations are the obvious prior art.
 
+## The Math
+
 Otherwise, I will reuse this section to talk about the underlying math.
 It is "prior" in a Platonic sense, at least :).
 

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -1,5 +1,5 @@
-- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Feature Name: `cargo-feature-migrations`
+- Start Date: 2021-07-01
 - RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -59,7 +59,7 @@ It's very important we have a good design so that we don't end up accidentally i
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-I recommend first reading the [Rationale and alternatives](rationale-and-alternatives) section.
+I recommend first reading the [Rationale and alternatives](#rationale-and-alternatives) section.
 I don't think this design is overwrought, but it does represent a new way of thinking about these sorts of issues that might feel unfamiliar.
 I fully acknowledge "migrations" is a scary word for many people due to their experiences with databases.
 
@@ -201,13 +201,13 @@ In any case, this means that *all* build plans (with the given version of the pa
 One might think there is a fix making the out-out a hard rejection, so such that no plan is allowed to have those features.
 But that creates other problems, namely that those same sneaky new deps would disallow all plans entirely.
 Moreover, this sort of "negative reasoning" undermines the entire "additive" comparability story Cargo features are supposed to have.
-This will make everything brittle, and make it impossible to express when you *are* in fact, agnostic to whether some unneeded feature is enabled due to something else.
-
-> I do think is useful to assert some features aren't enabled, but that should be done in the workspace root, not dependency crates, for sake of modularity.
+This will make everything brittle, and make it impossible to express when you *are* in fact, agnostic to whether some unneeded feature is enabled due to something else.<sup>[1](#assert-disabled)</sup>
 
 Finally, and is a matter of taste, I find writing down features that I *don't* need poor UX.
 We say "pay for what you use" in Rust, but writing down features that we, by definition, don't care about means cluttering our minds and `Cargo.toml`s.
 I would only want to propose negative reasoning as an absolute last resort.
+
+<a name="assert-disabled">1:</a> N.B. I do think is useful to assert some features aren't enabled, but that should be done in the workspace root, not dependency crates, for sake of modularity.
 
 ## Always at least one feature
 

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -356,6 +356,8 @@ The formalism it uses is not the same as this one, but it is related.
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
+- Whether to in fact deprecate `default-features`.
+
 - Syntax bikeshed, `all()` could be regular `cfg` syntax or something else.
 
 - Maybe we just worry about migrating the no-feature case for now.

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -87,7 +87,7 @@ We can do it like this
 "all()" = [ "std" ]
 ```
 Yes, that `all()` is pretty obscure.
-It means the "empty union"; no bad I cannot use feature lists as keys.
+It means the "empty union"; too bad I cannot use lists (of features) as TOML object keys.
 It is supposed to match syntax I proposed in https://github.com/rust-lang/rfcs/pull/3143#issuecomment-868829430.
 I am fine if we have some sugar for this common case.
 

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -15,9 +15,19 @@ This will allow adding new features to make existing functionality optional with
 ## Problem
 
 Today, Cargo's features most easily support workflow where features added in a new versions of a crate gate new functionality.
-For example, in a new version of a crate, someone creates a new function, and adds it behind a new feature; neither the function nor feature existed in the old version of the crate.
+
+> Example:
+>
+> In a new version of a crate, someone creates a new function, and adds it behind a new feature.
+>
+> Neither the function nor feature existed in the old version of the crate.
+
 The problem is there is another quite different use case of features: making previously mandatory functionality optional.
-For example, in a new version of a create, some creates a new feature for a function that *already* exists, so that it can be disabled.
+
+> Example:
+>
+> In a new version of a create, some creates a new feature for a function that *already* exists, so that it can be disabled.
+
 The workflow isn't supported so well, the only avoidance Cargo supports for it is the "default features" set, which isn't sufficient for reasons that will be provided below.
 
 This second use-case is really important --- in fact, perhaps more important.
@@ -162,7 +172,10 @@ A few ideas came up in the https://github.com/rust-lang/rfcs/pull/3140 thread th
 
 ## Feature opt-outs
 
-The most popular feature was some way to opt out of features, i.e. to say "give me the default features" *without* necessarily features 'x' or 'y'".
+The most popular proposal was some way to opt out of features, i.e. to say:
+
+> Give me the default features" *without* necessarily features 'x' or 'y'.
+
 This does solve the problem: without users opting out of all features, just the ones they can name, there is no risk new features they will need being disabled.
 However, it causes other problems.
 
@@ -172,7 +185,13 @@ We can't give that up across the board without destroying feature resolution, so
 I worry this will be very subtle and hard to teach.
 
 Second of all, there is an especially unintuitive case of the former where a non-opted-out default feature depends on an opted-out feature.
-E.g. the consumer depends on "default features without 'foo'", but "bar" is another default feature that depends on "foo".
+
+> Example:
+>
+> - Consumer depends on "default features without 'foo'"
+>
+> - "bar" is another default feature that depends on "foo".
+
 In this case, the not mentioned feature still drags in the opted out feature.
 This might happen because the user forgot to include both features.
 It might also happen because only in the new version, and in not the one the user was using when they wrote the spec, did the feature gain the problematic dep on the excluded feature.
@@ -205,7 +224,9 @@ First of all, we don't even need any notion of "default features" anymore for co
 Since there was at least one feature from the get-go, we simply prevent breaking changes by not removing old features.
 When we want to make existing functionality more optional, we just split existing features up:
 the old "everything else" feature gets a dependency on the new optional feature, and the new "everything else" feature, which is correspondingly narrower.
-For example, `everything-else-0` in the old version becomes `std`, `everything-else-1`, and `everything-else-0 = ["std", "everything-else-1"]`.
+
+> Example, `everything-else-0` in the old version becomes `std`, `everything-else-1`, and `everything-else-0 = ["std", "everything-else-1"]`.
+
 Importantly, there is no negative reasoning, or opting out, which avoids all the pitfalls of the previous solution.
 
 Of course, this method also has some serious ergonomic drawbacks.

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -15,7 +15,7 @@ This will allow adding new features to make existing functionality optional with
 ## Problem
 
 Today, Cargo's features most easily support workflow where features added in a new versions of a crate gate new functionality.
-For example, in a new version of a crate, someone crates a new function, and adds it behind a new feature; neither the function nor feature existed in the old version of the crate.
+For example, in a new version of a crate, someone creates a new function, and adds it behind a new feature; neither the function nor feature existed in the old version of the crate.
 The problem is there is another quite different use case of features: making previously mandatory functionality optional.
 For example, in a new version of a create, some creates a new feature for a function that *already* exists, so that it can be disabled.
 The workflow isn't supported so well, the only avoidance Cargo supports for it is the "default features" set, which isn't sufficient for reasons that will be provided below.
@@ -49,7 +49,7 @@ It's very important we have a good design so that we don't end up accidentally i
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-I recommend first reading the [rationale-and-alternatives] section.
+I recommend first reading the [Rationale and alternatives](rationale-and-alternatives) section.
 I don't think this design is overwrought, but it does represent a new way of thinking about these sorts of issues that might feel unfamiliar.
 I fully acknowledge "migrations" is a scary word for many people due to their experiences with databases.
 

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -7,7 +7,7 @@
 [summary]: #summary
 
 Extend Cargo to allow some limited forms of migrations of feature sets to be expressed.
-This will allow adding new features to make existing functionality optional without causing needless breakage.
+This will allow new features to be added that make existing functionality optional without causing needless breakage.
 
 # Motivation
 [motivation]: #motivation

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -234,7 +234,7 @@ When we want to make existing functionality more optional, we just split existin
 
 > Example: The old "everything else" feature gets a dependency on the new optional feature, and the new "everything else" feature, which is correspondingly narrower:
 >
-> - In code: `#![cfg(everything-else-0)]` attributes become either `#![cfg(std)]` or else `#![cfg(everything-else-1)]`
+> - In code: `#[cfg(everything-else-0)]` attributes become either `#[cfg(std)]` or else `#[cfg(everything-else-1)]`
 >
 > - In `Cargo.toml`:
 >   ```toml
@@ -345,7 +345,7 @@ Our migrations are monotonic because they only map feature sets to equal or larg
 Back to the `["foo-feature", "bar-feature"]` to `["foo-feature", "bar-feature", "baz-feature"]` problem.
 Recall for "at least one feature" alternative, we said that every item had to gated on not just at least one but exactly one feature
 (though those features could have dependencies on one another).
-What that meant mathematically was that the `cfg` for each item had to be [*meet-irreducible*](https://en.wikipedia.org/wiki/Birkhoff%27s_representation_theorem#The_partial_order_of_join-irreducible).
+What that meant mathematically was that the `#[cfg(..)]` for each item had to be [*meet-irreducible*](https://en.wikipedia.org/wiki/Birkhoff%27s_representation_theorem#The_partial_order_of_join-irreducible).
 That is the precise criterion for when a crate is truly "future proof" today, absent the proposed new functionality.
 
 Note it is OK if the migration homomorphisms are not injective.

--- a/text/0000-cargo-feature-migrations.md
+++ b/text/0000-cargo-feature-migrations.md
@@ -82,7 +82,7 @@ For users, that should be it!
 For crate authors, yes, now the work of migrations comes in.
 If in version 1.2 a `std` feature is added, then we need to say that users coming from 1.1 should have it enabled.
 We can do it like this
-```
+```toml
 [feature-migrations."1.1"]
 "all()" = [ "std" ]
 ```
@@ -113,7 +113,7 @@ fn bar();
 fn baz();
 ```
 we can have migration
-```
+```toml
 [feature-migrations."1.1"]
 "all(foo, bar)" = [ "baz" ]
 ```
@@ -135,14 +135,14 @@ Conversely if crates had to use `features = [ "std" ];"` from the get-go, I don'
 
 1. `Cargo.toml` has a new section in the form `feature-migrations`
    The format is
-   ```
-   [feature-migrations.<version>]
-   <feature-pseudo-cfg> = <feature-list>
+   ```toml
+   [feature-migrations."<version>"]
+   "<feature-pseudo-cfg>" = "<feature-list>"
    ```
    where
 
     - `<version>` is a string containing a prior crate version
-    - ```
+    - ```bnf
       <feature-pseudo-cfg> ::= <feature-name>
                             |  all(<possbily-empty-comma-separated-list-of-feature-names>)
       ```


### PR DESCRIPTION
Extend Cargo to allow some limited forms of migrations of feature sets to be expressed.
This will allow new features to be added that make existing functionality optional without causing needless breakage.

[Rendered](https://github.com/Ericson2314/rust-rfcs/blob/cargo-feature-migrations/text/0000-cargo-feature-migrations.md)