### PR TITLE
Update 2094-nll.md

### DIFF
--- a/text/2094-nll.md
+++ b/text/2094-nll.md
@@ -919,7 +919,7 @@ let foo = Foo { ... };
 let p: &'p mut Foo = &mut foo;
 let q: &'q mut &'p mut Foo = &mut p;
 let r: &'r mut Foo = &mut **q;
-use(*p); // <-- This line should result in an ERROR
+use(p); // or use(*q); // <-- This line should result in an ERROR
 use(r);
 ```
 


### PR DESCRIPTION
the type of *p is Foo, so here use p or *q.

[Rendered](https://github.com/davidyangss/rfcs/blob/patch-1/text/2094-nll.md)