### PR TITLE
Updated string-patterns feature name and tracking issue

### DIFF
--- a/text/0528-string-patterns.md
+++ b/text/0528-string-patterns.md
@@ -1,6 +1,7 @@
+- Feature Name: `pattern`
 - Start Date: 2015-02-17
 - RFC PR: [rust-lang/rfcs#528](https://github.com/rust-lang/rfcs/pull/528)
-- Rust Issue: [rust-lang/rust#22477](https://github.com/rust-lang/rust/issues/22477)
+- Rust Issue: [rust-lang/rust#27721](https://github.com/rust-lang/rust/issues/27721)
 
 # Summary
 


### PR DESCRIPTION
The feature name for `string-patterns` (which is `pattern`) was missing and the tracking issue listed was closed in favor of another. This PR adds the feature name and updates the tracking issue to match [unstable-book/library-features/pattern](https://doc.rust-lang.org/unstable-book/library-features/pattern.html).