### PR TITLE
Mention that Share was renamed to Sync

### DIFF
--- a/text/0019-opt-in-builtin-traits.md
+++ b/text/0019-opt-in-builtin-traits.md
@@ -2,6 +2,9 @@
 - RFC PR #: [rust-lang/rfcs#19](https://github.com/rust-lang/rfcs/pull/19), [rust-lang/rfcs#127](https://github.com/rust-lang/rfcs/pull/127)
 - Rust Issue #: [rust-lang/rust#13231](https://github.com/rust-lang/rust/issues/13231)
 
+**Note:** The `Share` trait described in this RFC was later
+[renamed to `Sync`](0123-share-to-threadsafe.md).
+
 # Summary
 
 The high-level idea is to add language features that simultaneously


### PR DESCRIPTION
Might make this easier to read for people encountering the RFC now.
