### PR TITLE
Add a `[lints]` table to `Cargo.toml`

### DIFF
--- a/text/0000-manifest-lint.md
+++ b/text/0000-manifest-lint.md
@@ -1,0 +1,97 @@
+- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+- Discuss how this impacts the ability to read, understand, and maintain Rust code. Code is read and modified far more often than written; will the proposed feature make code easier to maintain?
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+- If this is a language proposal, could this be done in a library or macro instead? Does the proposed change make Rust code easier or harder to read, understand, and maintain?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the language and project as a whole in a holistic
+way. Try to use this section as a tool to more fully consider all possible
+interactions with the project and language in your proposal.
+Also consider how this all fits into the roadmap for the project
+and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.

--- a/text/0000-manifest-lint.md
+++ b/text/0000-manifest-lint.md
@@ -119,6 +119,8 @@ When running rustc, cargo will transform the lints from `lint = level` to
 `--level lint` and pass them on the command line before `RUSTFLAGS`, allowing
 user configuration to override package configuration.
 
+**Note:** This reserves the lint name `workspace` to allow workspace inheritance.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 

--- a/text/0000-manifest-lint.md
+++ b/text/0000-manifest-lint.md
@@ -152,6 +152,18 @@ We could support platform or feature specific settings, like with
 - We have not yet defined semantics for sharing something like this across a
   workspace
 
+Instead of using workspace inheritance for `[lint]`, we could make it
+workspace-level configuration, like `[patch]` which is automatically applied to
+all workspace members.  However, `[patch]` and friends are because they affect
+the resolver / `Cargo.toml` and so they can only operate at the workspace
+level.  `[lints]` is more like `[dependencies]` in being something that applies
+at the package level but we want shared across workspaces.
+
+Instead of traditional workspace inheritance where there is a single value to
+inherit with `workspace = true`, we could have `[workspace.lints.<preset>]`
+which defines presets and the user could do `lints.<preset> = true`.  The user
+could then name them as they wish to avoid collision with rustc lints.
+
 Instead of the `[package.lints]` table being `lint = "level"`, we could organize
 it around `level = ["lint", ...]` like some other linters do (like
 [ruff](https://beta.ruff.rs/docs/configuration/)) but this works better for

--- a/text/0000-manifest-lint.md
+++ b/text/0000-manifest-lint.md
@@ -136,7 +136,7 @@ Python
   - Format is `level = [lint, ...]`
 - [pylint](https://github.com/PyCQA/pylint/blob/main/examples/pylintrc#L402)
   - Format is `level = [lint, ...]` but the [config file is a reflection of the CLI](https://pylint.pycqa.org/en/latest/user_guide/configuration/index.html)
-- [ruff](https://beta.ruff.rs/docs/configuration/))
+- [ruff](https://beta.ruff.rs/docs/configuration/)
   - Format is `level = [lint, ...]`, likely due to past precedence in ecosystem (see above)
 
 Javascript

--- a/text/0000-manifest-lint.md
+++ b/text/0000-manifest-lint.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Add a `package.lint` table to `Cargo.toml` to configure reporting levels for
+Add a `package.lints` table to `Cargo.toml` to configure reporting levels for
 rustc and other tool lints.
 
 # Motivation
@@ -37,9 +37,9 @@ See also
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-A new `package.lint` table would be added to configure lints:
+A new `package.lints` table would be added to configure lints:
 ```toml
-[package.lint]
+[package.lints]
 unsafe = "forbid"
 ```
 and `cargo` would pass these along as flags to `rustc` and `clippy`.
@@ -47,11 +47,11 @@ and `cargo` would pass these along as flags to `rustc` and `clippy`.
 This would work with
 [RFC 2906 `workspace-deduplicate`](https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html?highlight=2906#):
 ```toml
-[workspace.package.lint]
+[workspace.package.lints]
 unsafe = "forbid"
 
 [package]
-lint = "workspace"
+lints = "workspace"
 ```
 
 ## Documentation Updates
@@ -62,12 +62,12 @@ would be updated to say this works for workspace-inheritance
 
 As a new [`[package]` entry](https://doc.rust-lang.org/cargo/reference/manifest.html#the-package-section):
 
-**The `lint` field**
+**The `lints` field**
 
 Override the default level of lints by assigning them to a new level in a
 table, for example:
 ```toml
-[package.lint]
+[package.lints]
 unsafe = "forbid"
 ```
 
@@ -80,7 +80,7 @@ Supported levels include:
 **Note:** TOML does not support `:` in unquoted keys, requiring tool-specific
 lints to be quoted, like
 ```toml
-[package.lint]
+[package.lints]
 "clippy::enum_glob_use" = "warn"
 ```
 
@@ -88,7 +88,7 @@ lints to be quoted, like
 [reference-level-explanation]: #reference-level-explanation
 
 When parsing a manifest, cargo will resolve workspace inheritance for
-`package.lint.workspace = true` as it does with other fields.
+`package.lints.workspace = true` as it does with other fields.
 
 When running rustc, cargo will transform the lints from `lint = level` to
 `--level lint` and pass them on the command line before `RUSTFLAGS`, allowing
@@ -109,20 +109,22 @@ possibility's", we mention direct support for tying lints to rust versions.
 
 This could be left to `clippy.toml` but that leaves `rustc` without a solution.
 
-`[package.lint]` could be `[lint]` but the lints are tied to the package and
+`[package.lints]` could be `[lints]` but the lints are tied to the package and
 this aligns within the existing design space for workspace inheritance.
 
+`[lints]` could be `[lint]` but we decided to follow the precedence of `[dependencies]`.
+
 We could support platform or feature specific settings, like with
-`[lint.<target>]` or `[target.<target>.lint]` but
+`[lints.<target>]` or `[target.<target>.lints]` but
 - There isn't a defined use case for this yet besides having support for `cfg(feature = "clippy")` or
   which does not seem high enough priority to design
   around.
-- `[lint.<target>]` runs into ambiguity issues around what is a `<target>`
-  entry vs a `<lint>` entry in the `[lint]` table.
+- `[lints.<target>]` runs into ambiguity issues around what is a `<target>`
+  entry vs a `<lint>` entry in the `[lints]` table.
 - We have not yet defined semantics for sharing something like this across a
   workspace
 
-Instead of the `[package.lint]` table being `lint = "level"`, we could organize
+Instead of the `[package.lints]` table being `lint = "level"`, we could organize
 it around `level = ["lint", ...]` like some other linters do (like
 [ruff](https://beta.ruff.rs/docs/configuration/)) but this works better for
 logically organizing lints, highlighting what changed in diffs, and for
@@ -150,8 +152,6 @@ Go
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-Should it be `lint` or `lints`?
-
 How does this affect fingerprinting / recompilation and how should it?
 
 How should we hand rustdoc lint levels or, in the future, cargo lint levels?
@@ -165,12 +165,12 @@ but rustdoc uses `RUSTDOCFLAGS` and cargo would use neither.
 
 We can extend basic lint syntax:
 ```toml
-[package.lint]
+[package.lints]
 cyclomatic_complexity = "allow"
 ```
 to support configuration, whether for cargo or the lint tool:
 ```toml
-[package.lint]
+[package.lints]
 cyclomatic_complexity = { level = "allow", rust-version = "1.23.0", threshold = 30 }
 ```
 Where `rust-version` is used by cargo to determine whether to pass along this

--- a/text/0000-manifest-lint.md
+++ b/text/0000-manifest-lint.md
@@ -16,9 +16,9 @@ Currently, you can configure lints through
 - `#[<level>(<lint>)]` or `#![<level>(<lint>)]`, like `#[forbid(unsafe)]`
   - But this doesn't scale up with additional targets (benches, examples,
     tests) or workspaces
-- On the command line, like `cargo check -- --forbid unsafe`
+- On the command line, like `cargo clippy -- --forbid unsafe`
   - This puts the burden on the caller
-- Through `RUSTFLAGS`, like `RUSTFLAGS=--forbid=unsafe cargo check`
+- Through `RUSTFLAGS`, like `RUSTFLAGS=--forbid=unsafe cargo clippy`
   - This puts the burden on the caller
 - In `.cargo/config.toml`'s `target.*.rustflags`
   - This couples you to the running in specific directories and not running in

--- a/text/0000-manifest-lint.md
+++ b/text/0000-manifest-lint.md
@@ -184,7 +184,9 @@ How does this affect fingerprinting / recompilation and how should it?
 
 How should we hand rustdoc lint levels or, in the future, cargo lint levels?
 The current proposal takes all lints and passes them to rustc like `RUSTFLAGS`
-but rustdoc uses `RUSTDOCFLAGS` and cargo would use neither.
+but rustdoc uses `RUSTDOCFLAGS` and cargo would use neither.  This also starts
+to get into
+[user-defined tool attributes](https://rust-lang.github.io/rfcs/2103-tool-attributes.html).
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-manifest-lint.md
+++ b/text/0000-manifest-lint.md
@@ -1,97 +1,178 @@
-- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Feature Name: `manifest-lint`
+- Start Date: 2023-02-14
 - RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary
 [summary]: #summary
 
-One paragraph explanation of the feature.
+Add a `package.lint` table to `Cargo.toml` to configure reporting levels for
+rustc and other tool lints.
 
 # Motivation
 [motivation]: #motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+Currently, you can configure lints through
+- `#[<level>(<lint>)]` or `#![<level>(<lint>)]`, like `#[forbid(unsafe)]`
+  - But this doesn't scale up with additional targets (benches, examples,
+    tests) or workspaces
+- On the command line, like `cargo check -- --forbid unsafe`
+  - This puts the burden on the caller
+- Through `RUSTFLAGS`, like `RUSTFLAGS=--forbid=unsafe cargo check`
+  - This puts the burden on the caller
+- In `.cargo/config.toml`'s `target.*.rustflags`
+  - This couples you to the running in specific directories and not running in
+    the right directory causes rebuilds
+  - The cargo team has previously stated that
+    [they would like to see package-specific config moved to manifests](https://internals.rust-lang.org/t/proposal-move-some-cargo-config-settings-to-cargo-toml/13336/14?u=epage)
+
+We would like a solution that makes it easier to share across targets and
+packages for all tools.
+
+See also
+- [rust-lang/rust-clippy#1313](https://github.com/rust-lang/rust-clippy/issues/1313)
+- [rust-lang/cargo#5034](https://github.com/rust-lang/cargo/issues/5034)
+- [EmbarkStudios/rust-ecosystem#59](https://github.com/EmbarkStudios/rust-ecosystem/issues/59)
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+A new `package.lint` table would be added to configure lints:
+```toml
+[package.lint]
+unsafe = "forbid"
+```
+and `cargo` would pass these along as flags to `rustc` and `clippy`.
 
-- Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
-- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
-- Discuss how this impacts the ability to read, understand, and maintain Rust code. Code is read and modified far more often than written; will the proposed feature make code easier to maintain?
+This would work with
+[RFC 2906 `workspace-deduplicate`](https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html?highlight=2906#):
+```toml
+[workspace.package.lint]
+unsafe = "forbid"
 
-For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+[package]
+lint = "workspace"
+```
+
+## Documentation Updates
+
+Note:
+[Workspace: The Package Table](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table)
+would be updated to say this works for workspace-inheritance
+
+As a new [`[package]` entry](https://doc.rust-lang.org/cargo/reference/manifest.html#the-package-section):
+
+**The `lint` field**
+
+Override the default level of lints by assigning them to a new level in a
+table, for example:
+```toml
+[package.lint]
+unsafe = "forbid"
+```
+
+Supported levels include:
+- `forbid`
+- `deny`
+- `warn`
+- `allow`
+
+**Note:** TOML does not support `:` in unquoted keys, requiring tool-specific
+lints to be quoted, like
+```toml
+[package.lint]
+"clippy::enum_glob_use" = "warn"
+```
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
+When parsing a manifest, cargo will resolve workspace inheritance for
+`package.lint.workspace = true` as it does with other fields.
 
-- Its interaction with other features is clear.
-- It is reasonably clear how the feature would be implemented.
-- Corner cases are dissected by example.
-
-The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+When running rustc, cargo will transform the lints from `lint = level` to
+`--level lint` and pass them on the command line before `RUSTFLAGS`, allowing
+user configuration to override package configuration.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Why should we *not* do this?
+A concern brought up in
+[rust-lang/rust-clippy#1313](https://github.com/rust-lang/rust-clippy/issues/1313)
+was that this will pass lints unconditionally to the underlying tool, leading
+to "undefined lint" warnings when used on earlier versions, requiring that
+warning to also be suppressed, reducing its value.  However, in the "Future
+possibility's", we mention direct support for tying lints to rust versions.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
-- If this is a language proposal, could this be done in a library or macro instead? Does the proposed change make Rust code easier or harder to read, understand, and maintain?
+This could be left to `clippy.toml` but that leaves `rustc` without a solution.
+
+`[package.lint]` could be `[lint]` but the lints are tied to the package and
+this aligns within the existing design space for workspace inheritance.
+
+We could support platform or feature specific settings, like with
+`[lint.<target>]` or `[target.<target>.lint]` but
+- There isn't a defined use case for this yet besides having support for `cfg(feature = "clippy")` or
+  which does not seem high enough priority to design
+  around.
+- `[lint.<target>]` runs into ambiguity issues around what is a `<target>`
+  entry vs a `<lint>` entry in the `[lint]` table.
+- We have not yet defined semantics for sharing something like this across a
+  workspace
+
+Instead of the `[package.lint]` table being `lint = "level"`, we could organize
+it around `level = ["lint", ...]` like some other linters do (like
+[ruff](https://beta.ruff.rs/docs/configuration/)) but this works better for
+logically organizing lints, highlighting what changed in diffs, and for
+possibly adding lint-specific configuration in the future.
 
 # Prior art
 [prior-art]: #prior-art
 
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
+Python
+- [flake8](https://flake8.pycqa.org/en/latest/user/configuration.html)
+  - Format is `level = [lint, ...]`
+- [pylint](https://github.com/PyCQA/pylint/blob/main/examples/pylintrc#L402)
+  - Format is `level = [lint, ...]` but the [config file is a reflection of the CLI](https://pylint.pycqa.org/en/latest/user_guide/configuration/index.html)
+- [ruff](https://beta.ruff.rs/docs/configuration/))
+  - Format is `level = [lint, ...]`, likely due to past precedence in ecosystem (see above)
 
-- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+Javascript
+- [eslint](https://eslint.org/docs/latest/use/configure/rules)
+  - Format is `lint = level` / `lint = [ level, additional config ]`
 
-This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
-If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
-
-Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
-Please also take into consideration that rust sometimes intentionally diverges from common language features.
+Go
+- [golangci-lint](https://golangci-lint.run/usage/configuration/)
+  - Format is `level = [lint, ...]`
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+Should it be `lint` or `lints`?
+
+How does this affect fingerprinting / recompilation and how should it?
+
+How should we hand rustdoc lint levels or, in the future, cargo lint levels?
+The current proposal takes all lints and passes them to rustc like `RUSTFLAGS`
+but rustdoc uses `RUSTDOCFLAGS` and cargo would use neither.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would
-be and how it would affect the language and project as a whole in a holistic
-way. Try to use this section as a tool to more fully consider all possible
-interactions with the project and language in your proposal.
-Also consider how this all fits into the roadmap for the project
-and of the relevant sub-team.
+## Configurable lints
 
-This is also a good place to "dump ideas", if they are out of scope for the
-RFC you are writing but otherwise related.
-
-If you have tried and cannot think of any future possibilities,
-you may simply state that you cannot think of anything.
-
-Note that having something written down in the future-possibilities section
-is not a reason to accept the current or a future RFC; such notes should be
-in the section on motivation or rationale in this or subsequent RFCs.
-The section merely provides additional information.
+We can extend basic lint syntax:
+```toml
+[package.lint]
+cyclomatic_complexity = "allow"
+```
+to support configuration, whether for cargo or the lint tool:
+```toml
+[package.lint]
+cyclomatic_complexity = { level = "allow", rust-version = "1.23.0", threshold = 30 }
+```
+Where `rust-version` is used by cargo to determine whether to pass along this
+lint and `threshold` is used by the tool.  We'd need to define how to
+distinguish between reserved and unreserved field names.

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -235,16 +235,18 @@ chose `lint` being the keys because
 
 ## Linter Tables vs Linter Namespaces
 
-Instead of `<tool>.<lint>`, we could use `<tool>::<lint>` (e.g.
-`"clipp::enum_glob_use"` instead of `clippy.enum_glob_use`), like in the
-diagnostic messages.  This would make it easier to copy/paste lint names.
-However, with the schema being `<lint> = <level>`, this would require quoting
-the keys rather than leaving them as bare words.  This might also cause
-problems for tool-level configuration.  The first is that the lints wouldn't be
-easily grouped with their tool's config.  The second is if we use `lints.<lint> = <level>`
-and tool-level configuration goes under `lints.<tool>`,
-then keys under `[lints]` are ambiguous as to whether they are a tool or a
-lint, making it harder to collect all lints to forward tools.
+We started off with lints being referenced with their tool as a namespace (e.g.
+`"clipp::enum_glob_use"`) like in diagnostic messages, making copy/paste easy.
+
+However, we switched to a more hierarchical data model (e.g.
+`clippy.enum_glob_use`) to avoid quoting keys with the `lints.<lint> = <level>` schema.
+
+If we add lint/linter config in the future
+- Being more hierarchical means lint and linter config are kept closer to each
+  other, making it easier to evaluate their impact on each other.
+- `lints.<lint> = <level>` combined with `lints.<linter>.metadata` makes it
+  harder for cargo to collect all the lints to pass down into the compiler
+  driver.
 
 ## Lint Precedence
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -320,7 +320,9 @@ Ruby
 Currently Rust tells you where a lint level was enabled when it emits a lint.
 `rustc` only sees that these lints are coming in from the command-line and
 doesn't know about `[lints]`.
-It would be nice if it could also point to Cargo.toml for this.
+It would be nice if it could also point to Cargo.toml for this.  This could be
+as simple as a `--lint-source=Cargo.toml` with rustc knowing just enough about
+the `[lints]` table to process it directly.
 
 ## External file
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -142,8 +142,12 @@ cargo will:
   - These flags will be fingerprinted so changing them will cause a rebuild only
     for the commands where they are used.
 
-Note that this means that `[lints]` does not affect dependencies which is
-normally not an issue due to `--cap-lints` being used for dependencies.
+Note that this means that `[lints]` is only applied to the package where its
+defined and not to its dependencies, local or not.  This avoids having to unify
+`[lints]` tables across local packages.  Normally, lints for non-local
+dependencies won't be shown anyways because of `--cap-lints`.  As for local
+dependencies, they will likely have their own `[lints]` table, most the same
+one, inherited from the workspace.
 
 Initially, the only supported tools will be:
 - `rust`

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -144,6 +144,8 @@ Initially, the only supported tools will be:
 - `clippy`
 - `rustdoc`
 
+A downside to naming the category `rust` is it might be confusing if we ever expose `rustc::` lints.
+
 Addition of third-party tools would fall under their
 [attributes for tools](https://github.com/rust-lang/rust/issues/44690).
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -201,7 +201,10 @@ configuration too general, we would preclude the option of supporting
 per-package overrides as we wouldn't know enough about the shape of the data to
 know how to merge it.  There is likely a middle ground that we could make work
 but it would take time and experimentation to figure that out which is at odds
-with trying to maintain a stable file format.
+with trying to maintain a stable file format.  Another problem with `rules` is
+that it is divorced from any context.  In eslint, it is in an eslint-specific
+config file but a `[rules]` table is not a clear as a `[lints]` table as to
+what role it fulfills.
 
 We could support platform or feature specific settings, like with
 `[lints.<target>]` or `[target.<target>.lints]` but

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -135,7 +135,8 @@ cargo will:
   - Leaving off the `tool::` when it is `rust`
   - cargo will error if `lint` contains `::` as the first part is assumed to be
     a tool and it should be listed in that tool's table
-2. Sort them by priority and then lint name
+2. Sort them by priority and then an unspecified order within priority that we may change in the [future](#future-possibilities).
+  - On initial release, the sort will likely be reverse alphabetical which would cause `all` to be last, making it unlikely to do what the user wants which would raise awareness of the need for setting `priority` for all groups.
 3. Pass them on the command line before other configuration like
 `RUSTFLAGS`, allowing user configuration to override package configuration.
   - These flags will be fingerprinted so changing them will cause a rebuild only
@@ -350,6 +351,32 @@ Ruby
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
+
+## Help the user with `priority`
+
+When running linters through cargo, we could warn the user when there is ambiguity, including
+- A group and a lint at the same priority
+- A group that is a superset of another group at the same priority
+- Two intersecting groups at the same priority
+- A lint or group that is masked by a group in a later priority
+
+We could then take this a step further and change the way we sort within a
+priority level to put the most specific entry last, where ambiguity doesn't
+exist.  This would nearly eliminate the need for specifying `priority` with the
+current groups.
+
+We specifically recommend warning, rather than error, so groups can evolve to
+become intersecting without it being a breaking change.
+
+To implement this, either cargo needs to pass the lints down to the tool in a
+way to communicate the priority batches, allow cargo to query the group
+memberships from the linter, or we hard code this at compile-time like
+rust-analyzer
+([lints](https://rust-lang.github.io/rust-clippy/master/lints.json),
+[generate](https://github.com/rust-lang/rust-analyzer/blob/a6464392c15fa8788215d669c4c0b1e46bcadeea/crates/ide-db/src/tests/sourcegen_lints.rs)).
+One thing to keep in mind is the potential for [custom
+tools](https://rust-lang.github.io/rfcs/2103-tool-attributes.html) in the
+future.
 
 ## rustc reporting `Cargo.toml` as lint-level source
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -238,7 +238,7 @@ could then name them as they wish to avoid collision with rustc lints.
 
 ## Lint Predence
 
-The priority field is meant to allow mimicing
+The priority field is meant to allow mimicking
 - `-Aclippy::all -Wclippy::doc_markdown`
 - `-D future-incompatible -A semicolon_in_expressions_from_macros`
 
@@ -252,17 +252,17 @@ Unconfigurable:
 ```toml
 [lints]
 clippy = [
-  { all = "Alow" },
-  { doc_markdown = "Worn" },
+  { all = "allow" },
+  { doc_markdown = "worn" },
 ]
 ```
 
 Configurable:
 ```toml
 [[lints.clippy.all]]
-level = "Alow"
+level = "allow"
 [[lints.clippy.doc_markdown]]
-level = "Worn"
+level = "worn"
 ```
 Where the order is based on how to pass them on the command-line.
 
@@ -274,7 +274,7 @@ with a `priority: bool` field.  This might get confusing to mix with numbers
 though (what does `false` and `true` map to?).  There is also the problem that
 generally people will want to opt a specific lint into being low-priority (the
 group) and the leave the exceptions at default but making `priority = true` the
-default would read weird (everything is a priorty but one or two items).
+default would read weird (everything is a priority but one or two items).
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -229,7 +229,7 @@ chose `lint` being the keys because
 - TOML isn't great for nesting complex data structures and we have allow a
   `priority` field and might allo other lint-level configuration.  Organizing
   around `lint` makes this cleaner.
-- If we add support for packages overiding inherited workspace lints, it likely
+- If we add support for packages overriding inherited workspace lints, it likely
   better maps to a users model to just say the package lint table gets merged
   into the workspace lint table.  This is also easier to implement correctly.
 
@@ -271,7 +271,7 @@ subsets or disjoint of each other to avoid ambiguity.  While this might hold
 today, I'm a bit cautious of putting this requirement on us forever.  For
 example, if we merged `cargo semver-check`, there are proposed lint groups
 based on what a lint's user-overideable semver-level is which couldn't be
-guarenteed to meet these requirements.  On the implementation side, this will
+guaranteed to meet these requirements.  On the implementation side, this will
 require a new channel to communicate these lints to the tools (unless we infer
 order for flags/config as well) and require them to organize their data in a
 way for it to inferred.

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -150,7 +150,7 @@ Instead of using `::` as a separator between tool and lint (e.g.
 `clippy::enum_glob_use`), we could use TOML dotted keys for this (e.g.
 `clippy.enum_glob_use`).  This has the advantage of allowing unquoted keys at
 the cost of not being able to copy/paste the lint name from the tool's output
-into the fileV
+into the file.
 
 We could support platform or feature specific settings, like with
 `[lints.<target>]` or `[target.<target>.lints]` but
@@ -218,7 +218,7 @@ allowing them to change without forcing a rebuild.  We likely already need to
 be tool-aware for built-in tools to handle `rustdoc::` lints (see above) so
 this isn't much more of a step.
 
-How do we allow controling precedence between lints and lint groups?  We are
+How do we allow controlling precedence between lints and lint groups?  We are
 using a TOML table with the keys as lint names which does not allow controlling
 ordering.  Even if we switched to `level = [lint, ...]`, you get a hard coded
 precedence between levels that the user can't control.

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -388,8 +388,9 @@ plans for clippy itself.
 Currently, it is a hard error to mix `workspace = true` and lints.  We could
 open this up in the future for the package to override lints from the
 workspace.  This would not be a breaking change as we'd be changing an error
-case into a working case.  We'd need to ensure we had a path forward for the
-semantics for configurable lints.
+case into a working case.  We should consider the possibility of adding
+configurable lints in the future and what that would look like with
+overridin of lints.
 
 ## Extending the syntax to `.cargo/config.toml`
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -71,7 +71,7 @@ unsafe = "forbid"
 This is short-hand for:
 ```toml
 [lints.rust]
-unsafe = { level = "forbid", priority = 1 }
+unsafe = { level = "forbid", priority = 0 }
 ```
 
 `level` corresponds to the lint levels in `rustc`:
@@ -80,8 +80,10 @@ unsafe = { level = "forbid", priority = 1 }
 - `warn`
 - `allow`
 
-`priority` controls which lints override other lints:
-- `0` is lowest priority, being overridden by all, and shows up first on the command-line to tools like `rustc`
+`priority` is a signed value that controls which lints override other lints:
+- lower (particularly negative) numbers have lower priority, being overridden
+  by higher numbers, and shows up first on the command-line to tools like
+  `rustc`
 
 To know which table under `[lints]` a particular lint belongs under, it is the part before `::` in the lint
 name.  If there isn't a `::`, then the tool is `rust`.  For example a warning

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -1,7 +1,7 @@
 - Feature Name: `manifest-lint`
 - Start Date: 2023-02-14
 - RFC PR: [rust-lang/rfcs#3389](https://github.com/rust-lang/rfcs/pull/3389)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- Tracking Issue: [rust-lang/cargo#12115](https://github.com/rust-lang/cargo/issues/12115)
 
 # Summary
 [summary]: #summary

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -267,3 +267,12 @@ Similar to `profile` and `patch` being in both files, we could support
 `[lints]` in both files.  This allows more flexibility for experimentation with
 this feature, like conditionally applying them or applying them via environment
 variables.  For now, users still have the option of using `rustflags`.
+
+## Cargo Lints
+
+The cargo team has expressed interest in producing warnings for more situations
+but this requires defining a lint control system for it.  The overhead of doing
+so has detered people from adding additional warnings.  This would provide an
+MVP for controlling cargo lints, unblocking the cargo team from adding more
+warnings.  This just leaves the question of whether these belong more in cargo
+or in clippy which already has some cargo-specific lints.

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -80,7 +80,7 @@ unsafe = { level = "forbid", priority = 0 }
 - `warn`
 - `allow`
 
-`priority` is a signed value that controls which lints override other lints:
+`priority` is a signed value that controls which lints or lint groups override other lint groups:
 - lower (particularly negative) numbers have lower priority, being overridden
   by higher numbers, and shows up first on the command-line to tools like
   `rustc`

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -205,9 +205,13 @@ and other fields that are more workspace related.  Instead, we used
 
 Instead of `<tool>.<lint>`, we could use `<tool>::<lint>` (e.g.
 `"clipp::enum_glob_use"` instead of `clippy.enum_glob_use`), like in the
-diagnostic messages.  This would make it easier to copy/paste lint names but it
-will requiring quoting the keys and is more difficult to add tool-level
-configuration in the future.
+diagnostic messages.  This would make it easier to copy/paste lint names.
+However, with the schema being `<lint> = <level>`, this would require quoting
+the keys rather than leaving them as bare words.  This would also cause
+problems for tool-level configuration.  The first is that the lints wouldn't be
+easily grouped with their config.  The second is if we use `<lint> = <level>`,
+we'd be mixing tool names in with lints, making it easier to conflict and
+harder to collect all lints to forward to a tool.
 
 We could possibly extend this new field to `rustfmt` by shifting the focus from
 "lints" to "rules" (see

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -362,6 +362,9 @@ Similar to `profile` and `patch` being in both files, we could support
 this feature, like conditionally applying them or applying them via environment
 variables.  For now, users still have the option of using `rustflags`.
 
+In doing so, we would need to define how `priority` interacts with different
+sources of `[lints]`.
+
 ## Cargo Lints
 
 The cargo team has expressed interest in producing warnings for more situations

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -140,7 +140,9 @@ cargo will:
 3. Pass them on the command line before other configuration like
 `RUSTFLAGS`, allowing user configuration to override package configuration.
   - These flags will be fingerprinted so changing them will cause a rebuild only
-    for the commands where they are used.
+    for the commands where they are used.  By only including the lints for the
+    command in question, we reduce what is fingerprinted, reducing what gets
+    rebuilt when `[lints]` is changed.
 
 Note that this means that `[lints]` is only applied to the package where its
 defined and not to its dependencies, local or not.  This avoids having to unify

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -80,9 +80,9 @@ unsafe = { level = "forbid", priority = 0 }
 - `warn`
 - `allow`
 
-`priority` is a signed value that controls which lints or lint groups override other lint groups:
+`priority` is a signed integer that controls which lints or lint groups override other lint groups:
 - lower (particularly negative) numbers have lower priority, being overridden
-  by higher numbers, and shows up first on the command-line to tools like
+  by higher numbers, and show up first on the command-line to tools like
   `rustc`
 
 To know which table under `[lints]` a particular lint belongs under, it is the part before `::` in the lint
@@ -170,7 +170,7 @@ A concern brought up in
 was that this will pass lints unconditionally to the underlying tool, leading
 to "undefined lint" warnings when used on earlier versions, requiring that
 warning to also be suppressed, reducing its value.  However, in the "Future
-possibility's", we mention direct support for tying lints to rust versions.
+possibilities" section, we mention direct support for tying lints to rust versions.
 
 This does not allow sharing lints across workspaces.
 
@@ -236,7 +236,7 @@ inherit with `workspace = true`, we could have `[workspace.lints.<preset>]`
 which defines presets and the user could do `lints.<preset> = true`.  The user
 could then name them as they wish to avoid collision with rustc lints.
 
-## Lint Predence
+## Lint Precedence
 
 The priority field is meant to allow mimicking
 - `-Aclippy::all -Wclippy::doc_markdown`

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -308,6 +308,13 @@ Ruby
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
+## rustc reporting `Cargo.toml` as lint-level source
+
+Currently Rust tells you where a lint level was enabled when it emits a lint.
+`rustc` only sees that these lints are coming in from the command-line and
+doesn't know about `[lints]`.
+It would be nice if it could also point to Cargo.toml for this.
+
 ## External file
 
 Like with `package.license`, users might want to refer to an external file for

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -207,11 +207,12 @@ Instead of `<tool>.<lint>`, we could use `<tool>::<lint>` (e.g.
 `"clipp::enum_glob_use"` instead of `clippy.enum_glob_use`), like in the
 diagnostic messages.  This would make it easier to copy/paste lint names.
 However, with the schema being `<lint> = <level>`, this would require quoting
-the keys rather than leaving them as bare words.  This would also cause
+the keys rather than leaving them as bare words.  This might also cause
 problems for tool-level configuration.  The first is that the lints wouldn't be
-easily grouped with their config.  The second is if we use `<lint> = <level>`,
-we'd be mixing tool names in with lints, making it easier to conflict and
-harder to collect all lints to forward to a tool.
+easily grouped with their tool's config.  The second is if we use `lints.<lint> = <level>`
+and tool-level configuration goes under `lints.<tool>`,
+then keys under `[lints]` are ambiguous as to whether they are a tool or a
+lint, making it harder to collect all lints to forward tools.
 
 We could possibly extend this new field to `rustfmt` by shifting the focus from
 "lints" to "rules" (see

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -466,6 +466,11 @@ Ruby
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
+Blocking for stablization
+- Are we still comfortable with our schema choice?
+- Are we still comfortable with our precedence choice?
+- Can we fingerprint only the lints for the tool being run?
+
 # Future possibilities
 [future-possibilities]: #future-possibilities
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -196,7 +196,17 @@ This does not allow sharing lints across workspaces.
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-This could be left to `clippy.toml` but that leaves `rustc` without a solution.
+When designing this, we wanted to keep in mind how things work today, including
+- `clippy` defines all configuration as linter/tool config and not lint config (linter/lint config is a future possibility)
+- All `clippy` lints are disjoint
+- `rustdoc` has no plans for groups outside of `all`
+- `rustc` today has some intersecting groups
+
+However, we also need to consider how decisions might limit us in the future and whether we want to bind future decisions with this RFC, including
+- Whether existing decisions will be revisited
+- When new tools are added, like `cargo` and `cargo-semver-check`, which haven't had lint levels and configuration long enough (or at all) to explore their problem and design space.
+
+This could be left to `clippy.toml` but that leaves `rustc`, `rustdoc`, and future linters without a solution.
 
 `[lints]` could be `[package.lints]`, tying it to the package unlike `[patch]`
 and other fields that are more workspace related.  Instead, we used

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -317,7 +317,7 @@ Python
 - [pylint](https://github.com/PyCQA/pylint/blob/main/examples/pylintrc#L402)
   - Format is `level = [lint, ...]` but the [config file is a reflection of the CLI](https://pylint.pycqa.org/en/latest/user_guide/configuration/index.html)
 - [ruff](https://beta.ruff.rs/docs/configuration/)
-  - Format is `level = [lint, ...]`, likely due to past precedence in ecosystem (see above)
+  - Format is `level = [lint, ...]`, due to past precedence in ecosystem (see above)
 
 Javascript
 - [eslint](https://eslint.org/docs/latest/use/configure/rules)

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -155,7 +155,7 @@ higher-level cargo-plugins despite that configuration (like `package.edition`)
 being cargo-specific.  By baking the configuration for rustc, rustdoc, and
 clippy directly into cargo, we will be seeing more of this.  A hope is that
 this will actually improve with this RFC.  Over time, tools will need to switch
-to the model of running `cargo` to get confuguratio in response to this RFC.
+to the model of running `cargo` to get configuration in response to this RFC.
 As for users, if a tool's primary configuration is in `Cargo.toml`, that will
 provide a strong coupling with `cargo` in users minds as compared to using an
 external configuration file and overlooking the one or two fields read from

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -149,7 +149,10 @@ Initially, the only supported tools will be:
 - `clippy`
 - `rustdoc`
 
-A downside to naming the category `rust` is it might be confusing if we ever expose `rustc::` lints.
+The reason for `rust` existing, despite lints not being prefixed with `rust::`, is
+to avoid ambiguity in the data model between `lint.<lint>` and
+`lint.<tool>.<lint>`.  A downside to naming the tool `rust` is it might be
+confusing if we ever expose `rustc::` lints.
 
 Addition of third-party tools would fall under their
 [attributes for tools](https://github.com/rust-lang/rust/issues/44690).

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -260,6 +260,17 @@ generally people will want to opt a specific lint into being low-priority (the
 group) and the leave the exceptions at default but making `priority = true` the
 default would read weird (everything is a priority but one or two items).
 
+We could pass this to the tool and say "you figure it out" based on which is
+the most specific and least specific.  This requires lint groups to be
+subsets or disjoint of each other to avoid ambiguity.  While this might hold
+today, I'm a bit cautious of putting this requirement on us forever.  For
+example, if we merged `cargo semver-check`, there are proposed lint groups
+based on what a lint's user-overideable semver-level is which couldn't be
+guarenteed to meet these requirements.  On the implementation side, this will
+require a new channel to communicate these lints to the tools (unless we infer
+order for flags/config as well) and require them to organize their data in a
+way for it to inferred.
+
 We could use an array instead of a table:
 
 Unconfigurable:

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -169,7 +169,7 @@ dependencies.  This may cause some user confusion.
 There has been some user/IDE confusion about running commands like `rustfmt`
 directly and expecting them to pick up configuration only associated with their
 higher-level cargo-plugins despite that configuration (like `package.edition`)
-being cargo-specific.  By baking the configuration for rustc, rustdoc, and
+being cargo-specific.  By baking the configured lint levels for rustc, rustdoc, and
 clippy directly into cargo, we will be seeing more of this.  A hope is that
 this will actually improve with this RFC.  Over time, tools will need to switch
 to the model of running `cargo` to get configuration in response to this RFC.

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -183,6 +183,9 @@ possibly adding lint-specific configuration in the future.
 # Prior art
 [prior-art]: #prior-art
 
+Rust
+- [cargo cranky](https://github.com/ericseppanen/cargo-cranky)
+
 Python
 - [flake8](https://flake8.pycqa.org/en/latest/user/configuration.html)
   - Format is `level = [lint, ...]`

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -231,6 +231,12 @@ precedence between levels that the user can't control.
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
+## External file
+
+Like with `package.license`, users might want to refer to an external file for
+their lints.  This especially becomes useful for copy/pasting lints between
+projects.
+
 ## Configurable lints
 
 We can extend basic lint syntax:

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -129,12 +129,15 @@ package override the workspace on a lint-by-lint basis.
 
 cargo will contain a mapping of tool to underlying command (e.g. `rust` to
 `rustc`, `clippy` to `rustc` when clippy is the driver, `rustdoc` to
-`rustdoc`).  When running the underlying command, cargo will transform the
-lints from `lint = level` to `--level lint`, sort them by priority and then
-lint name, and pass them on the command line before other configuration,
-`RUSTFLAGS`, allowing user configuration to override package configuration.
-These flags will be fingerprinted so changing them will cause a rebuild only
-for the commands where they are used.
+`rustdoc`).  When running the underlying command for the specified package,
+cargo will transform the lints from `lint = level` to `--level lint`, sort them
+by priority and then lint name, and pass them on the command line before other
+configuration, `RUSTFLAGS`, allowing user configuration to override package
+configuration.  These flags will be fingerprinted so changing them will cause a
+rebuild only for the commands where they are used.
+
+Note that this means that `[lints]` does not affect dependencies which is
+normally not an issue due to `--cap-lints` being used for dependencies.
 
 Initially, the only supported tools will be:
 - `rust`
@@ -148,6 +151,10 @@ Addition of third-party tools would fall under their
 
 # Drawbacks
 [drawbacks]: #drawbacks
+
+Since `[lints]` only affects the associated package, and not dependencies, it
+will not work with `future-incompat` lints that are meant to be applied to
+dependencies.  This may cause some user confusion.
 
 There has been some user/IDE confusion about running commands like `rustfmt`
 directly and expecting them to pick up configuration only associated with their
@@ -361,6 +368,9 @@ Similar to `profile` and `patch` being in both files, we could support
 `[lints]` in both files.  This allows more flexibility for experimentation with
 this feature, like conditionally applying them or applying them via environment
 variables.  For now, users still have the option of using `rustflags`.
+
+We would need to define whether this only affects local packages as-if the user
+set it in `Cargo.toml` or if it also affects dependencies.
 
 In doing so, we would need to define how `priority` interacts with different
 sources of `[lints]`.

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -260,7 +260,7 @@ Unconfigurable:
 [lints]
 clippy = [
   { all = "allow" },
-  { doc_markdown = "worn" },
+  { doc_markdown = "warn" },
 ]
 ```
 
@@ -269,7 +269,7 @@ Configurable:
 [[lints.clippy.all]]
 level = "allow"
 [[lints.clippy.doc_markdown]]
-level = "worn"
+level = "warn"
 ```
 Where the order is based on how to pass them on the command-line.
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -199,6 +199,10 @@ Go
 - [golangci-lint](https://golangci-lint.run/usage/configuration/)
   - Format is `level = [lint, ...]`
 
+Ruby
+- [rubocop](https://docs.rubocop.org/rubocop/1.45/configuration.html)
+  - Format is `Lint: Enabled: true`
+
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -119,7 +119,7 @@ When parsing a manifest, cargo will resolve workspace inheritance for
 When running rustc, cargo will transform the lints from `lint = level` to
 `--level lint` and pass them on the command line before `RUSTFLAGS`, allowing
 user configuration to override package configuration.  These flags will be
-finterprinted so changing them will cause a rebuild.
+fingerprinted so changing them will cause a rebuild.
 
 **Note:** This reserves the lint name `workspace` to allow workspace inheritance.
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -114,7 +114,9 @@ workspace = true
 [reference-level-explanation]: #reference-level-explanation
 
 When parsing a manifest, cargo will resolve workspace inheritance for
-`lints.workspace = true` as it does with other fields.
+`lints.workspace = true` as it does with basic fields, when `workspace` is
+present, no other fields are allowed to be present.  This precludes having the
+package override the workspace on a lint-by-lint basis.
 
 When running rustc, cargo will transform the lints from `lint = level` to
 `--level lint` and pass them on the command line before `RUSTFLAGS`, allowing
@@ -244,6 +246,14 @@ cyclomatic_complexity = { level = "allow", rust-version = "1.23.0", threshold = 
 Where `rust-version` is used by cargo to determine whether to pass along this
 lint and `threshold` is used by the tool.  We'd need to define how to
 distinguish between reserved and unreserved field names.
+
+## Packages overriding inherited lints
+
+Currently, it is a hard error to mix `workspace = true` and lints.  We could
+open this up in the future for the package to override lints from the
+workspace.  This would not be a breaking change as we'd be changing an error
+case into a working case.  We'd need to ensure we had a path forward for the
+semantics for configurable lints.
 
 ## Extending the syntax to `.cargo/config.toml`
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -240,9 +240,18 @@ We could support platform or feature specific settings, like with
 
 Instead of the `[lints]` table being `lint = "level"`, we could organize
 it around `level = ["lint", ...]` like some other linters do (like
-[ruff](https://beta.ruff.rs/docs/configuration/)) but this works better for
-logically organizing lints, highlighting what changed in diffs, and for
-possibly adding lint-specific configuration in the future.
+[ruff](https://beta.ruff.rs/docs/configuration/)).  This is less verbose.  We
+chose `lint` being the keys because
+- Most reasons for organizing around `level` are preference from which ecosystem they came from (Python vs JS)
+- Organizing around `lint` makes it harder to lose track of what section you
+  are in for large lint lists (which exist), people do with dependency tables
+  today
+- TOML isn't great for nesting complex data structures and we have allow a
+  `priority` field and might allo other lint-level configuration.  Organizing
+  around `lint` makes this cleaner.
+- If we add support for packages overiding inherited workspace lints, it likely
+  better maps to a users model to just say the package lint table gets merged
+  into the workspace lint table.  This is also easier to implement correctly.
 
 ## Workspace Inheritance
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -143,7 +143,7 @@ higher-level cargo-plugins despite that configuration (like `package.edition`)
 being cargo-specific.  By baking the configuration for rustc, rustdoc, and
 clippy directly into cargo, we will be seeing more of this.  A hope is that
 this will actually improve with this RFC.  Over time, tools will need to switch
-to the model of runnign `cargo` to get confuguratio in response to this RFC.
+to the model of running `cargo` to get confuguratio in response to this RFC.
 As for users, if a tool's primary configuration is in `Cargo.toml`, that will
 provide a strong coupling with `cargo` in users minds as compared to using an
 external configuration file and overlooking the one or two fields read from

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -198,7 +198,7 @@ This does not allow sharing lints across workspaces.
 
 When designing this, we wanted to keep in mind how things work today, including
 - `clippy` defines all configuration as linter/tool config and not lint config (linter/lint config is a future possibility)
-- All `clippy` lints are disjoint
+- All `clippy` lint groups are disjoint
 - `rustdoc` has no plans for groups outside of `all`
 - `rustc` today has some intersecting groups
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -253,6 +253,9 @@ Where `rust-version` is used by cargo to determine whether to pass along this
 lint and `threshold` is used by the tool.  We'd need to define how to
 distinguish between reserved and unreserved field names.
 
+`cargo metadata` would need to report the `lints` table so `clippy` could read
+it without re-implementing workspace inheritance.
+
 ## Packages overriding inherited lints
 
 Currently, it is a hard error to mix `workspace = true` and lints.  We could

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -259,9 +259,9 @@ clippy = [
 
 Configurable:
 ```toml
-[[lints.clippy.all]
+[[lints.clippy.all]]
 level = "Alow"
-[[lints.clippy.doc_markdown]
+[[lints.clippy.doc_markdown]]
 level = "Worn"
 ```
 Where the order is based on how to pass them on the command-line.

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -180,7 +180,8 @@ external configuration file and overlooking the one or two fields read from
 
 As this focuses on lints, this leaves out first-party tools that need
 configuration but aren't linters, namely `rustfmt`, leading to an inconsistent
-experience if `clippy.toml` goes away.
+experience if `clippy.toml` goes away in the future (if we act on the future
+possibility of supporting linter configuration)
 
 A concern brought up in
 [rust-lang/rust-clippy#1313](https://github.com/rust-lang/rust-clippy/issues/1313)

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -378,6 +378,11 @@ avoid-breaking-exported-api = true
 Tools will need `cargo metadata` to report the `lints` table so they can read
 it without re-implementing workspace inheritance.
 
+**Note:** At this time, there is no lint configuration for clippy, just tool
+configuration.  `lints.clippy.cyclomatic_complexity` exists for illustrative
+purposes of what linters could support and is not indicative of any future
+plans for clippy itself.
+
 ## Packages overriding inherited lints
 
 Currently, it is a hard error to mix `workspace = true` and lints.  We could

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -130,11 +130,16 @@ package override the workspace on a lint-by-lint basis.
 cargo will contain a mapping of tool to underlying command (e.g. `rust` to
 `rustc`, `clippy` to `rustc` when clippy is the driver, `rustdoc` to
 `rustdoc`).  When running the underlying command for the specified package,
-cargo will transform the lints from `lint = level` to `--level lint`, sort them
-by priority and then lint name, and pass them on the command line before other
-configuration, `RUSTFLAGS`, allowing user configuration to override package
-configuration.  These flags will be fingerprinted so changing them will cause a
-rebuild only for the commands where they are used.
+cargo will:
+1. Transform the lints from `tool.lint = level` to `--level tool::lint`
+  - Leaving off the `tool::` when it is `rust`
+  - cargo will error if `lint` contains `::` as the first part is assumed to be
+    a tool and it should be listed in that tool's table
+2. Sort them by priority and then lint name
+3. Pass them on the command line before other configuration like
+`RUSTFLAGS`, allowing user configuration to override package configuration.
+  - These flags will be fingerprinted so changing them will cause a rebuild only
+    for the commands where they are used.
 
 Note that this means that `[lints]` does not affect dependencies which is
 normally not an issue due to `--cap-lints` being used for dependencies.

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -226,6 +226,11 @@ using a TOML table with the keys as lint names which does not allow controlling
 ordering.  Even if we switched to `level = [lint, ...]`, you get a hard coded
 precedence between levels that the user can't control.
 
+What does this mean for rustfmt?  If this feature slowly absorbs the role of
+`clippy.toml`, a `rustfmt.toml` file might stick out like a sore thumb.  Do we
+accept that, shoe-horn it in, generalize this feature into "tools" and "rules"
+from "linters" and "lints"?
+
 # Future possibilities
 [future-possibilities]: #future-possibilities
 

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -116,10 +116,21 @@ When parsing a manifest, cargo will resolve workspace inheritance for
 present, no other fields are allowed to be present.  This precludes having the
 package override the workspace on a lint-by-lint basis.
 
-When running rustc, cargo will transform the lints from `lint = level` to
-`--level lint` and pass them on the command line before `RUSTFLAGS`, allowing
-user configuration to override package configuration.  These flags will be
-fingerprinted so changing them will cause a rebuild.
+cargo will contain a mapping of tool to underlying command (e.g. `rust` to
+`rustc`, `clippy` to `rustc` when clippy is the driver, `rustdoc` to
+`rustdoc`).  When running the underlying command, cargo will transform the
+lints from `lint = level` to `--level lint` and pass them on the command line
+before other configuration, `RUSTFLAGS`, allowing user configuration to
+override package configuration.  These flags will be fingerprinted so changing
+them will cause a rebuild.
+
+Initially, the only supported tools will be:
+- `rust`
+- `clippy`
+- `rustdoc`
+
+Addition of third-party tools would fall under their
+[attributes for tools](https://github.com/rust-lang/rust/issues/44690).
 
 **Note:** This reserves the tool name `workspace` to allow workspace inheritance.
 
@@ -208,12 +219,6 @@ Ruby
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
-
-How should we hand rustdoc lint levels or, in the future, cargo lint levels?
-The current proposal takes all lints and passes them to rustc like `RUSTFLAGS`
-but rustdoc uses `RUSTDOCFLAGS` and cargo would use neither.  This also starts
-to get into
-[user-defined tool attributes](https://rust-lang.github.io/rfcs/2103-tool-attributes.html).
 
 Should we only apply/fingerprint lints for the appropriate tool?  For example,
 we would not include and fingerprint `clippy::` lints when running builds,

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -249,9 +249,16 @@ The priority field is meant to allow mimicking
 - `-Aclippy::all -Wclippy::doc_markdown`
 - `-D future-incompatible -A semicolon_in_expressions_from_macros`
 
-We can't order lints based on the level as which we want first is dependent on the context.
+We can't order lints based on the `level` as which we want first is dependent on the context (see above).
 
 We can't rely on the order of the keys in the table as that is undefined in TOML.
+
+For the most part, people won't need granularity, so we could instead start
+with a `priority: bool` field.  This might get confusing to mix with numbers
+though (what does `false` and `true` map to?).  There is also the problem that
+generally people will want to opt a specific lint into being low-priority (the
+group) and the leave the exceptions at default but making `priority = true` the
+default would read weird (everything is a priority but one or two items).
 
 We could use an array instead of a table:
 
@@ -275,13 +282,6 @@ Where the order is based on how to pass them on the command-line.
 
 Complex TOML arrays tend to be less friendly to work with including the fact
 that TOML 1.0 does not allow multi-line inline tables.
-
-For the most part, people won't need granularity, so we could instead start
-with a `priority: bool` field.  This might get confusing to mix with numbers
-though (what does `false` and `true` map to?).  There is also the problem that
-generally people will want to opt a specific lint into being low-priority (the
-group) and the leave the exceptions at default but making `priority = true` the
-default would read weird (everything is a priority but one or two items).
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -1,6 +1,6 @@
 - Feature Name: `manifest-lint`
 - Start Date: 2023-02-14
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3389](https://github.com/rust-lang/rfcs/pull/3389)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -43,7 +43,7 @@ A new `lints` table would be added to configure lints:
 [lints.rust]
 unsafe = "forbid"
 ```
-and `cargo` would pass these along as flags to `rustc` and `clippy`.
+and `cargo` would pass these along as flags to `rustc`, `clippy`, or other lint tools.
 
 This would work with
 [RFC 2906 `workspace-deduplicate`](https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html?highlight=2906#):

--- a/text/3389-manifest-lint.md
+++ b/text/3389-manifest-lint.md
@@ -51,7 +51,7 @@ This would work with
 [lints]
 workspace = true
 
-[workspace.lints]
+[workspace.lints.rust]
 unsafe = "forbid"
 ```
 


### PR DESCRIPTION
This proposal is trying to make it easier managing project-specific lint overrides.

[Rendered](https://github.com/epage/rfcs/blob/lints/text/3389-manifest-lint.md)

