### PR TITLE
prominent link to RFC book

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rust RFCs - [Active RFC List](https://rfcbot.rs/)
+# Rust RFCs - [RFC Book](https://rust-lang.github.io/rfcs/) - [Active RFC List](https://rfcbot.rs/)
 
 [Rust RFCs]: #rust-rfcs
 


### PR DESCRIPTION
I always have to search for the RFC book, usually with a search engine.

I now realize it is also set as homepage for this GitHub repository, but GH hides the homepage link in the sidebar so it is really easy to miss. The "Active RFC List" is several times more visible, but when I want to look for existing ratified RFCs it does not help...