### PR TITLE
Update RFC 135 documentation on `where` clauses

### DIFF
--- a/text/0135-where.md
+++ b/text/0135-where.md
@@ -405,13 +405,12 @@ self-type does not refer to any of the type parameters, such as the
 following:
 
     fn foo()
-        where int : Eq
+        where i32 : Eq
     { ... }
 
-Where clauses like these are considered an error. They have no
-particular meaning, since the callee knows all types involved. This is
-a conservative choice: if we find that we do desire a particular
-interpretation for them, we can always make them legal later.
+Although atypical, where clauses like this are not an error:
+all bounds can be proven by the callers, even when the
+substitution of parameter types is not necessary.
 
 # Drawbacks
 


### PR DESCRIPTION
This RFC is linked to by the [keyword definition](https://doc.rust-lang.org/std/keyword.where.html), though
it currently contains examples which are not accurate.

This PR updates the "Semantics" section to accurately report the case of:
`fn foo() where i32 : Eq { ... }`

Is not an error.