### PR TITLE
Make rubygems URL a commonmark autolink

### DIFF
--- a/text/2789-sparse-index.md
+++ b/text/2789-sparse-index.md
@@ -80,7 +80,7 @@ The rsync protocol requires scanning and checksumming of source and destination 
 # Prior art
 [prior-art]: #prior-art
 
-https://andre.arko.net/2014/03/28/the-new-rubygems-index-format/
+<https://andre.arko.net/2014/03/28/the-new-rubygems-index-format/>
 
 Bundler used to have a full index fetched ahead of time, similar to Cargo's, until it grew too large. Then it used a centralized query API, until that became too problematic to support. Then it switched to an incrementally downloaded flat file index format similar to the solution proposed here.
 


### PR DESCRIPTION
While GitHub supports implicit URL linkification, mdBook (which is used for <https://rust-lang.github.io/rfcs/2789-sparse-index.html#prior-art>) does not.

[Rendered](https://github.com/rust-lang/rfcs/blob/notriddle/2789-rubygems-link/text/2789-sparse-index.md)