### PR TITLE
Do not include headers in search index

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir mdbook
-        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.10/mdbook-v0.4.10-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.13/mdbook-v0.4.13-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
     - name: Generate Book
       run: |

--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,6 @@ title = "The Rust RFC Book"
 [output.html]
 no-section-label = true
 git-repository-url = "https://github.com/rust-lang/rfcs"
+
+[output.html.search]
+heading-split-level = 0


### PR DESCRIPTION
This significantly shrinks the pre-compressed search index:

    $ du -h searchindex-old.js searchindex-new.js
    26M	searchindex-old.js
    19M	searchindex-new.js

And shrinks the search index even after it's gzipped:

    $ du -h searchindex-old.js.gz searchindex-new.js.gz
    4.5M	searchindex-old.js.gz
    3.3M	searchindex-new.js.gz

This change requires a newer version of mdBook, with https://github.com/rust-lang/mdBook/pull/1637

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/1593513/135887809-853aea7c-a01a-4de2-8b0d-deda68fb4603.png)

After:

![image](https://user-images.githubusercontent.com/1593513/135887639-b53ed049-56b3-4d7e-869b-408de5ffaf65.png)
