### PR TITLE
mark RFC-3192 (aka the 'provide_any' feature) as rejected

### DIFF
--- a/text/3192-dyno.md
+++ b/text/3192-dyno.md
@@ -3,6 +3,14 @@
 - RFC PR: [rust-lang/rfcs#3192](https://github.com/rust-lang/rfcs/pull/3192)
 - Rust Issue: [rust-lang/rust#96024](https://github.com/rust-lang/rust/issues/96024)
 
+# This RFC was previously approved, but part of it later **rejected**
+
+The `Provider` interface that is core to this proposal has been rejected for now by [the libs team meeting]. Without that element, what remains here is essentially just the `Demand` type (being renamed in https://github.com/rust-lang/rust/pull/113464 to `Request`). Without `Provider`, `Demand`/`Request` is only usable by types defined within the standard library itself as is the case in the [error_generic_member_access] feature proposal. Since `error_generic_member_access` is the only known (at the time of writing this) feature using `Demand`/`Request`, the [decision] was made to track it in the `error_generic_member_access` feature and mark this as rejected for now.
+
+[error_generic_member_access]:  https://github.com/rust-lang/rfcs/pull/2895
+[the libs team meeting]: https://github.com/rust-lang/rust/issues/96024
+[decision]: https://github.com/rust-lang/rust/issues/96024#issuecomment-1629794600
+
 # Summary
 [summary]: #summary
 


### PR DESCRIPTION
This PR addresses the decision by the libs team not to proceed with the `Provider` trait and to merge what's left of RFC 3192 minus `Provider` (ie the `Request` aka `Demand` type) into [the WIP RFC 2895](https://github.com/rust-lang/rfcs/pull/2895).

For reference to these decisions, please see the following starting points:

* see the [May 2023 `provide_any` tracking issue](https://github.com/rust-lang/rust/issues/96024#issuecomment-1554773172) comment
* see the [July 9 2023 zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/error_generic_member_access/near/373733742)


[Rendered](https://github.com/waynr/rust-rfcs/blob/remove-rfc-3912/text/3192-dyno.md)