### PR TITLE
fix link message typo in rfc-2789

### DIFF
--- a/text/2789-sparse-index.md
+++ b/text/2789-sparse-index.md
@@ -1,7 +1,7 @@
 - Feature Name: sparse_index
 - Start Date: 2019-10-18
 - RFC PR: [rust-lang/rfcs#2789](https://github.com/rust-lang/rfcs/pull/2789)
-- Tracking Issue: [rust-lang/rust#9069](https://github.com/rust-lang/cargo/issues/9069)
+- Tracking Issue: [rust-lang/cargo#9069](https://github.com/rust-lang/cargo/issues/9069)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
when I refer to the sparse index rfc, I found the tracking issue item has the right link ,  but the error link message, this PR fix it.

[Rendered](https://github.com/wangkirin/rfcs/blob/patch-1/text/2789-sparse-index.md)