### PR TITLE
unauthenticated @rustbot label T-*

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,5 +1,6 @@
 [relabel]
 allow-unauthenticated = [
     "A-*",
+    "T-*",
     "not-rfc",
 ]


### PR DESCRIPTION
This is allowed in [`rust-lang/rust`](https://github.com/rust-lang/rust/blob/62d9034a0d571b78e518727d6cb4b090569e5238/triagebot.toml#L12).

Others have also expected it to work in this repo:
- https://github.com/rust-lang/rfcs/pull/3490#issuecomment-1722720545
- https://github.com/rust-lang/rfcs/pull/3485#issuecomment-1712657835

@rustbot label not-rfc