### PR TITLE
Change use of "UFCS" to "fully-qualified function call syntax"

### DIFF
--- a/text/0132-ufcs.md
+++ b/text/0132-ufcs.md
@@ -4,10 +4,14 @@
 
 # Summary
 
-This RFC describes a variety of extensions to allow any method to be
-used as first-class functions. The same extensions also allow for
-trait methods without receivers to be invoked in a more natural
-fashion.
+This RFC describes the fully-qualified syntax for making function calls,
+which was previously called Unambiguous or Universal Function Call Syntax
+(UFCS). The [Rust Reference section on call expressions] provides
+an overview of this syntax, and reasons for the change in terminology.
+
+There are a variety of extensions to allow any method to be used as
+first-class functions. The same extensions also allow for trait methods
+without receivers to be invoked in a more natural fashion.
 
 First, at present, the notation `path::method()` can be used to invoke
 inherent methods on types. For example, `Vec::new()` is used to create
@@ -210,3 +214,6 @@ to try and change the question:
   type parameter.  But there exists a lot of precedent for the current
   approach and hence I think this is likely a bad idea (not to mention
   that it's a drastic change).
+
+
+[Rust Reference section on call expressions]: https://doc.rust-lang.org/reference/expressions/call-expr.html#disambiguating-function-calls

--- a/text/0255-object-safety.md
+++ b/text/0255-object-safety.md
@@ -70,11 +70,11 @@ where a trait object is used with a generic call and would be something like
 "type error: SomeTrait does not implement SomeTrait" - no indication that the
 non-object-safe method were to blame, only a failure in trait matching.
 
-Another advantage of this proposal is that it implies that all
-method-calls can always be rewritten into an equivalent [UFCS]
-call. This simplifies the "core language" and makes method dispatch
-notation -- which involves some non-trivial inference -- into a kind
-of "sugar" for the more explicit UFCS notation.
+Another advantage of this proposal is that it implies that all method-calls
+can always be rewritten into an equivalent fully-qualified function call
+(see [RFC 132]). This simplifies the "core language" and makes method dispatch
+notation -- which involves some non-trivial inference -- into a kind of
+"sugar" for the more explicit fully-qualified notation.
 
 # Detailed design
 
@@ -212,5 +212,5 @@ N/A
   (2) specify that methods may include `where Self:Sized` to overcome
   object safety restrictions.
 
-[UFCS]: 0132-ufcs.md
+[RFC 132]: 0132-ufcs.md
 [RFC 546]: 0546-Self-not-sized-by-default.md


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rfcs/issues/3360, this PR updates RFC 132 and RFC 255 to use clearer terminology regarding fully-qualified function call syntax, and links to the relevant section of the Rust Reference.