### PR TITLE
Fixed the associated syntax error in the associated type Trait Headers

### DIFF
--- a/text/0195-associated-items.md
+++ b/text/0195-associated-items.md
@@ -263,7 +263,7 @@ Trait headers are written according to the following grammar:
 TRAIT_HEADER =
   'trait' IDENT [ '<' INPUT_PARAMS '>' ] [ ':' BOUNDS ] [ WHERE_CLAUSE ]
 
-INPUT_PARAMS = INPUT_TY { ',' INPUT_TY }* [ ',' ]
+INPUT_PARAMS = INPUT_PARAM { ',' INPUT_PARAM }* [ ',' ]
 INPUT_PARAM  = IDENT [ ':' BOUNDS ]
 
 BOUNDS = BOUND { '+' BOUND }* [ '+' ]


### PR DESCRIPTION
Related to [Fixed the associated syntax error in the associated type Trait Headers](https://github.com/rust-lang/rfcs/issues/3281#issuecomment-1185326642)

Closes #3281