### PR TITLE
Notify Zulip stream on types nominations

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -14,3 +14,13 @@ message_on_add = "A new T-cargo RFC has been opened: https://github.com/rust-lan
 zulip_stream = 318791 # t-crates-io
 topic = "RFC #{number} - {title}"
 message_on_add = "A new T-crates-io RFC has been opened: https://github.com/rust-lang/rfcs/pull/{number}"
+
+[notify-zulip."I-types-nominated"]
+zulip_stream = 326866 # #T-types/nominated
+topic = "RFC #{number}: {title}"
+message_on_add = """\
+@*T-types* RFC #{number} "{title}" has been nominated for team discussion.
+"""
+message_on_remove = "RFC #{number}'s nomination has been removed. Thanks all for participating!"
+message_on_close = "RFC #{number} has been closed. Thanks for participating!"
+message_on_reopen = "RFC #{number} has been reopened. Pinging @*T-types*."


### PR DESCRIPTION
Implements [#t-types/types-nominated rfcs](https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types/topic/types-nominated.20rfcs).

I've just copied the relevant entry from the `triagebot.toml` in `rust-lang/rust` and tweaked it slightly: https://github.com/rust-lang/rust/blob/af685931799459879b2a8995524755a06ffb5eec/triagebot.toml#L387-L395