### PR TITLE
Fix links in `triagebot.toml`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,8 +19,8 @@ message_on_add = "A new T-crates-io RFC has been opened: https://github.com/rust
 zulip_stream = 326866 # #T-types/nominated
 topic = "RFC #{number}: {title}"
 message_on_add = """\
-@*T-types* RFC #{number} "{title}" has been nominated for team discussion.
+@*T-types* RFC [{number}](https://github.com/rust-lang/rfcs/pull/{number}) "{title}" has been nominated for team discussion.
 """
-message_on_remove = "RFC #{number}'s nomination has been removed. Thanks all for participating!"
-message_on_close = "RFC #{number} has been closed. Thanks for participating!"
-message_on_reopen = "RFC #{number} has been reopened. Pinging @*T-types*."
+message_on_remove = "RFC [{number}](https://github.com/rust-lang/rfcs/pull/{number})'s nomination has been removed. Thanks all for participating!"
+message_on_close = "RFC [{number}](https://github.com/rust-lang/rfcs/pull/{number}) has been closed. Thanks for participating!"
+message_on_reopen = "RFC [{number}](https://github.com/rust-lang/rfcs/pull/{number}) has been reopened. Pinging @*T-types*."


### PR DESCRIPTION
Oops, `#NNN` links to `rust-lang/rust` by default, not `rust-lang/rfcs`. :facepalm:
Fix the links I added in #3499.

Sorry for the noise y'all :see_no_evil: 