### PR TITLE
Use `actions/deploy-pages` to deploy `mdbook` output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
       - master
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -19,16 +19,23 @@ jobs:
     - name: Generate Book
       run: |
         ./generate-book.py
-    - name: Deploy GitHub Pages
-      run: |
-        git worktree add gh-pages gh-pages
-        git config user.name "Deploy from CI"
-        git config user.email ""
-        cd gh-pages
-        # Delete the ref to avoid keeping history.
-        git update-ref -d refs/heads/gh-pages
-        rm -rf *
-        mv ../book/* .
-        git add .
-        git commit -m "Deploy $GITHUB_SHA to gh-pages"
-        git push --force
+    - name: Upload Artifact
+      uses: actions/upload-pages-artifact@v1.0.8
+      with:
+        path: ./book
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2.0.0


### PR DESCRIPTION
GitHub has official support for deploying to GitHub Pages from a GitHub Actions workflow, without having to deal with special git branches.

This is accomplished by using https://github.com/actions/upload-pages-artifact and https://github.com/actions/deploy-pages. The first action is creating a build artifact from the generated `/book` folder, while the second one is deploying that artifact to the GitHub Pages environment.

For this to work, the "Pages" settings of the repository will have to be changed:

![Bildschirm­foto 2023-04-18 um 13 44 45](https://user-images.githubusercontent.com/141300/232767093-4af2de50-caba-40f0-b5e9-a82ddc021d93.png)

We are already using a similar setup for the crates.io ops guide, and it has been working without any issues for us. As a future second step we could even enable the `build` job to run for PRs too, and only restrict the `deploy` job to the `master` branch.

/cc @rust-lang/infra 
