### PR TITLE
Disable the playground run button by default for code blocks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir mdbook
-        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.13/mdbook-v0.4.13-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
     - name: Generate Book
       run: |

--- a/book.toml
+++ b/book.toml
@@ -7,3 +7,6 @@ git-repository-url = "https://github.com/rust-lang/rfcs"
 
 [output.html.search]
 heading-split-level = 0
+
+[output.html.playground]
+runnable = false


### PR DESCRIPTION
Most example code in RFCs is not written with executability in mind, so having the "Run" button available by default on all RFCs seems a bit misleading. This now disables the playground for the whole book (which also removes the "hidden" code mdbook inserts). It thus only leaves the copy button.