### PR TITLE
Fix 404 handling

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,6 +4,7 @@ title = "The Rust RFC Book"
 [output.html]
 no-section-label = true
 git-repository-url = "https://github.com/rust-lang/rfcs"
+site-url = "/rfcs/"
 
 [output.html.search]
 heading-split-level = 0


### PR DESCRIPTION
This fixes the 404 not-found handling so that the not-found page can load javascript/css resources. Otherwise pages like https://rust-lang.github.io/rfcs/foo do not render correctly.
