### PR TITLE
FIXES #3214 generate-books.sh: ln --relative not supported on macOS

### DIFF
--- a/generate-book.sh
+++ b/generate-book.sh
@@ -8,15 +8,15 @@ fi
 
 printf '[Introduction](introduction.md)\n\n' > src/SUMMARY.md
 
-find ./text ! -type d -print0 | xargs -0 -I {} ln -frs {} -t src/
+find text ! -type d -print0 | xargs -0 -I {} ln -fs ../{} src/
 
 find ./text ! -type d -name '*.md' -print0 \
   | sort -z \
   | while read -r -d '' file;
 do
-    printf -- '- [%s](%s)\n' "$(basename "$file" ".md")" "$(basename "$file")" 
+    printf -- '- [%s](%s)\n' "$(basename "$file" ".md")" "$(basename "$file")"
 done >> src/SUMMARY.md
 
-ln -frs README.md src/introduction.md
+ln -fs ../README.md src/introduction.md
 
 mdbook build


### PR DESCRIPTION
FIXES #3214:

* Omit using "ln -r" for symbolic link creation
* Create symbolic links with old style expression
* Creates relative links
