### PR TITLE
Fix autolink syntax on 3216

### DIFF
--- a/text/3216-closure-lifetime-binder.md
+++ b/text/3216-closure-lifetime-binder.md
@@ -4,7 +4,7 @@
 - Rust Issue: [rust-lang/rust#97362](https://github.com/rust-lang/rust/issues/97362)
 
 
-This RFC went through a pre-RFC phase at https://internals.rust-lang.org/t/pre-rfc-allow-for-a-syntax-with-closures-for-explicit-higher-ranked-lifetimes/15888
+This RFC went through a pre-RFC phase at <https://internals.rust-lang.org/t/pre-rfc-allow-for-a-syntax-with-closures-for-explicit-higher-ranked-lifetimes/15888>
 
 # Summary
 


### PR DESCRIPTION


[Rendered](https://github.com/rust-lang/rfcs/blob/notriddle/3216-autolink/text/3216-closure-lifetime-binder.md)