### PR TITLE
RFC: Add std::io::inputln()

### DIFF
--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -28,17 +28,11 @@ io::stdin()
 ```
 
 While the above code is perfectly clear to everybody who already knows Rust, it
-can be quite overwhelming for a beginner. What is `mut`? What is `&mut`?  The
-2nd chapter gives only basic explanations and assures that mutability and
-borrowing will be explained in detail in later chapters. Don't worry about that
-for now, everything will make sense later.  But the beginner might worry about
-something else: Why is something so simple so complicated with Rust? For example
-in Python you can just do `guess = input()`.  Is Rust always this cumbersome?
-Maybe they should rather stick with their current favorite programming language
-instead.
-
-This RFC therefore proposes the introduction of a `std::io::inputln` function
-so that the above example could be simplified to just:
+can be quite overwhelming for a beginner because it confronts them with three
+new concepts at once: mutability, borrowing and the `Result` type. Didactically
+it would be better if these concepts could be introduced one at a time.  This
+RFC therefore proposes the introduction of a `std::io::inputln` function so
+that the above example could be simplified to just:
 
 ```rs
 let guess = io::inputln().expect("Failed to read line");

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -114,7 +114,7 @@ The newline trimming behavior is the same as of `std::io::BufRead::lines`.
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-> Why should the function trim newlines?
+## Why should the function trim newlines?
 
 We assume that the returned string will often be processed with `String::parse`,
 for example it is likely that developers will attempt the following:
@@ -130,7 +130,7 @@ programmers don't have to remember to add a `trim()` call whenever they want to
 parse the returned string. In cases where newlines have to be preserved the
 underlying `std::io::Stdin::read_line` can be used directly instead.
 
-> Why should the function handle EOF?
+## Why should the function handle EOF?
 
 If the function performs newline trimming, it also has to return an error when
 the input stream reaches EOF because otherwise users had no chance of detecting
@@ -154,7 +154,7 @@ fn main() -> std::io::Result<()> {
 }
 ```
 
-> Why should the function flush standard output before reading?
+## Why should the function flush standard output before reading?
 
 Users are bound to display prompts with the `print!` macro, for example they
 might do:
@@ -182,7 +182,7 @@ library](https://github.com/rust-lang/rust/issues/40032), the proposal also
 elaborated that standard output would immediately be reopend with `/dev/null`
 to uphold that very assumption.
 
-> Why should the function be implemented as a function instead of a macro?
+## Why should the function be implemented as a function instead of a macro?
 
 If the function were implemented as a macro it could take an optional `prompt`
 argument and only flush standard output when it is actually needed.
@@ -206,7 +206,7 @@ macro_rules! prompt {
 
 which is not at all helpful for a beginner trying to understand what's going on.
 
-> What is the impact of not doing this?
+## What is the impact of not doing this?
 
 A higher chance of Rust beginners getting overwhelmed by mutability and borrowing.
 

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -5,8 +5,8 @@
 # Summary
 [summary]: #summary
 
-Add an `inputln` function to `std` to read a line from standard input and return
-a `std::io::Result<String>`.
+Add an `inputln` function to `std::io` to read a line from standard input and
+return a `std::io::Result<String>`.
 
 # Motivation
 [motivation]: #motivation
@@ -37,11 +37,11 @@ in Python you can just do `guess = input()`.  Is Rust always this cumbersome?
 Maybe they should rather stick with their current favorite programming language
 instead.
 
-This RFC therefore proposes the introduction of a `std::inputln` function so
-that the above example could be simplified to just:
+This RFC therefore proposes the introduction of a `std::io::inputln` function
+so that the above example could be simplified to just:
 
 ```rs
-let guess = inputln().expect("Failed to read line");
+let guess = io::inputln().expect("Failed to read line");
 ```
 
 This would allow for a more graceful introduction to Rust. Letting beginners
@@ -54,7 +54,7 @@ complete beginners should reflect that.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-`std::inputln()` is a convenience wrapper around `std::io::Stdin::read_line`,
+`std::io::inputln()` is a convenience wrapper around `std::io::Stdin::read_line`,
 introduced so that Rust beginners can create interactive programs without having
 to worry about mutability or borrowing.  The function allocates a new String
 buffer for you, and reads a line from standard input.  The result is returned as
@@ -83,10 +83,10 @@ pub fn inputln() -> std::io::Result<String> {
   don't realize that they could reuse a buffer instead. This could potentially
   be remedied by a new Clippy lint.
 
-* There is no precedent for a function residing directly in the `std` module
-  (currently it only contains macros). So Rust programmers might out of habit
-  try to call `inputln!()`. This should however not pose a big hurdle because
-  `rustc` already provides a helpful error message:
+* `println!` and `writeln!` are both macros, so Rust programmers might out of
+  habit try to call `inputln!()`. This should however not pose a big hurdle if
+  `std::io::inputln` is added to `std::prelude` because in that case `rustc`
+  already provides a helpful error message:
 
   ```
     error: cannot find macro `inputln` in this scope
@@ -157,10 +157,8 @@ The name of the function is up to debate. `read_line()` would also be a
 reasonable choice, that does however potentially beg the question: Read from
 where? `inputln()` hints that the line comes from standard input.
 
-The location of the function is also up to debate. It could also reside in
-`std::io`, which would however come with the drawback that beginners need to
-either import it or prefix `std::io`, both of which seem like unnecessary
-hurdles.
+Should the function additionally be added to `std::prelude`, so that beginners
+can use it without needing to import `std::io`?
 
 > What related issues do you consider out of scope for this RFC that could be
 > addressed in the future independently of the solution that comes out of this RFC?

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -178,10 +178,30 @@ fn main() -> std::io::Result<()> {
 }
 ```
 
-> What other designs have been considered and what is the rationale for not
-> choosing them?
+> Why should the function be implemented as a function instead of a macro?
 
-The function could also be implemented as a macro but there is really no need for that.
+If the function were implemented as a macro it could take an optional `prompt`
+argument and take care of flushing stdout between printing the prompt and
+reading from stdin.
+
+Since the function is however meant to facilitate teaching Rust to complete
+beginners it should be as beginner-friendly as possible, which also entails
+implementing it as an actual function because then it has a clear signature:
+
+```rs
+pub fn inputln() -> std::io::Result<String>
+```
+
+As opposed to a macro for which `rustdoc` would show something like:
+
+```rs
+macro_rules! prompt {
+    () => { ... };
+    ($($args : tt) +) => { ... };
+}
+```
+
+which is not at all helpful for a beginner trying to understand what's going on.
 
 > What is the impact of not doing this?
 

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -132,8 +132,8 @@ The newline trimming behavior is the same as of `std::io::BufRead::lines`.
   let name = io::inputln()?;
   ```
 
-  This can be somewhat remedied by adding the above example to the `inputln()`
-  documentation.
+  This source of confusion could be mitigated by explaining the issue in the
+  documentation of `inputln()` and introducing a respective Clippy lint.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -240,10 +240,17 @@ standard library to be out of the scope of this RFC.
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Once this RFC is implemented the Chapter 2 of the Rust book could be simplified
-to introduce mutability and borrowing in a more gentle manner. Clippy could gain
-a lint to tell users to avoid unnecessary allocations due to repeated
-`inputln()` calls and suggest `std::io::Stdin::read_line` instead.
+Once this RFC is implemented:
+
+* The Chapter 2 of the Rust book could be simplified
+  to introduce mutability and borrowing in a more gentle manner.
+
+* Clippy should gain a lint that detects `print!(...); let x = io::inputln();`
+  and suggests you to insert a `io::stdout().flush();` between the statements.
+
+* Clippy might also introduce a lint to tell users to avoid unnecessary
+  allocations due to repeated `inputln()` calls and suggest
+  `std::io::Stdin::read_line` instead.
 
 With this addition Rust might lend itself more towards being the first
 programming language for students.

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -82,6 +82,8 @@ pub fn inputln() -> std::io::Result<String> {
 }
 ```
 
+The newline trimming behavior is the same as of `std::io::BufRead::lines`.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 
@@ -107,11 +109,21 @@ pub fn inputln() -> std::io::Result<String> {
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-> Why is this design the best in the space of possible designs?
+> Why should the function trim newlines?
 
-It is the simplest solution to the explained problem.
+We assume that the returned string will often be processed with `String::parse`,
+for example it is likely that developers will attempt the following:
 
-The newline stripping behavior is the same as of `std::io::BufRead::lines`.
+```rs
+let age: i32 = io::inputln()?.parse()?;
+```
+
+If `inputln()` didn't trim newlines the above would however always fail since
+the `FromStr` implementations in the standard library don't expect a trailing
+newline. Newline trimming is therefore included for better ergonomics, so that
+programmers don't have to remember to add a `trim()` call whenever they want to
+parse the returned string. In cases where newlines have to be preserved the
+underlying `std::io::Stdin::read_line` can be used directly instead.
 
 > What other designs have been considered and what is the rationale for not
 > choosing them?

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -5,8 +5,8 @@
 # Summary
 [summary]: #summary
 
-Add an `inputln` function to `std::io` to read a line from standard input and
-return a `std::io::Result<String>`.
+Add an `inputln` convenience function to `std::io` to read a line from standard
+input and return a `std::io::Result<String>`.
 
 # Motivation
 [motivation]: #motivation
@@ -54,11 +54,10 @@ complete beginners should reflect that.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-`std::io::inputln()` is a convenience wrapper around `std::io::Stdin::read_line`,
-introduced so that Rust beginners can create interactive programs without having
-to worry about mutability or borrowing.  The function allocates a new String
-buffer for you, and reads a line from standard input.  The result is returned as
-a `std::io::Result<String>`.
+`std::io::inputln()` is a convenience wrapper around `std::io::Stdin::read_line`.
+The function allocates a new String buffer for you, reads a line from standard
+input and strips the newline (`\n` or `\r\n`).  The result is returned as a
+`std::io::Result<String>`.
 
 If you are repeatedly reading lines from standard input and don't need to
 allocate a new String for each of them you should be using
@@ -72,6 +71,13 @@ buffer.
 pub fn inputln() -> std::io::Result<String> {
     let mut input = String::new();
     std::io::stdin().read_line(&mut input)?;
+
+    if input.ends_with('\n') {
+        input.pop();
+        if input.ends_with('\r') {
+            input.pop();
+        }
+    }
     Ok(input)
 }
 ```
@@ -104,6 +110,8 @@ pub fn inputln() -> std::io::Result<String> {
 > Why is this design the best in the space of possible designs?
 
 It is the simplest solution to the explained problem.
+
+The newline stripping behavior is the same as of `std::io::BufRead::lines`.
 
 > What other designs have been considered and what is the rationale for not
 > choosing them?

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -1,0 +1,180 @@
+- Feature Name: `inputln`
+- Start Date: 2021-11-16
+- RFC PR: [rust-lang/rfcs#3196](https://github.com/rust-lang/rfcs/pull/3196)
+
+# Summary
+[summary]: #summary
+
+Add an `inputln` function to `std` to read a line from standard input and return
+a `std::io::Result<String>`.
+
+# Motivation
+[motivation]: #motivation
+
+Building a small interactive program that reads input from standard input and
+writes output to standard output is well-established as a simple and fun way of
+learning and teaching a new programming language.  Case in point the chapter 2
+of the official Rust book is [Programming a Guessing Game], which suggests the
+following code:
+
+[Programming a Guessing Game]: https://doc.rust-lang.org/book/ch02-00-guessing-game-tutorial.html
+
+```rs
+let mut guess = String::new();
+
+io::stdin()
+    .read_line(&mut guess)
+    .expect("Failed to read line");
+```
+
+While the above code is perfectly clear to everybody who already knows Rust, it
+can be quite overwhelming for a beginner. What is `mut`? What is `&mut`?  The
+2nd chapter gives only basic explanations and assures that mutability and
+borrowing will be explained in detail in later chapters. Don't worry about that
+for now, everything will make sense later.  But the beginner might worry about
+something else: Why is something so simple so complicated with Rust? For example
+in Python you can just do `guess = input()`.  Is Rust always this cumbersome?
+Maybe they should rather stick with their current favorite programming language
+instead.
+
+This RFC therefore proposes the introduction of a `std::inputln` function so
+that the above example could be simplified to just:
+
+```rs
+let guess = inputln().expect("Failed to read line");
+```
+
+This would allow for a more graceful introduction to Rust. Letting beginners
+experience the exciting thrill of running their own first interactive Rust
+program, without being confronted with mutability and borrowing straight away.
+While mutability and borrowing are very powerful concepts, Rust does not force
+you to use them when you don't need them. The examples we use to teach Rust to
+complete beginners should reflect that.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+`std::inputln()` is a convenience wrapper around `std::io::Stdin::read_line`,
+introduced so that Rust beginners can create interactive programs without having
+to worry about mutability or borrowing.  The function allocates a new String
+buffer for you, and reads a line from standard input.  The result is returned as
+a `std::io::Result<String>`.
+
+If you are repeatedly reading lines from standard input and don't need to
+allocate a new String for each of them you should be using
+`std::io::Stdin::read_line` directly instead, so that you can reuse an existing
+buffer.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+```rs
+pub fn inputln() -> std::io::Result<String> {
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    Ok(input)
+}
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+* Can lead to unnecessary buffer allocations in Rust programs when developers
+  don't realize that they could reuse a buffer instead. This could potentially
+  be remedied by a new Clippy lint.
+
+* There is no precedent for a function residing directly in the `std` module
+  (currently it only contains macros). So Rust programmers might out of habit
+  try to call `inputln!()`. This should however not pose a big hurdle because
+  `rustc` already provides a helpful error message:
+
+  ```
+    error: cannot find macro `inputln` in this scope
+    --> src/main.rs:13:5
+     |
+  13 |     inputln!();
+     |     ^^^^^^^
+     |
+     = note: `inputln` is in scope, but it is a function, not a macro
+   ```
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+> Why is this design the best in the space of possible designs?
+
+It is the simplest solution to the explained problem.
+
+> What other designs have been considered and what is the rationale for not
+> choosing them?
+
+The function could also be implemented as a macro but there is really no need for that.
+
+> What is the impact of not doing this?
+
+A higher chance of Rust beginners getting overwhelmed by mutability and borrowing.
+
+# Prior art
+[prior-art]: #prior-art
+
+Python has [input()], Ruby has [gets], C# has `Console.ReadLine()`
+... all of these return a string read from standard input.
+
+[input()]: https://docs.python.org/3/library/functions.html#input
+[gets]: https://ruby-doc.org/docs/ruby-doc-bundle/Tutorial/part_02/user_input.html
+
+Other standard libraries additionally:
+
+* accept a prompt to display to the user before reading from standard input
+  (e.g. Python and Node.js)
+
+* provide some functions to parse multiple values of specific data types
+  into ovariables (e.g. C's `scanf`, C++, Java's `Scanner`)
+
+Python's `input()` function accepts a `prompt` argument because Python's output
+is line buffered by default, meaning a `print()` without a newline would only be
+output after a manual flush. Node.js accepts a prompt because its
+[readline](https://nodejs.org/api/readline.html) interface is very high level.
+Both reasonings don't apply to Rust. With Rust a simple `print!()` call before
+invoking `inputln()` suffices to display an input prompt and more high-level
+interfaces are better provided by crates.
+
+While scanning utilities could also be added to the Rust standard library, how
+these should be designed is less clear, as well as whether or not they should be
+in the standard library in the first place. There exist many well established
+input parsing libraries for Rust that are only a `cargo install` away. The same
+argument does not apply to `inputln()` ... beginners should be able to get
+started with an interactive Rust program without having to worry about
+mutability, borrowing or having to install a third-party library.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+> What parts of the design do you expect to resolve through the RFC process
+> before this gets merged?
+
+The name of the function is up to debate. `read_line()` would also be a
+reasonable choice, that does however potentially beg the question: Read from
+where? `inputln()` hints that the line comes from standard input.
+
+The location of the function is also up to debate. It could also reside in
+`std::io`, which would however come with the drawback that beginners need to
+either import it or prefix `std::io`, both of which seem like unnecessary
+hurdles.
+
+> What related issues do you consider out of scope for this RFC that could be
+> addressed in the future independently of the solution that comes out of this RFC?
+
+I consider the question whether or not scanning utilities should be added to the
+standard library to be out of the scope of this RFC.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Once this RFC is implemented the Chapter 2 of the Rust book could be simplified
+to introduce mutability and borrowing in a more gentle manner. Clippy could gain
+a lint to tell users to avoid unnecessary allocations due to repeated
+`inputln()` calls and suggest `std::io::Stdin::read_line` instead.
+
+With this addition Rust might lend itself more towards being the first
+programming language for students.

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -115,6 +115,26 @@ The newline trimming behavior is the same as of `std::io::BufRead::lines`.
      = note: `inputln` is in scope, but it is a function, not a macro
    ```
 
+* Might lead to confusion when users attempt the following:
+
+  ```rs
+  print!("enter your name: ");
+  let name = io::inputln()?;
+  ```
+
+  Because the `print!` macro does not flush stdout the prompt will only ever be
+  displayed after the user has input their name.  The correct way to implement
+  the above would be:
+
+  ```rs
+  print!("enter your name: ");
+  io::stdout().flush()?;
+  let name = io::inputln()?;
+  ```
+
+  This can be somewhat remedied by adding the above example to the `inputln()`
+  documentation.
+
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
@@ -184,13 +204,11 @@ Other standard libraries additionally:
 * provide some functions to parse multiple values of specific data types
   into ovariables (e.g. C's `scanf`, C++, Java's `Scanner`)
 
-Python's `input()` function accepts a `prompt` argument because Python's output
-is line buffered by default, meaning a `print()` without a newline would only be
-output after a manual flush. Node.js accepts a prompt because its
-[readline](https://nodejs.org/api/readline.html) interface is very high level.
-Both reasonings don't apply to Rust. With Rust a simple `print!()` call before
-invoking `inputln()` suffices to display an input prompt and more high-level
-interfaces are better provided by crates.
+Python's `input()` function can additionally make use of the GNU readline
+library and Node.js' [readline](https://nodejs.org/api/readline.html) interface
+provides a history and TTY keybindings as well.  The function suggested in this
+RFC does not include such high-level features, these are better left to crates,
+such as [`rustyline`](https://crates.io/crates/rustyline).
 
 While scanning utilities could also be added to the Rust standard library, how
 these should be designed is less clear, as well as whether or not they should be

--- a/text/3196-inputln.md
+++ b/text/3196-inputln.md
@@ -244,9 +244,16 @@ mutability, borrowing or having to install a third-party library.
 > What parts of the design do you expect to resolve through the RFC process
 > before this gets merged?
 
-The name of the function is up to debate. `read_line()` would also be a
-reasonable choice, that does however potentially beg the question: Read from
-where? `inputln()` hints that the line comes from standard input.
+The name of the function is up to debate. `read_line` would also be an obvious
+choice because the function wraps `std::io::Stdin::read_line`. Since the
+function however additionally performs newline trimming and yields an error for
+EOF (as opposed to returning an `Ok` variant), naming it the same might mislead
+users into thinking that the function does not have these subtle differences.
+In particular because there is precedent for convenience functions that share
+the name of their underlying function to also behave the same
+(`std::io::read_to_string` and `std::fs::read_to_string` both wrap
+`Read::read_to_string` without processing the string or introducing additional
+error sources).
 
 Should the function additionally be added to `std::prelude`, so that beginners
 can use it without needing to import `std::io`?


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3196)*

I think the best way to drive the addition of this function forward is to have a dedicated RFC for it.

[Rendered](https://github.com/rust-lang/rfcs/blob/126e2bd1f6853ec2701cc041104917640f94bb2f/text/3196-inputln.md#readme)

Previous discussions:

* https://github.com/rust-lang/rust/pull/75435
* https://github.com/rust-lang/rfcs/pull/3183 (related RFC that additionally proposes scan macros)