### PR TITLE
Mark Markdown files as linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
This follows the precedent of similar repos such as [`swift-evolution`](https://github.com/apple/swift-evolution/) and makes Markdown show up as the primary language in GitHub's language bar:

<img width="289" alt="image" src="https://user-images.githubusercontent.com/30873659/213943400-193a1caf-4f37-47b4-aa3d-f9e717ecabd8.png">