### PR TITLE
Withdraw RFC 2500 approval & use consistent wording.

### DIFF
--- a/text/0809-box-and-in-for-stdlib.md
+++ b/text/0809-box-and-in-for-stdlib.md
@@ -3,7 +3,7 @@
 - RFC PR: [rust-lang/rfcs#809](https://github.com/rust-lang/rfcs/pull/809)
 - Rust Issue: [rust-lang/rust#22181](https://github.com/rust-lang/rust/issues/22181)
 
-# This RFC has been **unapproved**
+# This RFC was previously approved, but later **withdrawn**
 
 For details see the [summary comment].
 

--- a/text/1228-placement-left-arrow.md
+++ b/text/1228-placement-left-arrow.md
@@ -3,7 +3,7 @@
 - RFC PR: [rust-lang/rfcs#1228](https://github.com/rust-lang/rfcs/pull/1228)
 - Rust Issue: [rust-lang/rust#27779](https://github.com/rust-lang/rust/issues/27779)
 
-# This RFC has been **unapproved**
+# This RFC was previously approved, but later **withdrawn**
 
 For details see the [summary comment].
 

--- a/text/2500-needle.md
+++ b/text/2500-needle.md
@@ -3,7 +3,7 @@
 - RFC PR: [rust-lang/rfcs#2500](https://github.com/rust-lang/rfcs/pull/2500)
 - Rust Issue: [rust-lang/rust#56345](https://github.com/rust-lang/rust/issues/56345)
 
-# This RFC has been **unapproved**
+# This RFC was previously approved, but later **withdrawn**
 
 For details see the [summary comment].
 

--- a/text/2500-needle.md
+++ b/text/2500-needle.md
@@ -3,6 +3,12 @@
 - RFC PR: [rust-lang/rfcs#2500](https://github.com/rust-lang/rfcs/pull/2500)
 - Rust Issue: [rust-lang/rust#56345](https://github.com/rust-lang/rust/issues/56345)
 
+# This RFC has been **unapproved**
+
+For details see the [summary comment].
+
+[summary comment]: https://github.com/rust-lang/rust/pull/76901#issuecomment-880169952
+
 # Summary
 [summary]: #summary
 


### PR DESCRIPTION
This is according to the decision within https://github.com/rust-lang/rust/pull/76901#issuecomment-880169952

Currently it is pending on the ongoing fcp, which will finish tomorrow.