### PR TITLE
Fix start date format in RFC 0201

### DIFF
--- a/text/0201-error-chaining.md
+++ b/text/0201-error-chaining.md
@@ -1,4 +1,4 @@
-- Start Date: (fill me in with today's date, 2014-07-17)
+- Start Date: 2014-07-17
 - RFC PR #: [rust-lang/rfcs#201](https://github.com/rust-lang/rfcs/pull/201)
 - Rust Issue #: [rust-lang/rust#17747](https://github.com/rust-lang/rust/issues/17747)
 


### PR DESCRIPTION
Fix start date accoding to the format of `YYYY-MM-DD` in `0000-template.md`.

[Rendered](https://github.com/xzmeng/rfcs/blob/fix-start-date-format-0201/text/0201-error-chaining.md)