### PR TITLE
Remove the 'kind' field from Item

### DIFF
--- a/text/2963-rustdoc-json.md
+++ b/text/2963-rustdoc-json.md
@@ -261,7 +261,6 @@ Name      | Type    | Description
 `links`   | Map<String, [ID](#ID)> | A map of intra-doc link names to the IDs of the items they resolve to. For example if the `docs` string contained `"see [HashMap][std::collections::HashMap] for more details"` then `links` would have `"std::collections::HashMap": "<some id>"`.
 `attrs`   | [String] | The [unstable](#Unstable) stringified attributes (other than doc comments) on the Item (e.g. `["#[inline]", "#[test]"]`).
 `deprecation` | [Deprecation](#Deprecation) | (*Optional*) Information about the Item's deprecation, if present.
-`kind`    | String  | The kind of Item this is. Determines what fields are in `inner`.
 `inner`   | Object  | The type-specific fields describing this Item. Check the `kind` field to determine what's available.
 
 ### Restricted visibility


### PR DESCRIPTION
The 'kind' field is possibly a duplicate of the 'kind' field in Item Summary.

Also, the presence of the 'kind' field in Item does not match with the relevant source:

https://github.com/rust-lang/rust/blob/b082e80e20475b1ec5b0bd0dd1dac3e6759c8022/src/rustdoc-json-types/lib.rs#L65

[Rendered](https://github.com/mplsgrant/rust-lang-rfcs/blob/mpls-2963-item-kind/text/2963-rustdoc-json.md)