### PR TITLE
Update link to blog post

### DIFF
--- a/text/1857-stabilize-drop-order.md
+++ b/text/1857-stabilize-drop-order.md
@@ -128,7 +128,7 @@ in the future.
 
 Closure captures are also dropped in unspecified order. At this moment, it seems
 like the drop order is similar to the order in which the captures are consumed within
-the closure (see [this blog post](https://aochagavia.github.io/blog/exploring-rusts-unspecified-drop-order/)
+the closure (see [this blog post](https://ochagavia.nl/blog/exploring-rusts-unspecified-drop-order/)
 for more details). Again, this order is closely tied to an implementation that
 we may want to change in the future, and the benefits of stabilizing it seem small.
 Furthermore, enforcing invariants through closure captures seems like a terrible footgun


### PR DESCRIPTION
Website is not accessible on the GitHub.io domain. So change to the current domain.

[Rendered](https://github.com/Jeroendevr/rfcs/blob/patch-1/text/1857-stabilize-drop-order.md)