### PR TITLE
RFC: Generic member access for dyn Error trait objects

### DIFF
--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -276,7 +276,7 @@ Error:
 
 Mission accomplished! The error trait gave us everything we needed to build
 error reports enriched by context relevant to our application. This same
-pattern can be implement many error reporting patterns, such as including help
+pattern can implement many error reporting patterns, such as including help
 text, spans, http status codes, or backtraces in errors which are still
 accessible after the error has been converted to a `dyn Error`.
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -154,11 +154,13 @@ The `Error` trait accomplishes this by providing a set of methods for accessing
 members of `dyn Error` trait objects. It requires that types implement the
 `Display` trait, which acts as the interface to the main member, the error
 message itself.  It provides the `source` function for accessing `dyn Error`
-members, which typically represent the current error's cause. Via
-`#![feature(backtrace)]` it provides the `backtrace` function, for accessing a
-`Backtrace` of the state of the stack when an error was created. For all other
-forms of context relevant to an error report, the `Error` trait provides the
-`context`, context_ref`, and `provide_context` functions.
+members, which typically represent the current error's cause.
+
+For all other forms of context relevant to an error report, the `Error` trait
+offers the `provide_context` method. The report renderer indirectly calls
+`provide_context` for any `Error` type that implements it using standard
+library methods on `dyn Error` itself: `<dyn Error>.request_ref` and `<dyn
+Error>.request_value`.
 
 As an example of how to use this interface to construct an error report, let’s
 explore how one could implement an error reporting type. In this example, our
@@ -243,7 +245,7 @@ impl fmt::Debug for ErrorReporter {
 
         for (ind, error) in errors.enumerate() {
             writeln!(fmt, "    {}: {}", ind, error)?;
-            if let Some(location) = error.context_ref::<Location>() {
+            if let Some(location) = error.request_ref::<Location>() {
                 writeln!(fmt, "        at {}:{}", location.file, location.line)?;
             }
         }

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -207,12 +207,15 @@ impl fmt::Debug for ErrorReporter {
 }
 ```
 
+As you can see the error trait provides the facilities needed to create error
+reports enriched by information that may be present in source errors.
+
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
 The following changes need to be made to implement this proposal:
 
-## Add a type like [`ObjectProvider::Request`] to std
+### Add a type like [`ObjectProvider::Request`] to std
 
 This type fills the same role as `&dyn Any` except that it supports other trait
 objects as the requested type.
@@ -331,7 +334,7 @@ pub struct FulfilledRequest(PhantomData<&'static Cell<()>>);
 pub type ProvideResult<'r, 'a> = Result<Request<'r, 'a>, FulfilledRequest>;
 ```
 
-## Define a generic accessor on the `Error` trait
+### Define a generic accessor on the `Error` trait
 
 ```rust
 pub trait Error {
@@ -344,7 +347,7 @@ pub trait Error {
 }
 ```
 
-## Use this `Request` type to handle passing generic types out of the trait object
+### Use this `Request` type to handle passing generic types out of the trait object
 
 ```rust
 impl dyn Error {

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -87,9 +87,14 @@ fn provide_context<'a>(&'a self, mut request: &mut Request<'a>) {
     request
         .provide_ref::<Backtrace>(&self.backtrace)
         .provide_ref::<SpanTrace>(&self.span_trace)
+        // supports dynamically sized types
         .provide_ref::<dyn Error>(&self.source)
         .provide_ref::<Vec<&'static Location<'static>>>(&self.locations)
-        .provide_ref::<[&'static Location<'static>]>(&self.locations);
+        .provide_ref::<[&'static Location<'static>]>(&self.locations)
+        // can be used to upcast self to other trait objects
+        .provide_ref::<dyn Serialize>(&self)
+        // or to pass owned values
+        .provide_value::<ExitCode>(self.exit_code);
 }
 ```
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -7,12 +7,27 @@
 [summary]: #summary
 
 This RFC proposes a pair of additions to the `Error` trait to support accessing
-generic forms of context from `dyn Error` trait objects, one method on the
-`Error` trait itself for returning references to members based on a given type
-id, and another fn implemented for `dyn Error` that uses a generic return type
-to get the type id to pass into the trait object's fn. These functions will act
-as a generalized version of `backtrace` and `source`, and would primarily be
-used during error reporting when rendering a chain of opaque errors.
+generic forms of context from `dyn Error` trait objects. These functions will
+act as a generalized version of `backtrace` and `source`, and would primarily
+be used during error reporting when rendering a chain of opaque errors.
+
+```rust
+pub trait Error {
+    /// Provide an untyped reference to a member whose type matches the provided `TypeId`.
+    ///
+    /// Returns `None` by default, implementors are encouraged to override.
+    fn provide_context(&self, ty: TypeId) -> Option<&dyn Any> {
+        None
+    }
+}
+
+impl dyn Error {
+    /// Retrieve a reference to `T`-typed context from the error if it is available.
+    pub fn context<T: Any>(&self) -> Option<&T> {
+        self.provide_context(TypeId::of::<T>())?.downcast_ref::<T>()
+    }
+}
+```
 
 # Motivation
 [motivation]: #motivation

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -6,14 +6,14 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes two additions to the `Error` trait to support accessing generic forms of context from `dyn Error` trait objects. This generalizes the pattern used in `backtrace` and `source` and allows ecosystem iteration on error reporting infrastructure outside of the standard library. The two proposed additions are a new trait method `Error::provide_context`, which offers `TypeId`-based member lookup, and a new inherent fn `<dyn Error>::context`, which makes use of an implementor's `provide_context` to return a typed reference directly. These additions would primarily be useful in "error reporting" contexts, where we typically no longer have type information and may be composing errors from many sources.
+This RFC proposes two additions to the `Error` trait to support accessing generic forms of context from `dyn Error` trait objects. This generalizes the pattern used in `backtrace` and `source` and allows ecosystem iteration on error reporting infrastructure outside of the standard library. The two proposed additions are a new trait method `Error::get_context`, which offers `TypeId`-based member lookup, and a new inherent fn `<dyn Error>::context`, which makes use of an implementor's `get_context` to return a typed reference directly. These additions would primarily be useful in "error reporting" contexts, where we typically no longer have type information and may be composing errors from many sources.
 
 ```rust
 pub trait Error {
     /// Provide an untyped reference to a member whose type matches the provided `TypeId`.
     ///
     /// Returns `None` by default, implementors are encouraged to override.
-    fn provide_context(&self, ty: TypeId) -> Option<&dyn Any> {
+    fn get_context(&self, ty: TypeId) -> Option<&dyn Any> {
         None
     }
 }
@@ -21,7 +21,7 @@ pub trait Error {
 impl dyn Error {
     /// Retrieve a reference to `T`-typed context from the error if it is available.
     pub fn context<T: Any>(&self) -> Option<&T> {
-        self.provide_context(TypeId::of::<T>())?.downcast_ref::<T>()
+        self.get_context(TypeId::of::<T>())?.downcast_ref::<T>()
     }
 }
 ```
@@ -29,25 +29,24 @@ impl dyn Error {
 # Motivation
 [motivation]: #motivation
 
-In Rust today, errors traditionally gather two forms of context when they are created: context for the *current error message* and context for the *final* *error report*. The `Error` trait exists to provide a consistent interface to context intended for error reports. This context includes the error message, the source error, and, more recently, backtraces.
+In Rust, errors typically gather two forms of context when they are created: context for the *current error message* and context for the *final* *error report*. The `Error` trait exists to provide a interface to context intended for error reports. This context includes the error message, the source error, and, more recently, backtraces.
 
 However, the current approach of promoting each form of context to a method on the `Error` trait doesn't leave room for forms of context that are not commonly used, or forms of context that are defined outside of the standard library.
 
 ## Example use cases this enables
-* using `backtrace::Backtrace` instead of `std::backtrace::Backtrace`
-* zig-like Error Return Traces by extracting `Location` types from errors gathered via `#[track_caller]` or some similar mechanism.
+* using alternatives to `std::backtrace::Backtrace` such as `backtrace::Backtrace` or [`SpanTrace`]
+* zig-like Error Return Traces by extracting `Location` types from errors gathered via `#[track_caller]` or similar.
 * error source trees instead of chains by accessing the source of an error as a slice of errors rather than as a single error, such as a set of errors caused when parsing a file
-* [`SpanTrace`], a backtrace-like type from the `tracing-error` library
 * Help text such as suggestions or warnings attached to an error report
 
-By adding a generic form of these functions that works around the restriction on generics in trait objects, we could support a greater diversity of error handling needs, as well as making room for experimentation with new forms of context in error reports.
+To support these use cases without ecosystem fragmentation, we would extend Error's vtable with a dynamic context API that allows implementors and clients to enrich errors in an opt-in fashion.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Error handling in Rust consists of two steps: creation/propagation and reporting. The `std::error::Error` trait exists to bridge the gap between these two steps. It does so by acting as a consistent interface that all error types can implement. This allows error reporting types to handle them in a consistent manner when constructing reports for end users.
+Error handling in Rust consists of two steps: creation/propagation and reporting. The `std::error::Error` trait exists to bridge the gap between these two steps. It does so by acting as a interface that all error types can implement. This allows error reporting types to handle them in a consistent manner when constructing reports for end users.
 
-The error trait accomplishes this by providing a set of methods for accessing members of `dyn Error` trait objects. The main member, the error message itself, is handled by the `Display` trait, which is a requirement for implementing the Error trait. For accessing `dyn Error` members, it provides the `source` function, which conventionally represents the lower level error that caused the current error. And, for accessing a `Backtrace` of the state of the stack when an error was created, it provides the `backtrace` function. For all other forms of context relevant to an error report, the error trait provides the `context` and `provide_context` functions.
+The error trait accomplishes this by providing a set of methods for accessing members of `dyn Error` trait objects. It requires types implement the display trait, which acts as the interface to the main member, the error message itself.  It provides the `source` function for accessing `dyn Error` members, which typically represent the current error's cause. It provides the `backtrace` function, for accessing a `Backtrace` of the state of the stack when an error was created. For all other forms of context relevant to an error report, the error trait provides the `context` and `get_context` functions.
 
 As an example of how to use these types to construct an error report, let’s explore how one could implement an error reporting type. In this example, our error reporting type will retrieve the source code location where each error in the chain was created (if it exists) and render it as part of the chain of errors. Our end goal is to get an error report that looks something like this:
 
@@ -58,7 +57,7 @@ Error:
     1: No such file or directory (os error 2)
 ```
 
-The first step is to define or use a type to represent a source location. In this example, we will define our own, but we could also use `std::panic::Location` or a similar type.
+The first step is to define or use a type to represent a source location. In this example, we will define our own:
 
 ```rust
 struct Location {
@@ -104,7 +103,7 @@ impl std::error::Error for ExampleError {
         Some(&self.source)
     }
 
-    fn provide_context(&self, type_id: TypeId) -> Option<&dyn Any> {
+    fn get_context(&self, type_id: TypeId) -> Option<&dyn Any> {
         if id == TypeId::of::<Location>() {
             Some(&self.location)
         } else {
@@ -145,12 +144,12 @@ impl fmt::Debug for ErrorReporter {
 
 There are two additions necessary to the standard library to implement this proposal:
 
-Add a function for dyn Error trait objects that will be used by error reporters to access members given a generic type. This function circumvents restrictions on generics in trait functions by being implemented for trait objects only, rather than as a member of the trait itself.
+Add a function for dyn Error trait objects that will be used by error reporters to access members given a type. This function circumvents restrictions on generics in trait functions by being implemented for trait objects only, rather than as a member of the trait itself.
 
 ```rust
 impl dyn Error {
     pub fn context<T: Any>(&self) -> Option<&T> {
-        self.provide_context(TypeId::of::<T>())?.downcast_ref::<T>()
+        self.get_context(TypeId::of::<T>())?.downcast_ref::<T>()
     }
 }
 ```
@@ -173,7 +172,7 @@ Add a member to the `Error` trait to provide the `&dyn Any` trait objects to the
 trait Error {
     /// ...
 
-    fn provide_context(&self, id: TypeId) -> Option<&dyn Any> {
+    fn get_context(&self, id: TypeId) -> Option<&dyn Any> {
         None
     }
 }
@@ -182,7 +181,7 @@ trait Error {
 With the expected usage:
 
 ```rust
-fn provide_context(&self, type_id: TypeId) -> Option<&dyn Any> {
+fn get_context(&self, type_id: TypeId) -> Option<&dyn Any> {
     if id == TypeId::of::<Location>() {
         Some(&self.location)
     } else {
@@ -201,7 +200,8 @@ fn provide_context(&self, type_id: TypeId) -> Option<&dyn Any> {
     self.span_trace.as_ref().map(|s| s as &dyn Any)
 }
 ```
-* When you return the wrong type and the downcast fails you get `None` rather than a compiler error guiding you to the right return type, which can make it challenging to debug mismatches between the type you return and the type you use to check against the type_id The downcast could be changed to panic when it fails
+# TODO rewrite
+* When you return the wrong type and the downcast fails you get `None` rather than a compiler error guiding you to the right return type, which can make it challenging to debug mismatches between the type you return and the type you use to check against the type_id
     * There is an alternative implementation that mostly avoids this issue
 * This approach cannot return slices or trait objects because of restrictions on `Any`
     * The alternative implementation avoids this issue
@@ -226,10 +226,10 @@ Nika Layzell has proposed an alternative implementation using a `Provider` type 
 * https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=0af9dbf0cd20fa0bea6cff16a419916b
 * https://github.com/mystor/object-provider
 
-With this design an implementation of the `provide_context` fn might instead look like:
+With this design an implementation of the `get_context` fn might instead look like:
 
 ```rust
-fn provide_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
+fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
     request
         .provide::<PathBuf>(&self.path)?
         .provide::<Path>(&self.path)?
@@ -259,18 +259,20 @@ I do not know of any other languages whose error handling has similar facilities
 [unresolved-questions]: #unresolved-questions
 
 * What should the names of these functions be?
-    * `context`/`context_ref`/`provide_context`
+    * `context`/`context_ref`/`get_context`/`provide_context`
     * `member`/`member_ref`
     * `provide`/`request`
 * Should we go with the implementation that uses `Any` or the one that supports accessing dynamically sized types like traits and slices?
 * Should there be a by value version for accessing temporaries?
-    * I bring this up specifically for the case where you want to use this function to get an `Option<&[&dyn Error]>` out of an error, in this case its unlikely that the error behind the trait object is actually storing the errors as `dyn Errors`, and theres no easy way to allocate storage to store the trait objects.
+    * We bring this up specifically for the case where you want to use this function to get an `Option<&[&dyn Error]>` out of an error, in this case its unlikely that the error behind the trait object is actually storing the errors as `dyn Errors`, and theres no easy way to allocate storage to store the trait objects.
+* How should context handle failed downcasts?
+    * suggestion: panic, as providing a type that doesn't match the typeid requested is a program error
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-I'd love to see the various error creating libraries like `thiserror` adding support for making members exportable as context for reporters.
+We'd love to see the various error creating libraries like `thiserror` adding support for making members exportable as context for reporters.
 
-Also, I'm interested in adding support for `Error Return Traces`, similar to zigs, and I think that this accessor function might act as a critical piece of that implementation.
+Also, we're interested in adding support for `Error Return Traces`, similar to zigs, and I think that this accessor function might act as a critical piece of that implementation.
 
 [`SpanTrace`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.SpanTrace.html

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -16,6 +16,10 @@ additions would primarily be useful in "error reporting" contexts, where we
 typically no longer have type information and may be composing errors from many
 sources.
 
+_note_: This RFC focuses on the more complicate of it's two proposed solutions
+in order to support accessing DSTs. The [alternative proposal] is easier to
+understand and may be more palatable.
+
 ## TLDR
 
 Add this method to the `Error` trait
@@ -452,4 +456,4 @@ let mut locations = e
 
 [`SpanTrace`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.SpanTrace.html
 [`ObjectProvider::Request`]: https://github.com/yaahc/nostd-error-poc/blob/master/fakecore/src/any.rs
-
+[alternative proposal]: #use-an-alternative-proposal-that-relies-on-the-any-trait-for-downcasting

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -219,7 +219,7 @@ reports enriched by information that may be present in source errors.
 
 The following changes need to be made to implement this proposal:
 
-### Add a type like [`Request`] to std
+### Add a type like [`Request`] to core
 
 This type fills the same role as `&dyn Any` except that it supports other trait
 objects as the requested type.

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -1,4 +1,4 @@
-- Feature Name: Add functions for generic member access to dyn Error and the Error trait
+- Feature Name: Add functions for generic member access to dyn Error and the `Error` trait
 - Start Date: 2020-04-01
 - RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/2895)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
@@ -9,7 +9,7 @@
 This RFC proposes additions to the `Error` trait to support accessing generic
 forms of context from `dyn Error` trait objects. This generalizes the pattern
 used in `backtrace` and `source`. This proposal adds the method
-`Error::get_context` to the error trait, which offers `TypeId`-based member
+`Error::get_context` to the `Error` trait, which offers `TypeId`-based member
 lookup and a new inherent function `<dyn Error>::context` which makes use of an
 implementor's `get_context` to return a typed reference directly. These
 additions would primarily be useful for error reporting, where we typically no
@@ -90,7 +90,7 @@ many new forms of error reporting.
 
 ## Moving `Error` into `libcore`
 
-Adding a generic member access function to the Error trait and removing the
+Adding a generic member access function to the `Error` trait and removing the
 `backtrace` function would make it possible to move the `Error` trait to libcore
 without losing support for backtraces on std. The only difference being that
 in places where you can currently write `error.backtrace()` on nightly you
@@ -108,14 +108,14 @@ allows error reporting types to handle errors in a consistent manner when
 constructing reports for end users while still retaining control over the
 format of the full report.
 
-The error trait accomplishes this by providing a set of methods for accessing
+The `Error` trait accomplishes this by providing a set of methods for accessing
 members of `dyn Error` trait objects. It requires that types implement the
 display trait, which acts as the interface to the main member, the error
 message itself.  It provides the `source` function for accessing `dyn Error`
 members, which typically represent the current error's cause. It provides the
 `backtrace` function, for accessing a `Backtrace` of the state of the stack
 when an error was created. For all other forms of context relevant to an error
-report, the error trait provides the `context` and `get_context` functions.
+report, the `Error` trait provides the `context` and `get_context` functions.
 
 As an example of how to use this interface to construct an error report, let’s
 explore how one could implement an error reporting type. In this example, our
@@ -211,7 +211,7 @@ impl fmt::Debug for ErrorReporter {
 }
 ```
 
-As you can see the error trait provides the facilities needed to create error
+As you can see the `Error` trait provides the facilities needed to create error
 reports enriched by information that may be present in source errors.
 
 # Reference-level explanation
@@ -364,9 +364,9 @@ impl dyn Error {
 # Drawbacks
 [drawbacks]: #drawbacks
 
-* The `Request` api is being added purely to help with this function, there may be
-  some design iteration here that could be done to make this more generally
-  applicable, it seems very similar to `dyn Any`.
+* The `Request` api is being added purely to help with this function. This will
+  likely need some design work to make it more generally applicable, hopefully
+  as a struct in `core::any`.
 * The `context` function name is currently widely used throughout the rust
   error handling ecosystem in libraries like `anyhow` and `snafu` as an
   ergonomic version of `map_err`. If we settle on `context` as the final name
@@ -376,8 +376,6 @@ impl dyn Error {
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-The two alternatives I can think of are:
-
 ## Do Nothing
 
 We could not do this, and continue to add accessor functions to the `Error`
@@ -385,7 +383,7 @@ trait whenever a new type reaches critical levels of popularity in error
 reporting.
 
 If we choose to do nothing we will continue to see hacks around the current
-limitations on the error trait such as the `Fail` trait, which added the
+limitations on the `Error` trait such as the `Fail` trait, which added the
 missing function access methods that didn't previously exist on the `Error`
 trait and type erasure / unnecessary boxing of errors to enable downcasting to
 extract members.
@@ -393,10 +391,6 @@ extract members.
 
 
 ## Use an alternative proposal that relies on the `Any` trait for downcasting
-
-This approach is simpler, but doesn't support providing dynamically sized
-types and is more error prone because it cannot provide compile time errors
-when the type you provide does not match the type_id you were given.
 
 ```rust
 pub trait Error {
@@ -426,7 +420,7 @@ more complicated solution.
   or returning the wrong type
 
 By making all the type id comparison internal to the `Request` type it is
-impossible to compare the wrong type ids. And by encouraging explicit type
+impossible to compare the wrong type ids. By encouraging explicit type
 parameters when calling `provide` the compiler is able to catch errors where
 the type passed in doesn't match the type that was expected. So while the API
 for the main proposal is more complicated it should be less error prone.
@@ -435,9 +429,9 @@ for the main proposal is more complicated it should be less error prone.
 [prior-art]: #prior-art
 
 I do not know of any other languages whose error handling has similar
-facilities for accessing members when reporting errors. For the most part prior
-art exists within rust itself in the form of previous additions to the `Error`
-trait.
+facilities for accessing members when reporting errors. For the most part,
+prior art for this proposal comes from within rust itself in the form of
+previous additions to the `Error` trait.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -248,6 +248,7 @@ impl fmt::Debug for ErrorReporter {
         let errors = std::iter::successors(Some(error), |e| e.source());
 
         for (ind, error) in errors.enumerate() {
+            writeln!(fmt, "    {}: {}", ind, error)?;
             if let Some(location) = error.context::<Location>() {
                 writeln!(fmt, "        at {}:{}", location.file, location.line)?;
             }

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -1,0 +1,304 @@
+- Feature Name: Add fns for generic member access to dyn Error and the Error trait
+- Start Date: 2020-04-01
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+This RFC proposes a pair of additions to the `Error` trait to support accessing
+generic forms of context from `dyn Error` trait objects, one method on the
+`Error` trait itself for returning references to members based on a given
+typeid, and another fn implemented for `dyn Error` that uses a generic return
+type to get the type id to pass into the trait object's fn. These functions
+will act as a generalized version of `backtrace`, `source`, and `cause`, and
+would primarily be used during error reporting when rendering a chain of opaque
+errors.
+
+# Motivation
+[motivation]: #motivation
+
+Today, there are a number of forms of context that are traditionally gathered
+when creating errors. These members are gathered so that a final error
+reporting type or function can access them and render them independently of the
+`Display` implementation for that specific error type to allow for consistently
+formatted and flexible error reports. Today, there are 2 such forms of context
+that are traditionally gathered, `backtrace` and `source`.
+
+However, the current approach of promoting each form of context to a fn on the
+`Error` trait doesn't leave room for forms of context that are not commonly
+used, or forms of context that are defined outside of the standard library.
+
+By adding a generic form of these functions that works around the issues of
+monomorphization on trait objects we can support more forms of context and
+forms of context that are experimented with outside of the standard library
+such as:
+
+* `SpanTrace` a backtrace like type from the `tracing-error` library
+* zig-like Error Return Traces by extracting `Location` types from errors
+  gathered via `#[track_caller]`
+* error source trees instead of chains by accessing the source of an error as a
+  slice of errors rather than as a single error, such as a set of errors caused
+  when parsing a file
+
+With a generic form of member access available on `Error` trait objects we
+could support a greater diversity of error handling needs and make room for
+experimentation on new forms of context in error reports.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+When implementing error handling in rust there are two main aspects that should
+be considered, the creation of errors and the reporting of errors.
+
+Error handling in rust consists mainly of two steps, creation/propogation and
+reporting. The `std::error::Error` trait exists to bridge this gap. It does so
+by acting as a consistent interface that all Error types can implement to allow
+Error Reporting types to handle them in a consistent manner when constructing
+reports for end users.
+
+The error trait accomplishes this by providing a set of methods for accessing
+members of `dyn Error` trait objects. For accessing the message that should be
+rendered to the end user the Error trait implements the `Display` trait. For
+accessing `dyn Error` members it provides the `source` function, which
+conventionally represents the lower level error that caused a subsequent error.
+For accessing a `Backtrace` of the state of the stack when an error was created
+it provides the `backtrace` function. For all other forms of context relevant
+to an Error Report the error trait provides the `context`/`context_any`
+functions.
+
+As an example lets explore how one could implement an error reporting type that
+retrieves the Location where each error in the chain was created, if it exists,
+and renders it as part of the chain of errors.
+
+The goal is to implement an Error Report that looks something like this:
+
+```
+Error:
+    0: Failed to read instrs from ./path/to/instrs.json
+        at instrs.rs:42
+    1: No such file or directory (os error 2)
+```
+
+The first step is to define or use a Location type. In this example we will
+define our own but we could use also use `std::panic::Location` for example.
+
+```rust
+struct Location {
+    file: &'static str,
+    line: usize,
+}
+```
+
+Next we need to gather the location when creating our error types.
+
+```rust
+struct ExampleError {
+    source: std::io::Error,
+    location: Location,
+    path: PathBuf,
+}
+
+impl fmt::Display for ExampleError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "Failed to read instrs from {}", path.display())
+    }
+}
+
+fn read_instrs(path: &Path) -> Result<String, ExampleError> {
+    std::fs::read_to_string(path).map_err(|source| {
+        ExampleError {
+            source,
+            path: path.to_owned(),
+            location: Location {
+                file: file!(),
+                line: line!(),
+            },
+        }
+    })
+}
+```
+
+Next we need to implement the `Error` trait to expose these members to the
+Error Reporter.
+
+```rust
+impl std::error::Error for ExampleError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+
+    fn context_any(&self, type_id: TypeID) -> Option<&dyn Any> {
+        if id == TypeId::of::<Location>() {
+            Some(&self.location)
+        } else {
+            None
+        }
+    }
+}
+```
+
+And finally, we create an error reporter that prints the error and its source
+recursively along with the location data if it was gathered.
+
+```rust
+struct ErrorReporter(Box<dyn Error + Send + Sync + 'static>);
+
+impl fmt::Debug for ErrorReporter {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut current_error = Some(self.0.as_ref());
+        let mut ind = 0;
+
+        while let Some(error) = current_error {
+            writeln!(fmt, "    {}: {}", ind, error)?;
+
+            if let Some(location) = error.context::<Location>() {
+                writeln!(fmt, "        at {}:{}", location.file, location.line)?;
+            }
+
+            ind += 1;
+            current_error = error.source();
+        }
+
+        Ok(())
+    }
+}
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+There are two additions necessary to the standard library to implement this
+proposal:
+
+
+First we need to add a function for dyn Error trait objects that will be used
+by error reporters to access members given a generic type. This function
+circumvents restrictions on generics in trait functions by being implemented
+for trait objects only, rather than as a member of the trait itself.
+
+```rust
+impl dyn Error {
+    pub fn context<T: Any>(&self) -> Option<&T> {
+        self.context_any(TypeId::of::<T>())?.downcast_ref::<T>()
+    }
+}
+```
+
+Second we need to add a member to the `Error` trait to provide the `&dyn Any`
+trait objects to the `context` fn for each member based on the type_id.
+
+```rust
+trait Error {
+    /// ...
+
+    fn context_any(&self, id: TypeId) -> Option<&dyn Any> {
+        None
+    }
+}
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+* The API for defining how to return types is cumbersome and possibly not
+  accessible for new rust users.
+    * If the type is stored in an Option getting it converted to an `&Any` will
+      probably challenge new devs, this can be made easier with documented
+      examples covering common use cases and macros like `thiserror`.
+```rust
+} else if typeid == TypeId::of::<SpanTrace>() {
+    self.span_trace.as_ref().map(|s| s as &dyn Any)
+}
+```
+* When you return the wrong type and the downcast fails you get `None` rather
+  than a compiler error guiding you to the right return type, which can make it
+  challenging to debug mismatches between the type you return and the type you
+  use to check against the type_id
+    * The downcast could be changed to panic when it fails
+    * There is an alternative implementation that mostly avoids this issue
+* Introduces more overhead from the downcasts
+* This approach cannot return slices or trait objects because of restrictions
+  on `Any`
+    * The alternative solution avoids this issue
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+The two alternatives I can think of are:
+
+## Do Nothing
+
+We could not do this, and continue to add accessor functions to the `Error`
+trait whenever a new type reaches critical levels of popularity in error
+reporting.
+
+
+## Use an alternative to Any for passing generic types across the trait boundary
+
+Nika Layzell has proposed an alternative implementation using a `Provider` type
+which avoids using `&dyn Any`. I do not necessarily think that the main
+suggestion is necessarily better, but it is much simpler.
+    * https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=0af9dbf0cd20fa0bea6cff16a419916b
+    * https://github.com/mystor/object-provider
+
+With this design an implementation of the `context_any` fn might instead look like:
+
+```rust
+fn provide<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
+    request
+        .provide::<PathBuf>(&self.path)?
+        .provide::<Path>(&self.path)?
+        .provide::<dyn Debug>(&self.path)
+}
+```
+
+The advantages of this design are that:
+
+1. It supports accessing trait objects and slices
+2. If the user specifies the type they are trying to pass in explicitly they
+   will get compiler errors when the type doesn't match.
+3. Less verbose implementation
+
+The disadvatages are:
+
+1. More verbose function signature, very lifetime heavy
+2. The Request type uses unsafe code which needs to be verified
+3. could encourage implementations where they pass the provider to
+   `source.provide` first which would prevent the error reporter from knowing
+   which error in the chain gathered each piece of context and might cause
+   context to show up multiple times in a report.
+
+# Prior art
+[prior-art]: #prior-art
+
+I do not know of any other languages whose error handling has similar
+facilities for accessing members when reporting errors. For the most part prior
+art exists within rust itself in the form of previous additions to the `Error`
+trait.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What should the names of these functions be?
+    - `context`/`context_ref`/`context_any`
+    - `member`/`member_ref`
+    - `provide`/`request`
+- Should we go with the implementation that uses `Any` or the one that supports
+  accessing dynamically sized types like traits and slices?
+- Should there be a by value version for accessing temporaries?
+    - I bring this up specifically for the case where you want to use this
+      function to get an `Option<&[&dyn Error]>` out of an error, in this case
+      its unlikely that the error behind the trait object is actually storing
+      the errors as `dyn Errors`, and theres no easy way to allocate storage to
+      store the trait objects.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+I'd love to see the various error creating libraries like `thiserror` adding
+support for making members exportable as context for reporters.
+
+Also, I'm interested in adding support for `Error Return Traces`, similar to
+zigs, and I think that this accessor function might act as a critical piece of
+that implementation.

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -8,14 +8,13 @@
 
 This RFC proposes additions to the `Error` trait to support accessing generic
 forms of context from `dyn Error` trait objects. This generalizes the pattern
-used in `backtrace` and `source` and allows ecosystem iteration on error
-reporting infrastructure outside of the standard library. This proposal adds
-the method `Error::get_context` to the error trait, which offers `TypeId`-based
-member lookup, and a new inherent fn `<dyn Error>::context`,
-which makes use of an implementor's `get_context` to return a typed reference
-directly. These additions would primarily be useful in "error reporting"
-contexts, where we typically no longer have type information and may be
-composing errors from many sources.
+used in `backtrace` and `source`. This proposal adds the method
+`Error::get_context` to the error trait, which offers `TypeId`-based member
+lookup, and a new inherent fn `<dyn Error>::context`, which makes use of an
+implementor's `get_context` to return a typed reference directly. These
+additions would primarily be useful in "error reporting" contexts, where we
+typically no longer have type information and may be composing errors from many
+sources.
 
 ## TLDR
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -28,7 +28,45 @@ Add this method to the `Error` trait
 pub trait Error {
     // ...
 
-    /// Provides an object of type `T` in response to this request.
+    /// Provides type based access to context intended for error reports
+    ///
+    /// Used in conjunction with [`context`] to extract references to member variables from `dyn
+    /// Error` trait objects.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use core::pin::Pin;
+    /// use backtrace::Backtrace;
+    /// use core::fmt;
+    /// use fakecore::any::Request;
+    ///
+    /// #[derive(Debug)]
+    /// struct Error {
+    ///     backtrace: Backtrace,
+    /// }
+    ///
+    /// impl fmt::Display for Error {
+    ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///         write!(f, "Example Error")
+    ///     }
+    /// }
+    ///
+    /// impl fakecore::error::Error for Error {
+    ///     fn provide_context<'a>(&'a self, mut request: Pin<&mut Request<'a>>) {
+    ///         request.provide::<Backtrace>(&self.backtrace);
+    ///     }
+    /// }
+    ///
+    /// fn main() {
+    ///     let backtrace = Backtrace::new();
+    ///     let error = Error { backtrace };
+    ///     let dyn_error = &error as &dyn fakecore::error::Error;
+    ///     let backtrace_ref = dyn_error.context::<Backtrace>().unwrap();
+    ///
+    ///     assert!(core::ptr::eq(&error.backtrace, backtrace_ref));
+    /// }
+    /// ```
     fn provide_context<'a>(&'a self, request: Pin<&mut Request<'a>>) {}
 }
 ```

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -10,15 +10,15 @@ This RFC proposes additions to the `Error` trait to support accessing generic
 forms of context from `dyn Error` trait objects. This generalizes the pattern
 used in `backtrace` and `source`. This proposal adds the method
 `Error::get_context` to the error trait, which offers `TypeId`-based member
-lookup, and a new inherent fn `<dyn Error>::context`, which makes use of an
+lookup and a new inherent fn `<dyn Error>::context` which makes use of an
 implementor's `get_context` to return a typed reference directly. These
-additions would primarily be useful in "error reporting" contexts, where we
-typically no longer have type information and may be composing errors from many
-sources.
+additions would primarily be useful for error reporting, where we typically no
+longer have type information and may be composing errors from many sources.
 
-_note_: This RFC focuses on the more complicated of it's two proposed solutions
-in order to support accessing DSTs. The [alternative proposal] is easier to
-understand and may be more palatable.
+_note_: This RFC focuses on the more complicated of it's two proposed
+solutions. The proposed solution provides support accessing dynamically sized
+types. The [alternative proposal] is easier to understand and may be more
+palatable.
 
 ## TLDR
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -67,10 +67,14 @@ and, more recently, backtraces.
 However, the current approach of promoting each form of context to a method on
 the `Error` trait doesn't leave room for forms of context that are not commonly
 used, or forms of context that are defined outside of the standard library.
-Adding a generic equivalent to these member access functions would leave room
-for many more forms of context in error reports.
 
-## Example use cases this enables
+## Extracting non-std types from `dyn Errors`
+
+By adding a generic form of these member access functions we are no longer
+restricted to types defined in the standard library. This opens the door to
+many new forms of error reporting.
+
+### Example use cases this enables
 
 * using alternatives to `std::backtrace::Backtrace` such as
   `backtrace::Backtrace` or [`SpanTrace`]
@@ -80,10 +84,6 @@ for many more forms of context in error reports.
   slice of errors rather than as a single error, such as a set of errors caused
   when parsing a file
 * Help text such as suggestions or warnings attached to an error report
-
-To support these use cases without ecosystem fragmentation, we would extend the
-Error trait with a dynamic context API that allows implementors and clients to
-enrich errors in an opt-in fashion.
 
 ## Moving `Error` into `libcore`
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -146,7 +146,7 @@ format of the full report.
 
 The `Error` trait accomplishes this by providing a set of methods for accessing
 members of `dyn Error` trait objects. It requires that types implement the
-display trait, which acts as the interface to the main member, the error
+`Display` trait, which acts as the interface to the main member, the error
 message itself.  It provides the `source` function for accessing `dyn Error`
 members, which typically represent the current error's cause. It provides the
 `backtrace` function, for accessing a `Backtrace` of the state of the stack
@@ -468,15 +468,15 @@ impl dyn Error {
 
 ### Why isn't this the primary proposal?
 
-There are two big issues with using the `Any` trait that I believe justify the
+There are two significant issues with using the `Any` trait that motivate the
 more complicated solution.
 
 - You cannot return dynamically sized types as `&dyn Any`
 - It's easy to introduce runtime errors with `&dyn Any` by either comparing to
   or returning the wrong type
 
-By making all the type id comparison internal to the `Request` type it is
-impossible to compare the wrong type ids. By encouraging explicit type
+By making all the `TypeId` comparison internal to the `Request` type it is
+impossible to compare the wrong `TypeId`s. By encouraging explicit type
 parameters when calling `provide` the compiler is able to catch errors where
 the type passed in doesn't match the type that was expected. So while the API
 for the main proposal is more complicated it should be less error prone.

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -137,7 +137,7 @@ would instead need to write `error.context::<Backtrace>()`.
 
 Error handling in Rust consists of three steps: creation/propagation, handling,
 and reporting. The `std::error::Error` trait exists to bridge the gap between
-creation and reporting. It does so by acting as a interface that all error
+creation and reporting. It does so by acting as an interface that all error
 types can implement that defines how to access context intended for error
 reports, such as the error message, source, or location it was created. This
 allows error reporting types to handle errors in a consistent manner when

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -6,49 +6,122 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes two additions to the `Error` trait to support accessing generic forms of context from `dyn Error` trait objects. This generalizes the pattern used in `backtrace` and `source` and allows ecosystem iteration on error reporting infrastructure outside of the standard library. The two proposed additions are a new trait method `Error::get_context`, which offers `TypeId`-based member lookup, and a new inherent fn `<dyn Error>::context`, which makes use of an implementor's `get_context` to return a typed reference directly. These additions would primarily be useful in "error reporting" contexts, where we typically no longer have type information and may be composing errors from many sources.
+This RFC proposes additions to the `Error` trait to support accessing generic
+forms of context from `dyn Error` trait objects. This generalizes the pattern
+used in `backtrace` and `source` and allows ecosystem iteration on error
+reporting infrastructure outside of the standard library. The two proposed
+additions are a new trait method `Error::get_context`, which offers
+`TypeId`-based member lookup, and a new inherent fn `<dyn Error>::context`,
+which makes use of an implementor's `get_context` to return a typed reference
+directly. These additions would primarily be useful in "error reporting"
+contexts, where we typically no longer have type information and may be
+composing errors from many sources.
+
+The names here are just placeholders. The specifics of the `Request` type are a
+suggested starting point. And the `Request` style api could be replaced with a
+much simpler API based on  `TypeId` + `dyn Any` at the cost of being
+incompatible with dynamically sized types. The basic proposal is this:
+
+Add this method to the `Error` trait
 
 ```rust
 pub trait Error {
-    /// Provide an untyped reference to a member whose type matches the provided `TypeId`.
-    ///
-    /// Returns `None` by default, implementors are encouraged to override.
-    fn get_context(&self, ty: TypeId) -> Option<&dyn Any> {
-        None
+    // ...
+
+    /// Provides an object of type `T` in response to this request.
+    fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
+        Ok(request)
     }
 }
+```
 
-impl dyn Error {
-    /// Retrieve a reference to `T`-typed context from the error if it is available.
-    pub fn context<T: Any>(&self) -> Option<&T> {
-        self.get_context(TypeId::of::<T>())?.downcast_ref::<T>()
-    }
+Where an example implementation of this method would look like:
+
+```rust
+fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
+    request
+        .provide::<Backtrace>(&self.backtrace)?
+        .provide::<SpanTrace>(&self.span_trace)?
+        .provide::<dyn Error>(&self.source)?
+        .provide::<Vec<&'static Location<'static>>>(&self.locations)?
+        .provide::<[&'static Location<'static>>(&self.locations)
+}
+```
+
+And usage would then look like this:
+
+```rust
+let e: &dyn Error = &concrete_error;
+
+if let Some(bt) = e.context::<Backtrace>() {
+    println!("{}", bt);
 }
 ```
 
 # Motivation
 [motivation]: #motivation
 
-In Rust, errors typically gather two forms of context when they are created: context for the *current error message* and context for the *final* *error report*. The `Error` trait exists to provide a interface to context intended for error reports. This context includes the error message, the source error, and, more recently, backtraces.
+In Rust, errors typically gather two forms of context when they are created:
+context for the *current error message* and context for the *final* *error
+report*. The `Error` trait exists to provide a interface to context intended
+for error reports. This context includes the error message, the source error,
+and, more recently, backtraces.
 
-However, the current approach of promoting each form of context to a method on the `Error` trait doesn't leave room for forms of context that are not commonly used, or forms of context that are defined outside of the standard library.
+However, the current approach of promoting each form of context to a method on
+the `Error` trait doesn't leave room for forms of context that are not commonly
+used, or forms of context that are defined outside of the standard library.
+Adding a generic equivalent to these member access functions would leave room
+for many more forms of context in error reports.
 
 ## Example use cases this enables
-* using alternatives to `std::backtrace::Backtrace` such as `backtrace::Backtrace` or [`SpanTrace`]
-* zig-like Error Return Traces by extracting `Location` types from errors gathered via `#[track_caller]` or similar.
-* error source trees instead of chains by accessing the source of an error as a slice of errors rather than as a single error, such as a set of errors caused when parsing a file
+
+* using alternatives to `std::backtrace::Backtrace` such as
+  `backtrace::Backtrace` or [`SpanTrace`]
+* zig-like Error Return Traces by extracting `Location` types from errors
+  gathered via `#[track_caller]` or similar.
+* error source trees instead of chains by accessing the source of an error as a
+  slice of errors rather than as a single error, such as a set of errors caused
+  when parsing a file
 * Help text such as suggestions or warnings attached to an error report
 
-To support these use cases without ecosystem fragmentation, we would extend Error's vtable with a dynamic context API that allows implementors and clients to enrich errors in an opt-in fashion.
+To support these use cases without ecosystem fragmentation, we would extend the
+Error trait with a dynamic context API that allows implementors and clients to
+enrich errors in an opt-in fashion.
+
+## Moving `Error` into `libcore`
+
+Adding a generic member access function to the Error trait and removing the
+`backtrace` fn would make it possible to move the `Error` trait to libcore
+without losing support for backtraces on std. The only difference would be that
+in places where you can currently write `error.backtrace()` on nightly you
+would instead need to write `error.context::<Backtrace>()`.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Error handling in Rust consists of two steps: creation/propagation and reporting. The `std::error::Error` trait exists to bridge the gap between these two steps. It does so by acting as a interface that all error types can implement. This allows error reporting types to handle them in a consistent manner when constructing reports for end users.
+Error handling in Rust consists of three steps: creation/propagation, handling,
+and reporting. The `std::error::Error` trait exists to bridge the gap between
+creation and reporting. It does so by acting as a interface that all error
+types can implement that defines how to access context intended for error
+reports, such as the error message, source, or location it was created. This
+allows error reporting types to handle errors in a consistent manner when
+constructing reports for end users while still retaining control over the
+format of the full report.
 
-The error trait accomplishes this by providing a set of methods for accessing members of `dyn Error` trait objects. It requires types implement the display trait, which acts as the interface to the main member, the error message itself.  It provides the `source` function for accessing `dyn Error` members, which typically represent the current error's cause. It provides the `backtrace` function, for accessing a `Backtrace` of the state of the stack when an error was created. For all other forms of context relevant to an error report, the error trait provides the `context` and `get_context` functions.
+The error trait accomplishes this by providing a set of methods for accessing
+members of `dyn Error` trait objects. It requires types implement the display
+trait, which acts as the interface to the main member, the error message
+itself.  It provides the `source` function for accessing `dyn Error` members,
+which typically represent the current error's cause. It provides the
+`backtrace` function, for accessing a `Backtrace` of the state of the stack
+when an error was created. For all other forms of context relevant to an error
+report, the error trait provides the `context` and `get_context` functions.
 
-As an example of how to use these types to construct an error report, let’s explore how one could implement an error reporting type. In this example, our error reporting type will retrieve the source code location where each error in the chain was created (if it exists) and render it as part of the chain of errors. Our end goal is to get an error report that looks something like this:
+As an example of how to use this interface to construct an error report, let’s
+explore how one could implement an error reporting type. In this example, our
+error reporting type will retrieve the source code location where each error in
+the chain was created (if it exists) and render it as part of the chain of
+errors. Our end goal is to get an error report that looks something like this:
 
 ```
 Error:
@@ -57,7 +130,8 @@ Error:
     1: No such file or directory (os error 2)
 ```
 
-The first step is to define or use a type to represent a source location. In this example, we will define our own:
+The first step is to define or use a type to represent a source location. In
+this example, we will define our own:
 
 ```rust
 struct Location {
@@ -95,7 +169,7 @@ fn read_instrs(path: &Path) -> Result<String, ExampleError> {
 }
 ```
 
-Next, we need to implement the `Error` trait to expose these members to the error reporter.
+Then, we need to implement the `Error` trait to expose these members to the error reporter.
 
 ```rust
 impl std::error::Error for ExampleError {
@@ -103,17 +177,14 @@ impl std::error::Error for ExampleError {
         Some(&self.source)
     }
 
-    fn get_context(&self, type_id: TypeId) -> Option<&dyn Any> {
-        if id == TypeId::of::<Location>() {
-            Some(&self.location)
-        } else {
-            None
-        }
+    fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
+        request.provide::<Location>(&self.location)
     }
 }
 ```
 
-And, finally, we create an error reporter that prints the error and its source recursively, along with any location data that was gathered
+And, finally, we create an error reporter that prints the error and its source
+recursively, along with any location data that was gathered
 
 ```rust
 struct ErrorReporter(Box<dyn Error + Send + Sync + 'static>);
@@ -142,50 +213,146 @@ impl fmt::Debug for ErrorReporter {
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-There are two additions necessary to the standard library to implement this proposal:
+The following changes need to be made to implement this proposal:
 
-Add a function for dyn Error trait objects that will be used by error reporters to access members given a type. This function circumvents restrictions on generics in trait functions by being implemented for trait objects only, rather than as a member of the trait itself.
+## Add a type like [`ObjectProvider::Request`] to std
+
+This type fills the same role as `&dyn Any` except that it supports other trait
+objects as the requested type.
+
+Here is the implementation for the proof of concept:
+
+```rust
+/// A dynamic request for an object based on its type.
+///
+/// `'r` is the lifetime of request, and `'out` is the lifetime of the requested
+/// reference.
+pub struct Request<'r, 'out> {
+    buf: NonNull<TypeId>,
+    _marker: PhantomData<&'r mut &'out Cell<()>>,
+}
+
+impl<'r, 'out> Request<'r, 'out> {
+    /// Provides an object of type `T` in response to this request.
+    ///
+    /// Returns `Err(FulfilledRequest)` if the value was successfully provided,
+    /// and `Ok(self)` if `T` was not the type being requested.
+    ///
+    /// This method can be chained within `provide` implementations using the
+    /// `?` operator to concisely provide multiple objects.
+    pub fn provide<T: ?Sized + 'static>(self, value: &'out T) -> ProvideResult<'r, 'out> {
+        self.provide_with(|| value)
+    }
+
+    /// Lazily provides an object of type `T` in response to this request.
+    ///
+    /// Returns `Err(FulfilledRequest)` if the value was successfully provided,
+    /// and `Ok(self)` if `T` was not the type being requested.
+    ///
+    /// The passed closure is only called if the value will be successfully
+    /// provided.
+    ///
+    /// This method can be chained within `provide` implementations using the
+    /// `?` operator to concisely provide multiple objects.
+    pub fn provide_with<T: ?Sized + 'static, F>(mut self, cb: F) -> ProvideResult<'r, 'out>
+    where
+        F: FnOnce() -> &'out T,
+    {
+        match self.downcast_buf::<T>() {
+            Some(this) => {
+                debug_assert!(
+                    this.value.is_none(),
+                    "Multiple requests to a `RequestBuf` were acquired?"
+                );
+                this.value = Some(cb());
+                Err(FulfilledRequest(PhantomData))
+            }
+            None => Ok(self),
+        }
+    }
+
+    /// Get the `TypeId` of the requested type.
+    pub fn type_id(&self) -> TypeId {
+        unsafe { *self.buf.as_ref() }
+    }
+
+    /// Returns `true` if the requested type is the same as `T`
+    pub fn is<T: ?Sized + 'static>(&self) -> bool {
+        self.type_id() == TypeId::of::<T>()
+    }
+
+    /// Try to downcast this `Request` into a reference to the typed
+    /// `RequestBuf` object.
+    ///
+    /// This method will return `None` if `self` was not derived from a
+    /// `RequestBuf<'_, T>`.
+    fn downcast_buf<T: ?Sized + 'static>(&mut self) -> Option<&mut RequestBuf<'out, T>> {
+        if self.is::<T>() {
+            unsafe { Some(&mut *(self.buf.as_ptr() as *mut RequestBuf<'out, T>)) }
+        } else {
+            None
+        }
+    }
+
+    /// Calls the provided closure with a request for the the type `T`, returning
+    /// `Some(&T)` if the request was fulfilled, and `None` otherwise.
+    ///
+    /// The `ObjectProviderExt` trait provides helper methods specifically for
+    /// types implementing `ObjectProvider`.
+    pub fn with<T: ?Sized + 'static, F>(f: F) -> Option<&'out T>
+    where
+        for<'a> F: FnOnce(Request<'a, 'out>) -> ProvideResult<'a, 'out>,
+    {
+        let mut buf = RequestBuf {
+            type_id: TypeId::of::<T>(),
+            value: None,
+        };
+        let _ = f(Request {
+            buf: unsafe {
+                NonNull::new_unchecked(&mut buf as *mut RequestBuf<'out, T> as *mut TypeId)
+            },
+            _marker: PhantomData,
+        });
+        buf.value
+    }
+}
+
+// Needs to have a known layout so we can do unsafe pointer shenanigans.
+#[repr(C)]
+struct RequestBuf<'a, T: ?Sized> {
+    type_id: TypeId,
+    value: Option<&'a T>,
+}
+
+/// Marker type indicating a request has been fulfilled.
+pub struct FulfilledRequest(PhantomData<&'static Cell<()>>);
+
+/// Provider method return type.
+///
+/// Either `Ok(Request)` for an unfulfilled request, or `Err(FulfilledRequest)`
+/// if the request was fulfilled.
+pub type ProvideResult<'r, 'a> = Result<Request<'r, 'a>, FulfilledRequest>;
+```
+
+## Define a generic accessor on the `Error` trait
+
+```rust
+pub trait Error {
+    // ...
+
+    /// Provides an object of type `T` in response to this request.
+    fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
+        Ok(request)
+    }
+}
+```
+
+## Use this `Request` type to handle passing generic types out of the trait object
 
 ```rust
 impl dyn Error {
-    pub fn context<T: Any>(&self) -> Option<&T> {
-        self.get_context(TypeId::of::<T>())?.downcast_ref::<T>()
-    }
-}
-```
-
-With the expected usage:
-
-```rust
-// With explicit parameter passing
-let spantrace = error.context::<SpanTrace>();
-
-// With a type inference
-fn get_spantrace(error: &(dyn Error + 'static)) -> Option<&SpanTrace> {
-    error.context()
-}
-```
-
-Add a member to the `Error` trait to provide the `&dyn Any` trait objects to the `context` fn for each member based on the type_id.
-
-```rust
-trait Error {
-    /// ...
-
-    fn get_context(&self, id: TypeId) -> Option<&dyn Any> {
-        None
-    }
-}
-```
-
-With the expected usage:
-
-```rust
-fn get_context(&self, type_id: TypeId) -> Option<&dyn Any> {
-    if id == TypeId::of::<Location>() {
-        Some(&self.location)
-    } else {
-        None
+    pub fn context<T: ?Sized + 'static>(&self) -> Option<&T> {
+        Request::with::<T, _>(|req| self.get_context(req))
     }
 }
 ```
@@ -193,19 +360,13 @@ fn get_context(&self, type_id: TypeId) -> Option<&dyn Any> {
 # Drawbacks
 [drawbacks]: #drawbacks
 
-* The API for defining how to return types is cumbersome and possibly not accessible for new rust users.
-    * If the type is stored in an Option getting it converted to an `&Any` will probably challenge new devs, this can be made easier with documented examples covering common use cases and macros like `thiserror`.
-```rust
-} else if typeid == TypeId::of::<SpanTrace>() {
-    self.span_trace.as_ref().map(|s| s as &dyn Any)
-}
-```
-# TODO rewrite
-* When you return the wrong type and the downcast fails you get `None` rather than a compiler error guiding you to the right return type, which can make it challenging to debug mismatches between the type you return and the type you use to check against the type_id
-    * There is an alternative implementation that mostly avoids this issue
-* This approach cannot return slices or trait objects because of restrictions on `Any`
-    * The alternative implementation avoids this issue
-* The `context` function name is currently widely used throughout the rust error handling ecosystem in libraries like `anyhow` and `snafu` as an ergonomic version of `map_err`. If we settle on `context` as the final name it will possibly break existing libraries.
+* The `Request` api is being added purely to help with this fn, there may be
+  some design iteration here that could be done to make this more generally
+  applicable, it seems very similar to `dyn Any`.
+* The `context` function name is currently widely used throughout the rust
+  error handling ecosystem in libraries like `anyhow` and `snafu` as an
+  ergonomic version of `map_err`. If we settle on `context` as the final name
+  it will possibly break existing libraries.
 
 
 # Rationale and alternatives
@@ -215,45 +376,50 @@ The two alternatives I can think of are:
 
 ## Do Nothing
 
-We could not do this, and continue to add accessor functions to the `Error` trait whenever a new type reaches critical levels of popularity in error reporting.
+We could not do this, and continue to add accessor functions to the `Error`
+trait whenever a new type reaches critical levels of popularity in error
+reporting.
 
-If we choose to do nothing we will continue to see hacks around the current limitations on the error trait such as the `Fail` trait, which added the missing function access methods that didn't previously exist on the `Error` trait and type erasure / unnecessary boxing of errors to enable downcasting to extract members. [[1]](https://docs.rs/tracing-error/0.1.2/src/tracing_error/error.rs.html#269-274).
+If we choose to do nothing we will continue to see hacks around the current
+limitations on the error trait such as the `Fail` trait, which added the
+missing function access methods that didn't previously exist on the `Error`
+trait and type erasure / unnecessary boxing of errors to enable downcasting to
+extract members.
+[[1]](https://docs.rs/tracing-error/0.1.2/src/tracing_error/error.rs.html#269-274).
 
-## Use an alternative to Any for passing generic types across the trait boundary
 
-Nika Layzell has proposed an alternative implementation using a `Provider` type which avoids using `&dyn Any`. I do not necessarily think that the main suggestion is necessarily better, but it is much simpler.
+## Use an alternative proposal that relies on the `Any` trait for downcasting
 
-* https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=0af9dbf0cd20fa0bea6cff16a419916b
-* https://github.com/mystor/object-provider
-
-With this design an implementation of the `get_context` fn might instead look like:
+This approach is much simpler, but critically doesn't support providing
+dynamically sized types, and it is more error prone because it cannot provide
+compile time errors when the type you provide does not match the type_id you
+were given.
 
 ```rust
-fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
-    request
-        .provide::<PathBuf>(&self.path)?
-        .provide::<Path>(&self.path)?
-        .provide::<dyn Debug>(&self.path)
+pub trait Error {
+    /// Provide an untyped reference to a member whose type matches the provided `TypeId`.
+    ///
+    /// Returns `None` by default, implementors are encouraged to override.
+    fn provide(&self, ty: TypeId) -> Option<&dyn Any> {
+        None
+    }
+}
+
+impl dyn Error {
+    /// Retrieve a reference to `T`-typed context from the error if it is available.
+    pub fn request<T: Any>(&self) -> Option<&T> {
+        self.get_context(TypeId::of::<T>())?.downcast_ref::<T>()
+    }
 }
 ```
-
-The advantages of this design are that:
-
-1. It supports accessing trait objects and slices
-2. If the user specifies the type they are trying to pass in explicitly they will get compiler errors when the type doesn't match.
-3. Takes advantage of deref sugar to help with conversions from wrapper types to inner types.
-4. Less verbose implementation
-
-The disadvatages are:
-
-1. More verbose function signature, very lifetime heavy
-2. The Request type uses unsafe code which needs to be verified
-3. could encourage implementations where they pass the provider to `source.provide` first which would prevent the error reporter from knowing which error in the chain gathered each piece of context and might cause context to show up multiple times in a report.
 
 # Prior art
 [prior-art]: #prior-art
 
-I do not know of any other languages whose error handling has similar facilities for accessing members when reporting errors. For the most part prior art exists within rust itself in the form of previous additions to the `Error` trait.
+I do not know of any other languages whose error handling has similar
+facilities for accessing members when reporting errors. For the most part prior
+art exists within rust itself in the form of previous additions to the `Error`
+trait.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
@@ -262,17 +428,32 @@ I do not know of any other languages whose error handling has similar facilities
     * `context`/`context_ref`/`get_context`/`provide_context`
     * `member`/`member_ref`
     * `provide`/`request`
-* Should we go with the implementation that uses `Any` or the one that supports accessing dynamically sized types like traits and slices?
 * Should there be a by value version for accessing temporaries?
-    * We bring this up specifically for the case where you want to use this function to get an `Option<&[&dyn Error]>` out of an error, in this case its unlikely that the error behind the trait object is actually storing the errors as `dyn Errors`, and theres no easy way to allocate storage to store the trait objects.
+    * We bring this up specifically for the case where you want to use this
+      function to get an `Option<&[&dyn Error]>` out of an error, in this case
+      its unlikely that the error behind the trait object is actually storing
+      the errors as `dyn Errors`, and theres no easy way to allocate storage to
+      store the trait objects.
 * How should context handle failed downcasts?
-    * suggestion: panic, as providing a type that doesn't match the typeid requested is a program error
+    * suggestion: panic, as providing a type that doesn't match the typeid
+      requested is a program error
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-We'd love to see the various error creating libraries like `thiserror` adding support for making members exportable as context for reporters.
+Libraries like `thiserror` could add support for making members exportable as
+context for reporters.
 
-Also, we're interested in adding support for `Error Return Traces`, similar to zigs, and I think that this accessor function might act as a critical piece of that implementation.
+This opens the door to supporting `Error Return Traces`, similar to zigs, where
+if each return location is stored in a `Vec<&'static Location<'static>>` a full
+return trace could be built up with:
+
+```rust
+let mut locations = e
+    .chain()
+    .filter_map(|e| e.context::<[&'static Location<'static>]>())
+    .flat_map(|locs| locs.iter());
+```
 
 [`SpanTrace`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.SpanTrace.html
+[`ObjectProvider::Request`]: https://github.com/yaahc/nostd-error-poc/blob/master/fakecore/src/any.rs

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -1,4 +1,4 @@
-- Feature Name: Add fns for generic member access to dyn Error and the Error trait
+- Feature Name: Add functions for generic member access to dyn Error and the Error trait
 - Start Date: 2020-04-01
 - RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/2895)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
@@ -10,7 +10,7 @@ This RFC proposes additions to the `Error` trait to support accessing generic
 forms of context from `dyn Error` trait objects. This generalizes the pattern
 used in `backtrace` and `source`. This proposal adds the method
 `Error::get_context` to the error trait, which offers `TypeId`-based member
-lookup and a new inherent fn `<dyn Error>::context` which makes use of an
+lookup and a new inherent function `<dyn Error>::context` which makes use of an
 implementor's `get_context` to return a typed reference directly. These
 additions would primarily be useful for error reporting, where we typically no
 longer have type information and may be composing errors from many sources.
@@ -85,14 +85,14 @@ many new forms of error reporting.
   gathered via `#[track_caller]` or similar.
 * error source trees instead of chains by accessing the source of an error as a
   slice of errors rather than as a single error, such as a set of errors caused
-  when parsing a file
+  when parsing a file TODO reword
 * Help text such as suggestions or warnings attached to an error report
 
 ## Moving `Error` into `libcore`
 
 Adding a generic member access function to the Error trait and removing the
-`backtrace` fn would make it possible to move the `Error` trait to libcore
-without losing support for backtraces on std. The only difference would be that
+`backtrace` function would make it possible to move the `Error` trait to libcore
+without losing support for backtraces on std. The only difference being that
 in places where you can currently write `error.backtrace()` on nightly you
 would instead need to write `error.context::<Backtrace>()`.
 
@@ -109,10 +109,10 @@ constructing reports for end users while still retaining control over the
 format of the full report.
 
 The error trait accomplishes this by providing a set of methods for accessing
-members of `dyn Error` trait objects. It requires types implement the display
-trait, which acts as the interface to the main member, the error message
-itself.  It provides the `source` function for accessing `dyn Error` members,
-which typically represent the current error's cause. It provides the
+members of `dyn Error` trait objects. It requires that types implement the
+display trait, which acts as the interface to the main member, the error
+message itself.  It provides the `source` function for accessing `dyn Error`
+members, which typically represent the current error's cause. It provides the
 `backtrace` function, for accessing a `Backtrace` of the state of the stack
 when an error was created. For all other forms of context relevant to an error
 report, the error trait provides the `context` and `get_context` functions.
@@ -120,8 +120,9 @@ report, the error trait provides the `context` and `get_context` functions.
 As an example of how to use this interface to construct an error report, let’s
 explore how one could implement an error reporting type. In this example, our
 error reporting type will retrieve the source code location where each error in
-the chain was created (if it exists) and render it as part of the chain of
-errors. Our end goal is to get an error report that looks something like this:
+the chain was created (if it captured a location) and render it as part of the
+chain of errors. Our end goal is to get an error report that looks something
+like this:
 
 ```
 Error:
@@ -363,7 +364,7 @@ impl dyn Error {
 # Drawbacks
 [drawbacks]: #drawbacks
 
-* The `Request` api is being added purely to help with this fn, there may be
+* The `Request` api is being added purely to help with this function, there may be
   some design iteration here that could be done to make this more generally
   applicable, it seems very similar to `dyn Any`.
 * The `context` function name is currently widely used throughout the rust

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -268,61 +268,55 @@ A usable version of this is available in the [proof of concept] repo under
 
 ```rust
 use core::any::TypeId;
-use core::cell::Cell;
 use core::fmt;
-use core::marker::PhantomData;
+use core::marker::{PhantomData, PhantomPinned};
 use core::pin::Pin;
 
 /// A dynamic request for an object based on its type.
-///
-/// `'out` is the lifetime of the requested reference.
-#[repr(transparent)]
-pub struct Request<'out>(RequestBuf<PhantomData<&'out Cell<()>>>);
-// FIXME: The argument of the RequestBuf should be a thin unsized type,
-// but `extern type` is impossible to use correctly right now
-// (it cannot be placed at offset > 0, and it cannot be placed inside a union).
-// Since miri doesn't complain we'll let it slide.
+#[repr(C)]
+pub struct Request<'a> {
+    type_id: TypeId,
+    _pinned: PhantomPinned,
+    _marker: PhantomData<&'a ()>,
+}
 
-impl<'out> Request<'out> {
+impl<'a> Request<'a> {
     /// Provides an object of type `T` in response to this request.
     ///
-    /// Returns `Err(FulfilledRequest)` if the value was successfully provided,
-    /// and `Ok(self)` if `T` was not the type being requested.
+    /// If an object of type `T` has already been provided for this request, the
+    /// existing value will be replaced by the newly provided value.
     ///
-    /// This method can be chained within `provide` implementations using the
-    /// `?` operator to concisely provide multiple objects.
-    pub fn provide<T: ?Sized + 'static>(&mut self, value: &'out T) -> &mut Self {
+    /// This method can be chained within `provide` implementations to concisely
+    /// provide multiple objects.
+    pub fn provide<T: ?Sized + 'static>(self: Pin<&mut Self>, value: &'a T) -> Pin<&mut Self> {
         self.provide_with(|| value)
     }
 
     /// Lazily provides an object of type `T` in response to this request.
     ///
-    /// Returns `Err(FulfilledRequest)` if the value was successfully provided,
-    /// and `Ok(self)` if `T` was not the type being requested.
+    /// If an object of type `T` has already been provided for this request, the
+    /// existing value will be replaced by the newly provided value.
     ///
     /// The passed closure is only called if the value will be successfully
     /// provided.
     ///
-    /// This method can be chained within `provide` implementations using the
-    /// `?` operator to concisely provide multiple objects.
-    pub fn provide_with<T: ?Sized + 'static, F>(&mut self, cb: F) -> &mut Self
+    /// This method can be chained within `provide` implementations to concisely
+    /// provide multiple objects.
+    pub fn provide_with<T: ?Sized + 'static, F>(mut self: Pin<&mut Self>, cb: F) -> Pin<&mut Self>
     where
-        F: FnOnce() -> &'out T,
+        F: FnOnce() -> &'a T,
     {
-        if self.is::<T>() {
-            let this = unsafe { &mut *(self as *mut _ as *mut RequestBuf<Option<&'out T>>) };
-            debug_assert!(
-                this.value.is_none(),
-                "Multiple requests to a `RequestBuf` were acquired?"
-            );
-            this.value = Some(cb());
+        if let Some(buf) = self.as_mut().downcast_buf::<T>() {
+            // NOTE: We could've already provided a value here of type `T`,
+            // which will be clobbered in this case.
+            *buf = Some(cb());
         }
         self
     }
 
     /// Get the `TypeId` of the requested type.
     pub fn type_id(&self) -> TypeId {
-        self.0.type_id
+        self.type_id
     }
 
     /// Returns `true` if the requested type is the same as `T`
@@ -330,28 +324,41 @@ impl<'out> Request<'out> {
         self.type_id() == TypeId::of::<T>()
     }
 
+    /// Try to downcast this `Request` into a reference to the typed
+    /// `RequestBuf` object, and access the trailing `Option<&'a T>`.
+    ///
+    /// This method will return `None` if `self` is not the prefix of a
+    /// `RequestBuf<'_, T>`.
+    fn downcast_buf<T: ?Sized + 'static>(self: Pin<&mut Self>) -> Option<&mut Option<&'a T>> {
+        if self.is::<T>() {
+            // Safety: `self` is pinned, meaning it exists as the first
+            // field within our `RequestBuf`. As the type matches, and
+            // `RequestBuf` has a known in-memory layout, this downcast is
+            // sound.
+            unsafe {
+                let ptr = self.get_unchecked_mut() as *mut Self as *mut RequestBuf<'a, T>;
+                Some(&mut (*ptr).value)
+            }
+        } else {
+            None
+        }
+    }
+
     /// Calls the provided closure with a request for the the type `T`, returning
     /// `Some(&T)` if the request was fulfilled, and `None` otherwise.
-    ///
-    /// The `ObjectProviderExt` trait provides helper methods specifically for
-    /// types implementing `ObjectProvider`.
-    pub fn with<T: ?Sized + 'static, F>(f: F) -> Option<&'out T>
+    pub fn with<T: ?Sized + 'static, F>(f: F) -> Option<&'a T>
     where
         F: FnOnce(Pin<&mut Self>),
     {
-        let mut buf = RequestBuf {
-            type_id: TypeId::of::<T>(),
-            value: None,
-        };
-        unsafe {
-            let request = &mut *(&mut buf as *mut _ as *mut Request);
-            f(Pin::new(request));
-        }
-        buf.value
+        let mut buf = RequestBuf::new();
+        // safety: We never move `buf` after creating `pinned`.
+        let mut pinned = unsafe { Pin::new_unchecked(&mut buf) };
+        f(pinned.as_mut().request());
+        pinned.take()
     }
 }
 
-impl<'out> fmt::Debug for Request<'out> {
+impl<'a> fmt::Debug for Request<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Request")
             .field("type_id", &self.type_id())
@@ -361,9 +368,32 @@ impl<'out> fmt::Debug for Request<'out> {
 
 // Needs to have a known layout so we can do unsafe pointer shenanigans.
 #[repr(C)]
-struct RequestBuf<T: ?Sized> {
-    type_id: TypeId,
-    value: T,
+struct RequestBuf<'a, T: ?Sized + 'static> {
+    request: Request<'a>,
+    value: Option<&'a T>,
+}
+
+impl<'a, T: ?Sized + 'static> RequestBuf<'a, T> {
+    fn new() -> Self {
+        RequestBuf {
+            request: Request {
+                type_id: TypeId::of::<T>(),
+                _pinned: PhantomPinned,
+                _marker: PhantomData,
+            },
+            value: None,
+        }
+    }
+
+    fn request(self: Pin<&mut Self>) -> Pin<&mut Request<'a>> {
+        // safety: projecting Pin onto our `request` field.
+        unsafe { self.map_unchecked_mut(|this| &mut this.request) }
+    }
+
+    fn take(self: Pin<&mut Self>) -> Option<&'a T> {
+        // safety: `Option<&'a T>` is `Unpin`
+        unsafe { self.get_unchecked_mut().value.take() }
+    }
 }
 ```
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -390,10 +390,9 @@ extract members.
 
 ## Use an alternative proposal that relies on the `Any` trait for downcasting
 
-This approach is much simpler, but critically doesn't support providing
-dynamically sized types, and it is more error prone because it cannot provide
-compile time errors when the type you provide does not match the type_id you
-were given.
+This approach is simpler, but doesn't support providing dynamically sized
+types and is more error prone because it cannot provide compile time errors
+when the type you provide does not match the type_id you were given.
 
 ```rust
 pub trait Error {
@@ -441,9 +440,6 @@ trait.
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Libraries like `thiserror` could add support for making members exportable as
-context for reporters.
-
 This opens the door to supporting `Error Return Traces`, similar to zigs, where
 if each return location is stored in a `Vec<&'static Location<'static>>` a full
 return trace could be built up with:
@@ -457,3 +453,4 @@ let mut locations = e
 
 [`SpanTrace`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.SpanTrace.html
 [`ObjectProvider::Request`]: https://github.com/yaahc/nostd-error-poc/blob/master/fakecore/src/any.rs
+

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -44,7 +44,7 @@ fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 
         .provide::<SpanTrace>(&self.span_trace)?
         .provide::<dyn Error>(&self.source)?
         .provide::<Vec<&'static Location<'static>>>(&self.locations)?
-        .provide::<[&'static Location<'static>>(&self.locations)
+        .provide::<[&'static Location<'static>]>(&self.locations)
 }
 ```
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -6,10 +6,16 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes a pair of additions to the `Error` trait to support accessing
-generic forms of context from `dyn Error` trait objects. These functions will
-act as a generalized version of `backtrace` and `source`, and would primarily
-be used during error reporting when rendering a chain of opaque errors.
+This RFC proposes two additions to the `Error` trait to support accessing
+generic forms of context from `dyn Error` trait objects, generalizing the
+pattern used in `backtrace` and `source` and allowing ecosystem iteration on
+error reporting infrastructure outside of the standard library. The two
+proposed additions are a new trait method `Error::provide_context` which offers
+`TypeId`-based member lookup and a new inherent fn `<dyn Error>::context` which
+makes use of an implementor's `provide_context` to return a typed reference
+directly. These additions would primarily be useful in "error reporting"
+contexts where we typically no longer have type information and may be
+composing errors from many sources.
 
 ```rust
 pub trait Error {

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -198,7 +198,7 @@ struct ExampleError {
 
 impl fmt::Display for ExampleError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "Failed to read instrs from {}", path.display())
+        write!(fmt, "Failed to read instrs from {}", self.path.display())
     }
 }
 
@@ -737,7 +737,7 @@ previous additions to the `Error` trait.
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-This opens the door to supporting `Error Return Traces`, similar to zigs, where
+This opens the door to supporting [`Error Return Traces`](https://ziglang.org/documentation/master/#toc-Error-Return-Traces), similar to zigs, where
 if each return location is stored in a `Vec<&'static Location<'static>>` a full
 return trace could be built up with:
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -9,18 +9,15 @@
 This RFC proposes additions to the `Error` trait to support accessing generic
 forms of context from `dyn Error` trait objects. This generalizes the pattern
 used in `backtrace` and `source` and allows ecosystem iteration on error
-reporting infrastructure outside of the standard library. The two proposed
-additions are a new trait method `Error::get_context`, which offers
-`TypeId`-based member lookup, and a new inherent fn `<dyn Error>::context`,
+reporting infrastructure outside of the standard library. This proposal adds
+the method `Error::get_context` to the error trait, which offers `TypeId`-based
+member lookup, and a new inherent fn `<dyn Error>::context`,
 which makes use of an implementor's `get_context` to return a typed reference
 directly. These additions would primarily be useful in "error reporting"
 contexts, where we typically no longer have type information and may be
 composing errors from many sources.
 
-The names here are just placeholders. The specifics of the `Request` type are a
-suggested starting point. And the `Request` style api could be replaced with a
-much simpler API based on  `TypeId` + `dyn Any` at the cost of being
-incompatible with dynamically sized types. The basic proposal is this:
+## TLDR
 
 Add this method to the `Error` trait
 
@@ -35,7 +32,7 @@ pub trait Error {
 }
 ```
 
-Where an example implementation of this method would look like:
+Example implementation:
 
 ```rust
 fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 'a> {
@@ -48,7 +45,7 @@ fn get_context<'r, 'a>(&'a self, request: Request<'r, 'a>) -> ProvideResult<'r, 
 }
 ```
 
-And usage would then look like this:
+Example usage:
 
 ```rust
 let e: &dyn Error = &concrete_error;
@@ -63,7 +60,7 @@ if let Some(bt) = e.context::<Backtrace>() {
 
 In Rust, errors typically gather two forms of context when they are created:
 context for the *current error message* and context for the *final* *error
-report*. The `Error` trait exists to provide a interface to context intended
+report*. The `Error` trait exists to provide an interface to context intended
 for error reports. This context includes the error message, the source error,
 and, more recently, backtraces.
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -353,14 +353,9 @@ impl<'a> Request<'a> {
         self
     }
 
-    /// Get the `TypeId` of the requested type.
-    fn type_id(&self) -> TypeId {
-        self.type_id
-    }
-
     /// Returns `true` if the requested type is the same as `T`
     pub fn is<T: ?Sized + 'static>(&self) -> bool {
-        self.type_id() == TypeId::of::<T>()
+        self.type_id == TypeId::of::<T>()
     }
 
     /// Try to downcast this `Request` into a reference to the typed
@@ -400,7 +395,7 @@ impl<'a> Request<'a> {
 impl<'a> fmt::Debug for Request<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Request")
-            .field("type_id", &self.type_id())
+            .field("type_id", &self.type_id)
             .finish()
     }
 }

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -222,8 +222,11 @@ The following changes need to be made to implement this proposal:
 This type fills the same role as `&dyn Any` except that it supports other trait
 objects as the requested type.
 
-Here is the implementation for the proof of concept, taken from Nika Layzell's
+Here is the implementation for the proof of concept, based on Nika Layzell's
 [object-provider crate]:
+
+A usable version of this is available in the [proof of concept] repo under
+`fakecore/src/any.rs`.
 
 ```rust
 use core::any::TypeId;
@@ -453,3 +456,4 @@ let mut locations = e
 [`Request`]: https://github.com/yaahc/nostd-error-poc/blob/master/fakecore/src/any.rs
 [alternative proposal]: #use-an-alternative-proposal-that-relies-on-the-any-trait-for-downcasting
 [object-provider crate]: https://github.com/mystor/object-provider
+[proof of concept]: https://github.com/yaahc/nostd-error-poc

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -219,12 +219,13 @@ reports enriched by information that may be present in source errors.
 
 The following changes need to be made to implement this proposal:
 
-### Add a type like [`ObjectProvider::Request`] to std
+### Add a type like [`Request`] to std
 
 This type fills the same role as `&dyn Any` except that it supports other trait
 objects as the requested type.
 
-Here is the implementation for the proof of concept:
+Here is the implementation for the proof of concept, taken from Nika Layzell's
+[object-provider crate]:
 
 ```rust
 /// A dynamic request for an object based on its type.
@@ -465,5 +466,6 @@ let mut locations = e
 ```
 
 [`SpanTrace`]: https://docs.rs/tracing-error/0.1.2/tracing_error/struct.SpanTrace.html
-[`ObjectProvider::Request`]: https://github.com/yaahc/nostd-error-poc/blob/master/fakecore/src/any.rs
+[`Request`]: https://github.com/yaahc/nostd-error-poc/blob/master/fakecore/src/any.rs
 [alternative proposal]: #use-an-alternative-proposal-that-relies-on-the-any-trait-for-downcasting
+[object-provider crate]: https://github.com/mystor/object-provider

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -354,7 +354,7 @@ impl<'a> Request<'a> {
     }
 
     /// Get the `TypeId` of the requested type.
-    pub fn type_id(&self) -> TypeId {
+    fn type_id(&self) -> TypeId {
         self.type_id
     }
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -236,10 +236,9 @@ fn provide_context(&self, type_id: TypeId) -> Option<&dyn Any> {
   use to check against the type_id
     * The downcast could be changed to panic when it fails
     * There is an alternative implementation that mostly avoids this issue
-* Introduces more overhead from the downcasts
 * This approach cannot return slices or trait objects because of restrictions
   on `Any`
-    * The alternative solution avoids this issue
+    * The alternative implementation avoids this issue
 * The `context` function name is currently widely used throughout the rust
   error handling ecosystem in libraries like `anyhow` and `snafu` as an
   ergonomic version of `map_err`. If we settle on `context` as the final name
@@ -268,8 +267,9 @@ extract members.
 Nika Layzell has proposed an alternative implementation using a `Provider` type
 which avoids using `&dyn Any`. I do not necessarily think that the main
 suggestion is necessarily better, but it is much simpler.
-    * https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=0af9dbf0cd20fa0bea6cff16a419916b
-    * https://github.com/mystor/object-provider
+
+* https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=0af9dbf0cd20fa0bea6cff16a419916b
+* https://github.com/mystor/object-provider
 
 With this design an implementation of the `provide_context` fn might instead look like:
 
@@ -287,7 +287,9 @@ The advantages of this design are that:
 1. It supports accessing trait objects and slices
 2. If the user specifies the type they are trying to pass in explicitly they
    will get compiler errors when the type doesn't match.
-3. Less verbose implementation
+3. Takes advantage of deref sugar to help with conversions from wrapper types
+   to inner types.
+4. Less verbose implementation
 
 The disadvatages are:
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -440,11 +440,11 @@ previous additions to the `Error` trait.
     * `context`/`context_ref`/`get_context`/`provide_context`
     * `member`/`member_ref`
     * `provide`/`request`
-* Should there be a by value version for accessing temporaries?
+* Should there be a by-value version for accessing temporaries?
     * We bring this up specifically for the case where you want to use this
-      function to get an `Option<&[&dyn Error]>` out of an error, in this case
-      its unlikely that the error behind the trait object is actually storing
-      the errors as `dyn Errors`, and theres no easy way to allocate storage to
+      function to get an `Option<&[&dyn Error]>` out of an error, in this case,
+      it is unlikely that the error behind the trait object is actually storing
+      the errors as `dyn Error`s, and theres no easy way to allocate storage to
       store the trait objects.
 * How should context handle failed downcasts?
     * suggestion: panic, as providing a type that doesn't match the typeid


### PR DESCRIPTION
This PR is a duplicate of #2895, which I have agreed to take over for @yaahc. The idea is to close that in favor of this PR so I can drive additional changes as feedback comes in.

The current state of this proposal is as follows:

* A [implementation](nightly_implementation) gated by the `error_generic_member_access` feature flag is available in nightly.
* There is an [open PR](feedback_pr) to address feedback from the [`provide_any` tracking issue](provide_any_tracking) in nightly.
* It has been proposed to supercede the [`provide_any` feature](provide_any) by taking on the `Demand`/`Request` API (minus the `Provider` trait) for the sake of generic member access on `dyn Error`.

[nightly_implementation]: https://github.com/rust-lang/rust/blob/399b068235ceea440540539b3bfd1aeb82214a28/library/core/src/error.rs#L194
[provide_any]: https://github.com/rust-lang/rfcs/pull/3460
[pr_to_address_feedback]: https://github.com/rust-lang/rust/pull/113464
[provide_any_tracking]: https://github.com/rust-lang/rust/issues/96024


[Rendered](https://github.com/waynr/rust-rfcs/blob/error_generic_member_access/text/0000-dyn-error-generic-member-access.md)