### PR TITLE
Add back intentional typo in RFC 3013

### DIFF
--- a/text/3013-conditional-compilation-checking.md
+++ b/text/3013-conditional-compilation-checking.md
@@ -13,7 +13,7 @@ the risks is that a condition may contain misspelled identifiers, or may use ide
 obsolete or have been removed from a product. For example:
 
 ```rust
-#[cfg(feature = "widnows")]
+#[cfg(feature = "widnows")]    // notice the typo!
 fn do_windows_thing() { /* ... */ }
 ```
 

--- a/text/3013-conditional-compilation-checking.md
+++ b/text/3013-conditional-compilation-checking.md
@@ -13,7 +13,7 @@ the risks is that a condition may contain misspelled identifiers, or may use ide
 obsolete or have been removed from a product. For example:
 
 ```rust
-#[cfg(feature = "windows")]
+#[cfg(feature = "widnows")]
 fn do_windows_thing() { /* ... */ }
 ```
 


### PR DESCRIPTION
The typo which was corrected in 1ddcc5fda380fc5b5be21532ae1c9d15d77105d7 was intentional as the purpose of RFC 3013 is to enable the Rust compiler to detect typos such as the example given. I've reverted the change and added a comment to draw attention to the intentional typo. 