### PR TITLE
Add start date to RFC 1214

### DIFF
--- a/text/1214-projections-lifetimes-and-wf.md
+++ b/text/1214-projections-lifetimes-and-wf.md
@@ -1,5 +1,5 @@
 - Feature Name: N/A
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Start Date: 2015-07-17
 - RFC PR: [rust-lang/rfcs#1214](https://github.com/rust-lang/rfcs/pull/1214)
 - Rust Issue: [rust-lang/rust#27579](https://github.com/rust-lang/rust/issues/27579)
 


### PR DESCRIPTION
The date is based on the PR date, and seems useful and convenient if the RFC is opened in the book and the reader wants to know roughly when it was written.