### PR TITLE
Guaranteed TCO

### DIFF
--- a/text/0000-guaranteed-tco.md
+++ b/text/0000-guaranteed-tco.md
@@ -141,17 +141,17 @@ The section should return to the examples given in the previous section, and exp
 
 Why should we *not* do this?
 
-As this feature should be mostly independent from other features the main drawback lies in the implementation and maintenance effort. This feature adds a new keyword which will need to be implemented not only in Rust but also in other tooling. The main effort, however, lies in supporting this feature in the backends:
+As this feature should be mostly independent from other features the main drawback lies in the implementation and maintenance effort. This feature adds a new keyword which will need to be implemented not only in Rust but also in other tooling. The primary effort, however, lies in supporting this feature in the backends:
 - LLVM supports a `musttail` marker to indicate that TCO should be performed [docs](https://llvm.org/docs/LangRef.html#id327). Clang which already depends on this feature, seems to only generate correct code for the x86 backend [source](https://github.com/rust-lang/rfcs/issues/2691#issuecomment-1490009983) (as of 30.03.23).
 - GCC does not support a equivalent `musttail` marker.
 - WebAssembly accepted tail-calls into the [standard](https://github.com/WebAssembly/proposals/pull/157/) and Cranelift is now [working](https://github.com/bytecodealliance/rfcs/pull/29) towards supporting it.
 
-Additionally, this proposal is limited to exactly matching function signatures which will *not* allow general tail-calls, however, the work towards this initial version could be used for a more comprehensive version.
+Additionally, this proposal is limited to exactly matching function signatures which will *not* allow general tail-calls, however, the work towards this initial version is likely to be useful for a more comprehensive version.
 
 There is also a unwanted interaction between TCO and debugging. As TCO by design elides stack frames this information is lost during debugging, that is the parent functions and their local variable values are incomplete. As TCO provides a semantic guarantee of constant stack usage it is also not generally possible to disable TCO for debugging builds as then the stack could overflow. (Still maybe a compiler flag could be provided to temporarily disable TCO for debugging builds.)
 
 
-# TODO Rationale and alternatives
+# Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 ## Why is this design the best in the space of possible designs?
@@ -197,9 +197,12 @@ This would be a error prone and unergonomic approach to solving this problem.
 
 
 ## What is the impact of not doing this?
-- https://github.com/rust-lang/rust/issues/102952
-- Clang has support, this feature would restore this deficit parity
-- 
+One goal of Rust is to ([source](https://blog.rust-lang.org/inside-rust/2022/04/04/lang-roadmap-2024.html)):
+> Rust's goal is to empower everyone to build reliable and efficient software.
+This feature provides a crucial optimization for some low level code. It seems that without this feature there is a [big incentive](https://github.com/rust-lang/rust/issues/102952) to use other system level languages that can perform TCO.
+
+Additionally, this feature enables recursive algorithms that require TCO, which would provide better support for functional programming in Rust. 
+
 
 ## If this is a language proposal, could this be done in a library or macro instead? Does the proposed change make Rust code easier or harder to read, understand, and maintain?
 While there exist libraries for a trampoline based method to avoid growing the stack, this is not enough to achieve the possible performance of real TCO, so this feature requires support by the compiler itself.

--- a/text/0000-guaranteed-tco.md
+++ b/text/0000-guaranteed-tco.md
@@ -212,11 +212,9 @@ Additionally, this feature enables recursive algorithms that require TCO, which 
 While there exist libraries for a trampoline based method to avoid growing the stack, this is not enough to achieve the possible performance of real TCO, so this feature requires support by the compiler itself.
 
 
-# TODO Prior art
+# Prior art
 [prior-art]: #prior-art
-
-TODO remove
-----
+<!-- 
 Discuss prior art, both the good and the bad, in relation to this proposal.
 A few examples of what this can include are:
 
@@ -230,16 +228,20 @@ If there is no prior art, that is fine - your ideas are interesting to us whethe
 
 Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
 Please also take into consideration that rust sometimes intentionally diverges from common language features.
-----
+-->
+Functional languages usually depend on proper tail calls as a language feature, which requires guaranteed TCO. For system level languages the topic of guaranteed TCO is usually wanted but implementation effort is the common reason this is not yet done. Even languages with managed code such as .Net or ECMAScript (though implementation is lagging behind) also support guaranteed TCO, again performance and resource usage were the main motivators for their implementation.
+
+See below for a more detailed description for compilers and languages.
+
 
 
 ## Clang
 Clang, as of April 2021, does offer support for a musttail attribute on `return` statements in both C and C++. This functionality is enabled by the support in LLVM, which should also be the first backend an initial implementation in Rust.
 
-It seems this feature is received with "excitement" by those that can make use of it, a popular example is its usage to improve [Protobuf parsing speed](https://blog.reverberate.org/2021/04/21/musttail-efficient-interpreters.html). However, one issue is that it is not very portable and there still seem to be some problem with it's [implementation](https://github.com/rust-lang/rfcs/issues/2691#issuecomment-1490009983).
+It seems this feature is received with "excitement" by those that can make use of it, a popular example of its usage is to improve [Protobuf parsing speed](https://blog.reverberate.org/2021/04/21/musttail-efficient-interpreters.html). However, one issue is that it is not very portable and there still seem to be some problem with it's [implementation](https://github.com/rust-lang/rfcs/issues/2691#issuecomment-1490009983).
 
 
-For a more detailed description see this excerpt from the description of the [implementation](https://reviews.llvm.org/rG834467590842):
+For a more detailed description see this excerpt from the description of the feature, taken from the [implementation](https://reviews.llvm.org/rG834467590842):
 
 >  Guaranteed tail calls are now supported with statement attributes
 >  ``[[clang::musttail]]`` in C++ and ``__attribute__((musttail))`` in C. The
@@ -279,16 +281,7 @@ There is also a proposal (https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2920
 
 
 ## GCC
-GCC does not support a feature equivalent to Clang's `musttail`, there also does not seem to be push to implement it ([pipermail](https://gcc.gnu.org/pipermail/gcc/2021-April/235882.html)). However, there also exists a experimental [plugin](https://github.com/pietro/gcc-musttail-plugin) for gcc last updated in 2021.
-
-
-## dotnet
-[Pull Request](https://github.com/dotnet/runtime/pull/341) ([Issue](https://github.com/dotnet/runtime/issues/2191))
-> This implements tailcall-via-help support for all platforms supported by
-> the runtime. In this new mechanism the JIT asks the runtime for help
-> whenever it realizes it will need a helper to perform a tailcall, i.e.
-> when it sees an explicit tail. prefixed call that it cannot make into a
-> fast jump-based tailcall.
+GCC does not support a feature equivalent to Clang's `musttail`, there also does not seem to be push to implement it ([pipermail](https://gcc.gnu.org/pipermail/gcc/2021-April/235882.html)) (as of 2021). However, there also exists a experimental [plugin](https://github.com/pietro/gcc-musttail-plugin) for GCC last updated in 2021.
 
 
 ## Zig
@@ -306,10 +299,23 @@ fn add(a: i32, b: i32) i32 {
 }
 ```
 
-(TODO what is the communities reception of this feature?)
+(TODO: What is the community sentiment regarding this feature? Except for some bug reports I did not find anything.)
+
+## Carbon
+As per this [issue](https://github.com/carbon-language/carbon-lang/issues/1761) it seems providing TCO is of interest even if the implementation is difficult
 
 
-## JS
+## .Net
+The .Net JIT does support TCO as of 2020, a main motivator for this feature was improving performance.
+[Pull Request](https://github.com/dotnet/runtime/pull/341) ([Issue](https://github.com/dotnet/runtime/issues/2191))
+> This implements tailcall-via-help support for all platforms supported by
+> the runtime. In this new mechanism the JIT asks the runtime for help
+> whenever it realizes it will need a helper to perform a tailcall, i.e.
+> when it sees an explicit tail. prefixed call that it cannot make into a
+> fast jump-based tailcall.
+
+
+## ECMA Script / JS
 https://github.com/rust-lang/rfcs/pull/1888#issuecomment-368204577 (Feb, 2018)
 > Technically the ES6 spec mandates tail-calls, but the situation in reality is more complicated than that.
 >

--- a/text/0000-guaranteed-tco.md
+++ b/text/0000-guaranteed-tco.md
@@ -176,7 +176,7 @@ The goal behind this design is to TCO functions other than exactly matching func
 
 While quite noisy it is also less flexible than the chosen approach. Indeed TCO is a property of the call and not a function, sometimes a call should be guaranteed to be TCO and sometimes not, marking a function would be less flexible.
 
-### Attribute on Return
+### Attribute on `return`
 One alternative could be to use a attribute instead of the `become` keyword for function calls. To my knowledge this would be the first time a attribute would be allowed for a call. Example:
 
 ```rust
@@ -199,6 +199,7 @@ This would be a error prone and unergonomic approach to solving this problem.
 ## What is the impact of not doing this?
 One goal of Rust is to ([source](https://blog.rust-lang.org/inside-rust/2022/04/04/lang-roadmap-2024.html)):
 > Rust's goal is to empower everyone to build reliable and efficient software.
+
 This feature provides a crucial optimization for some low level code. It seems that without this feature there is a [big incentive](https://github.com/rust-lang/rust/issues/102952) to use other system level languages that can perform TCO.
 
 Additionally, this feature enables recursive algorithms that require TCO, which would provide better support for functional programming in Rust. 

--- a/text/0000-guaranteed-tco.md
+++ b/text/0000-guaranteed-tco.md
@@ -22,7 +22,7 @@ For the second goal no guaranteed method exists, so if TCO is performed depends 
 Some specific use cases that are supported by this feature are new ways to encode state machines and jump tables, allowing code to be written in a continuation-passing style, recursive algorithms to be guaranteed TCO, and faster interpreters. One common example for the usefulness of tail-calls in C is improving performance of Protobuf parsing [blog](https://blog.reverberate.org/2021/04/21/musttail-efficient-interpreters.html), which would then also be possible in Rust.
 
 
-# Guide-level explanation
+# TODO Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
 ## Introducing new named concepts. 
@@ -125,7 +125,7 @@ For new Rust programmers this feature should probably be introduced late into th
 As this feature introduces a new keyword and is independent of existing code it has no impact on existing code. For code that does use this feature, it is required that a programmer understands the differences between `become` and `return`, it is difficult to judge how big this impact is without an initial implementation. One difference, however, is in debugging code that uses `become`. As the stack is not preserved, debugging context is lost which likely makes debugging more difficult. That is, elided parent functions as well as their variable values are not available during debugging. (Though this issue might be lessened by providing a flag to opt out of TCO, which would, however, break the semantic guarantee of creating further stack frames. This is likely an issue that needs some investigation after creating an initial implementation.)
 
 
-# Reference-level explanation
+# TODO Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
 This is the technical portion of the RFC. Explain the design in sufficient detail that:
@@ -151,11 +151,11 @@ Additionally, this proposal is limited to exactly matching function signatures w
 There is also a unwanted interaction between TCO and debugging. As TCO by design elides stack frames this information is lost during debugging, that is the parent functions and their local variable values are incomplete. As TCO provides a semantic guarantee of constant stack usage it is also not generally possible to disable TCO for debugging builds as then the stack could overflow. (Still maybe a compiler flag could be provided to temporarily disable TCO for debugging builds.)
 
 
-# Rationale and alternatives
+# TODO Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 ## Why is this design the best in the space of possible designs?
-This design is the best tradeoff between implementation effort and provided functionality. Though it 
+TODO This design is the best tradeoff between implementation effort and provided functionality.
 
 ## What other designs have been considered and what is the rationale for not choosing them?
 
@@ -179,7 +179,7 @@ This design is the best tradeoff between implementation effort and provided func
 While there exist libraries for a trampoline based method to avoid growing the stack, this is not enough to achieve the possible performance of real TCO, so this feature requires support by the compiler itself.
 
 
-# Prior art
+# TODO Prior art
 [prior-art]: #prior-art
 
 Discuss prior art, both the good and the bad, in relation to this proposal.
@@ -196,14 +196,14 @@ If there is no prior art, that is fine - your ideas are interesting to us whethe
 Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
 Please also take into consideration that rust sometimes intentionally diverges from common language features.
 
-# Unresolved questions
+# TODO Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?
 - What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
 - What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
 
-# Future possibilities
+# TODO Future possibilities
 [future-possibilities]: #future-possibilities
 
 Think about what the natural extension and evolution of your proposal would

--- a/text/0000-guaranteed-tco.md
+++ b/text/0000-guaranteed-tco.md
@@ -1,0 +1,159 @@
+- Feature Name: guaranteed_tco
+- Start Date: 2023-04-01
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+This feature allows guaranteeing that function calls are tail-call optimized (TCO) via the `become` keyword. If this guarantee can not be provided by the compiler an error is generated instead. The check for the guarantee is done by verifying that the candidate function call follows several restrictions such as tail position and a function signature that exactly matches the calling function (it might be possible to loosen the function signature restriction in the future).
+
+# Motivation
+[motivation]: #motivation
+
+While opportunistic TCO is already supported there currently is no way to natively guarantee TCO. This optimization is interesting for two general goals. One goal is to do function calls without adding a new stack frame to the stack, this mainly has semantic implications as for example recursive algorithms can overflow the stack without this optimization. The other goal is to, in simple words, replace `call` instructions by `jmp` instructions, this optimization has performance implications and can provide massive speedups for algorithms that have a high density of function calls.
+
+Note that workarounds for the first goal exist by using so called trampolining which limits the stack depth. However, while this functionality is provided by several crates, a inclusion in the language can provide greater adoption of a more functional programming style.
+
+For the second goal no guaranteed method exists, so if TCO is performed depends on the specific structure of the code and the compiler version. This can result in TCO no longer being performed if non-semantic changes to the code are done or the compiler version changes.
+
+Some specific use cases that are supported by this feature are new ways to encode state machines and jump tables, allowing code to be written in a continuation-passing style, recursive algorithms to be guaranteed TCO, and faster interpreters. One common example for the usefulness of tail-calls in C is improving performance of Protobuf parsing [blog](https://blog.reverberate.org/2021/04/21/musttail-efficient-interpreters.html), which would then also be possible in Rust.
+
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+The `become` keyword can be used at the same locations as the `return` keyword, however, only a *simple* function call can take the place of the argument. That is supported are calls such as `become foo()`, `become foo(a)`, `become foo(a, b)`, however, **not** supported are calls that contain or are part of a larger expression such as `become foo() + 1`, `become foo(1 + 1)`, `become foo(bar())` (though this may be subject to change). Additionally, there is a further restriction on the tail-callable functions: the function signature must exactly match that of the calling function (a restriction that might be loosened in the future). 
+
+TODO explain in terms of examples
+
+Now on to some examples.
+
+### The difference between `return` and `become`
+One essential difference to `return` is that `become` drops function **local** variables before the function call instead of after. So the following function ([original example](https://github.com/rust-lang/rfcs/issues/2691#issuecomment-1136728427)):
+```rust
+fn x() {
+    let a = Box::new(());
+    let b = Box::new(());
+    become y(a)
+}
+```
+
+Will be desugared in the following way:
+```rust
+fn x() {
+    let a = Box::new(());
+    let b = Box::new(());
+    let _tmp = a;
+    drop(b);
+    become y(_tmp)
+}
+```
+
+This early dropping allows us to avoid many complexities associated with deciding if a call can be TCO, instead the heavy lifting is done by the borrow checker and a lifetime error will be produced if references to local variables are passed to the called function. To be clear a reference to a local variable could be passed if instead of `become` the call would be done with `return y(a);` (or equivalently `y(a)`), indeed this difference between the handling of local variables is also the main difference between `return` and `become`.
+
+
+
+
+TODO
+```rust
+fn sum_list(data: Vec<u64>, mut offset: usize, mut accum: u64) -> u64 {
+    if offset < data.len() {
+        accum += data[offset];
+        offset += 1;
+        become sum_list(data, offset, accum)
+    } else {
+        accum
+    }
+}
+```
+
+TODO as specific as possible ..
+So how should a Rust programmer *think* about this feature. This feature is useful only for some specific coding styles, though it might make a function programming style more popular. In general this feature is only of interest for programmers that want to program in a more functional style than was previously possible with rust, or for programmers that want to achieve the best possible performance for
+
+TODO should sample error messages be provided? migration guidance?
+
+For new Rust programmers this feature should probably be introduced late into the learning process, it is not a required feature and only useful for niche problems. So it should be taught similarly as to programmers that already know Rust. It is likely enough to provide a description of the feature, compare the differences to `return`, and give examples of possible use-cases and mistakes.
+
+As this feature introduces a new keyword and is independent of existing code it has no impact on existing code. For code that does use this feature, it is required that a programmer understands the differences between `become` and `return`, it is difficult to judge how big this impact is without an initial implementation. One difference, however, is in debugging code that uses `become`. As the stack is not preserved, debugging context is lost which likely makes debugging more difficult. That is, elided parent functions as well as their variable values are not available during debugging. (Though this issue might be lessened by providing a flag to opt out of TCO, which would, however, break the semantic guarantee of creating further stack frames. This is likely an issue that needs some investigation after creating an initial implementation.)
+
+
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+- Discuss how this impacts the ability to read, understand, and maintain Rust code. Code is read and modified far more often than written; will the proposed feature make code easier to maintain?
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+- If this is a language proposal, could this be done in a library or macro instead? Does the proposed change make Rust code easier or harder to read, understand, and maintain?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the language and project as a whole in a holistic
+way. Try to use this section as a tool to more fully consider all possible
+interactions with the project and language in your proposal.
+Also consider how this all fits into the roadmap for the project
+and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.


### PR DESCRIPTION
This RFC proposes a feature to provide a guarantee that function calls are tail-call optimized via the `become` keyword. If this guarantee can not be provided by the compiler an error is generated instead.

[Rendered](https://github.com/phi-go/rfcs/blob/guaranteed-tco/text/0000-guaranteed-tco.md)

For reference, previous RFCs https://github.com/rust-lang/rfcs/pull/81 and https://github.com/rust-lang/rfcs/pull/1888, as well as an earlier issue https://github.com/rust-lang/rfcs/issues/271, and the currently active issue https://github.com/rust-lang/rfcs/issues/2691.



