### PR TITLE
Move `rustdoc-types` crate to T-Rustdoc ownership.

### DIFF
--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from being privately maintained to being officially maintained by the rustdoc team.
+The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from being individually maintained to being officially maintained by the rustdoc team.
 
 # Motivation
 [motivation]: #motivation
@@ -31,7 +31,10 @@ The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from b
 
 Currently I ([`@aDotInTheVoid`](https://github.com/aDotInTheVoid/)) maintain the `rustdoc-types` crate on [my personal github](https://github.com/aDotInTheVoid/rustdoc-types/). No-one else has either github or crates.io permissions. This means if I become unable (or more likely disinterested), the crate will not see updates.
 
-Additionally, if an update to `rustdoc-json-types` happens while i'm away from a computer for an extended period of time, their will be a delay in this update being published on crates.io. [This almost happened](https://github.com/aDotInTheVoid/rustdoc-types/issues/25), but was avoided due to the bors queue being quiet at the time.
+Additionally, if an update to `rustdoc-json-types` happens while I'm away from a computer for an extended period of time, their will be a delay in this update being published on crates.io. This happened with format_version 29, which was merged on [April 8th](https://github.com/rust-lang/rust/commit/537aab7a2e7fe9cdf50b5ff18485e0793cd8db62),
+but was only published to crates.io on
+[April 19th](https://github.com/aDotInTheVoid/rustdoc-types/commit/ad92b911488dd42681e3dc7e496f777f556a94f6), due to personal reasons.
+[This almost happened previously](https://github.com/aDotInTheVoid/rustdoc-types/issues/25), but was avoided due to the bors queue being quiet at the time.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -11,7 +11,7 @@ The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from b
 # Motivation
 [motivation]: #motivation
 
-[`rustdoc-types`](https://crates.io/crates/rustdoc-types) is a crate published on crates.io. It is used by users of the unstable [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578) backend to provided a type representing the output of `rustdoc --output-format json`.  It's published on crates.io to be used by out-of-tree tools that take rustdoc-json as an input. Eg:.
+[`rustdoc-types`](https://crates.io/crates/rustdoc-types) is a crate published on crates.io. It is used by users of the unstable [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578) backend to provided a type representing the output of `rustdoc --output-format json`.  It's published on crates.io to be used by out-of-tree tools that take rustdoc-json as an input. E.g:
 
 | Name | Purpose |
 |--|--|
@@ -29,9 +29,9 @@ The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from b
 
 [RFC 1977]: https://rust-lang.github.io/rfcs/1977-public-private-dependencies.html
 
-Currently I ([`@aDotInTheVoid`](https://github.com/aDotInTheVoid/)) maintain the `rustdoc-types` crate on [my personal github](https://github.com/aDotInTheVoid/rustdoc-types/). No-one else has either github or crates.io permissions. This means if I become unable (or more likely disinterested), the crate will not see updates.
+Currently I ([`@aDotInTheVoid`](https://github.com/aDotInTheVoid/)) maintain the `rustdoc-types` crate on [my personal GitHub](https://github.com/aDotInTheVoid/rustdoc-types/). No-one else has either GitHub or crates.io permissions. This means if I become unable (or more likely disinterested), the crate will not see updates.
 
-Additionally, if an update to `rustdoc-json-types` happens while I'm away from a computer for an extended period of time, their will be a delay in this update being published on crates.io. This happened with format_version 29, which was merged on [April 8th](https://github.com/rust-lang/rust/commit/537aab7a2e7fe9cdf50b5ff18485e0793cd8db62),
+Additionally, if an update to `rustdoc-json-types` happens while I'm away from a computer for an extended period of time, there will be a delay in this update being published on crates.io. This happened with format_version 29, which was merged on [April 8th](https://github.com/rust-lang/rust/commit/537aab7a2e7fe9cdf50b5ff18485e0793cd8db62),
 but was only published to crates.io on
 [April 19th](https://github.com/aDotInTheVoid/rustdoc-types/commit/ad92b911488dd42681e3dc7e496f777f556a94f6), due to personal reasons.
 [This almost happened previously](https://github.com/aDotInTheVoid/rustdoc-types/issues/25), but was avoided due to the bors queue being quiet at the time.
@@ -47,26 +47,26 @@ This involves:
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-`rustdoc-types` is a republishing of the in-tree [`rustdoc-json-types`](https://github.com/rust-lang/rust/tree/b8536c1aa1973dd2438841815b1eeec129480e45/src/rustdoc-json-types) crate. `rustdoc-json-types` is a dependency of `librustdoc`, and is the canonical source of truth for the rustdoc-json output format. Changes to the format are made a a PR to `rust-lang/rust`, and will modify `src/rustdoc-json-types`, `src/librustdoc/json` and `tests/rustdoc-json`. None of this will change.
+`rustdoc-types` is a republishing of the in-tree [`rustdoc-json-types`](https://github.com/rust-lang/rust/tree/b8536c1aa1973dd2438841815b1eeec129480e45/src/rustdoc-json-types) crate. `rustdoc-json-types` is a dependency of `librustdoc`, and is the canonical source of truth for the rustdoc-json output format. Changes to the format are made as a PR to `rust-lang/rust`, and will modify `src/rustdoc-json-types`, `src/librustdoc/json` and `tests/rustdoc-json`. None of this will change.
 
 Republishing `rustdoc-json-types` as `rustdoc-types` is done with [a script](https://github.com/aDotInTheVoid/rustdoc-types/blob/17cbe9f8f07de954261dbb9536c394381770de7b/update.sh) so that it is as low maintenance as possible. This also ensures that all format/documentation changes happen in the rust-lang/rust repo, and go through the normal review process there.
 
-The update/publishing process will be moved to T-Rustdoc. In the medium term, I (`@aDotInTheVoid`) will still do it, but
+The update/publishing process will be moved to T-rustdoc. In the medium term, I (`@aDotInTheVoid`) will still do it, but
 - In an official capacity
 - With bus factor for when I stop.
 
-We (T-Rustdoc) will continue to publish new version of the `rustdoc-types` crate
+We (T-rustdoc) will continue to publish a new version of the `rustdoc-types` crate
 every time the upstream implementation changes, and these will be versioned with
-normal semver. Changes to rustdoc-json in `rust-lang/rust` will not be accepted
+normal SemVer. Changes to rustdoc-json in `rust-lang/rust` will not be accepted
 if they would make it not possible to publish `rustdoc-types`.
 
 ## Actual Mechanics of the move
 
-### Github
+### GitHub
 
-Github has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transferring repositories. T-Infra will handle the permissions of moving the repository into the rust-lang github organization.
+GitHub has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transferring repositories. T-infra will handle the permissions of moving the repository into the rust-lang GitHub organization.
 
-At the end of this we should have a crate in the rust-lang github org with T-Rustdoc as contributors, and T-infra as owners.
+At the end of this we should have a crate in the rust-lang GitHub org with T-rustdoc as contributors, and T-infra as owners.
 
 ### crates.io
 
@@ -110,7 +110,7 @@ The `rust-lang-owner` is needed because team owners cannot add new owners.
 # Prior art
 [prior-art]: #prior-art
 
-- [Rust RFC 3119](https://rust-lang.github.io/rfcs/3119-rust-crate-ownership.html) establishes the Rust crate ownership policy. Under it's categories, `rustdoc-types` would be a **Intentional artifact**
+- [Rust RFC 3119](https://rust-lang.github.io/rfcs/3119-rust-crate-ownership.html) establishes the Rust crate ownership policy. Under its categories, `rustdoc-types` would be am **intentional artifact**
 - [Some old zulip discussion about why `rustdoc-json-types` was created.](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/JSON.20Format/near/223685843) What was said then is that if T-Rustdoc wants to publish a crate, it needs to go through an RFC. This is that RFC.
 - the [`cargo
   metadata`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html)

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -66,7 +66,10 @@ if they would make it not possible to publish `rustdoc-types`.
 
 GitHub has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transferring repositories. T-infra will handle the permissions of moving the repository into the rust-lang GitHub organization.
 
-At the end of this we should have a crate in the rust-lang GitHub org with T-rustdoc as contributors, and T-infra as owners.
+At the end of this we should have a moved the [`aDotInTheVoid/rustdoc-types`]
+repo into the rust-lang GitHub org. T-rustdoc will have contributors
+permissions, and T-infra (or rust-lang-owner) will have GitHub admin permissions
+to the repo.
 
 ### crates.io
 

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -49,29 +49,20 @@ This involves:
 
 `rustdoc-types` is a republishing of the in-tree [`rustdoc-json-types`](https://github.com/rust-lang/rust/tree/b8536c1aa1973dd2438841815b1eeec129480e45/src/rustdoc-json-types) crate. `rustdoc-json-types` is a dependency of `librustdoc`, and is the canonical source of truth for the rustdoc-json output format. Changes to the format are made a a PR to `rust-lang/rust`, and will modify `src/rustdoc-json-types`, `src/librustdoc/json` and `tests/rustdoc-json`. None of this will change.
 
-Republishing `rustdoc-json-types` as `rustdoc-types` is done with [a script](https://github.com/aDotInTheVoid/rustdoc-types/blob/577a774c2433beda669271102a201910c4169c0c/update.sh) so that it is as low maintenance as possible. This also ensures that all format/documentation changes happen in the rust-lang/rust repo, and go through the normal review process there.
+Republishing `rustdoc-json-types` as `rustdoc-types` is done with [a script](https://github.com/aDotInTheVoid/rustdoc-types/blob/17cbe9f8f07de954261dbb9536c394381770de7b/update.sh) so that it is as low maintenance as possible. This also ensures that all format/documentation changes happen in the rust-lang/rust repo, and go through the normal review process there.
 
 The update/publishing process will be moved to T-Rustdoc. In the medium term, I (`@aDotInTheVoid`) will still do it, but
 - In an official capacity
 - With bus factor for when I stop.
 
+We will continue to publish new version of the `rustdoc-types` crate every time
+the upstream implementation changes.
+
 ## Actual Mechanics of the move
 
 ### Github
 
-Github has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transferring repositories.
-
-
-- When you transfer a repository that you own to another personal account, the new owner will receive a confirmation email. The confirmation email includes instructions for accepting the transfer. If the new owner doesn't accept the transfer within one day, the invitation will expire.
-   - N/A: Not transferring to another personal account
-- To transfer a repository that you own to an organization, you must have permission to create a repository in the target organization.
-   - I (`@aDotInTheVoid`) don't have create-repo perms in the `rust-lang` org. Therefore I'll add a member of T-Infra as an owner to `aDotInTheVoid/rustdoc-types` (I can't add teams, as it's not in an org). They'll then move it to the repo to the `rust-lang` org. Once moved, T-Infra can become owners.
-- The target account must not have a repository with the same name, or a fork in the same network.
-   - OK.
-- The original owner of the repository is added as a collaborator on the transferred repository. Other collaborators to the transferred repository remain intact.
-   - OK. After the transfer. T-Rustdoc should be added as a colaborator, and I should be removed so that I only have permissions via my membership in T-Rustdoc. 
-- Single repositories forked from a private upstream network cannot be transferred.
-   - OK.
+Github has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transferring repositories. T-Infra will handle the permissions of moving the repository into the rust-lang github organization.
 
 At the end of this we should have a crate in the rust-lang github org with T-Rustdoc as contributors, and T-infra as owners.
 
@@ -105,15 +96,27 @@ The `rust-lang-owner` is needed because team owners cannot add new owners.
 - We could publish `rustdoc-json-types` directly from `rust-lang/rust`. However
    - `rust-lang/rust` doesn't currently publish to crates.io.
    - `rustdoc-json-types` doesn't currently bump the version field in `Cargo.toml`
-   - It may be desirable to use different types in rustdoc vs users, eg to have a specialized version of `Id` that doesn't allocate
-   - `rustdoc-types` is a nicer name, and what people already depend on.
+   - It may be desirable to one day use different types for rustdoc serialization vs users deserialization
 
+     Reasons for this:
+     - It could enable performance optmizations by avoiding allocations into strings
+     - It could help with stabilization:
+       - Allows making structs/enums `#[non_exaustive]`
+       - Allows potentially supporting multiple format verions.
+   - `rustdoc-types` is a nicer name, and what people already depend on.
 
 # Prior art
 [prior-art]: #prior-art
 
 - [Rust RFC 3119](https://rust-lang.github.io/rfcs/3119-rust-crate-ownership.html) establishes the Rust crate ownership policy. Under it's categories, `rustdoc-types` would be a **Intentional artifact**
 - [Some old zulip discussion about why `rustdoc-json-types` was created.](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/JSON.20Format/near/223685843) What was said then is that if T-Rustdoc wants to publish a crate, it needs to go through an RFC. This is that RFC.
+- the [`cargo
+  metadata`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html)
+  command gives JSON information about a cargo package. The
+  [cargo-metadata](https://docs.rs/cargo_metadata/latest/cargo_metadata/) crate
+  provides access to this. Instead of being a export of the cargo-side type declarations,
+  it's manually written, and not officially maintained. This has [lead to compatibilty issues](https://github.com/oli-obk/cargo_metadata/issues/240)
+  in the past. Desipite being stable, the exact compatibilty story [isn't yet determined](https://github.com/rust-lang/cargo/issues/12377).
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -110,7 +110,7 @@ The `rust-lang-owner` is needed because team owners cannot add new owners.
 # Prior art
 [prior-art]: #prior-art
 
-- [Rust RFC 3119](https://rust-lang.github.io/rfcs/3119-rust-crate-ownership.html) establishes the Rust crate ownership policy. Under its categories, `rustdoc-types` would be am **intentional artifact**
+- [Rust RFC 3119](https://rust-lang.github.io/rfcs/3119-rust-crate-ownership.html) establishes the Rust crate ownership policy. Under its categories, `rustdoc-types` would be an **intentional artifact**
 - [Some old zulip discussion about why `rustdoc-json-types` was created.](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/JSON.20Format/near/223685843) What was said then is that if T-Rustdoc wants to publish a crate, it needs to go through an RFC. This is that RFC.
 - the [`cargo
   metadata`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html)

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -1,6 +1,6 @@
 - Feature Name: `rustdoc_types_maintainers`
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Start Date: 2023-10-3
+- RFC PR: [rust-lang/rfcs#3505](https://github.com/rust-lang/rfcs/pull/3505)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -11,7 +11,7 @@ The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from b
 # Motivation
 [motivation]: #motivation
 
-[`rustdoc-types`](https://crates.io/crates/rustdoc-types) is a crate published on crates.io. It is used by users of the unstable [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578) backend to provided a type representing the output of `rustdoc --output-format json`.  It's published on crates.io to be used by out-of-tree tools that take rustdoc-json as an input. E.g:
+[`rustdoc-types`](https://crates.io/crates/rustdoc-types) is a crate published on crates.io. It is used by users of the unstable [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578) backend to provide a type representing the output of `rustdoc --output-format json`.  It's published on crates.io to be used by out-of-tree tools that take rustdoc-json as an input. E.g:
 
 | Name | Purpose |
 |--|--|

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -58,7 +58,8 @@ The update/publishing process will be moved to T-rustdoc. In the medium term, I 
 We (T-rustdoc) will continue to publish a new version of the `rustdoc-types` crate
 every time the upstream implementation changes, and these will be versioned with
 normal SemVer. Changes to rustdoc-json in `rust-lang/rust` will not be accepted
-if they would make it not possible to publish `rustdoc-types`.
+if they would make it not possible to publish `rustdoc-types` (eg: using `rustc_*` 
+crates, or nightly features).
 
 ## Actual Mechanics of the move
 

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -39,7 +39,7 @@ Additionally, if an update to `rustdoc-json-types` happens while i'm away from a
 This involves:
 
 1. Moving the [github.com/aDotInTheVoid/rustdoc-types](https://github.com/aDotInTheVoid/rustdoc-types/) repo to the `rust-lang` organization, and make `rust-lang/rustdoc` maintainers/owners.
-2. Move overship of `rustdoc-types` on crates.io to the rustdoc team.
+2. Move ownership of `rustdoc-types` on crates.io to the rustdoc team.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -48,21 +48,19 @@ This involves:
 
 Republishing `rustdoc-json-types` as `rustdoc-types` is done with [a script](https://github.com/aDotInTheVoid/rustdoc-types/blob/577a774c2433beda669271102a201910c4169c0c/update.sh) so that it is as low maintenance as possible. This also ensures that all format/documentation changes happen in the rust-lang/rust repo, and go through the normal review process there.
 
-`rustdoc-types` is a republishing of the in-tree [`rustdoc-json-types`](https://github.com/rust-lang/rust/tree/b8536c1aa1973dd2438841815b1eeec129480e45/src/rustdoc-json-types) crate. `rustdoc-json-types` is a dependency of `librustdoc`, and is the canonical source of truth for the canonical description of the rustdoc-json output format. Changes to the format are made a a PR to `rust-lang/rust`, and will modify `src/rustdoc-json-types`, `src/librustdoc/json` and `tests/rustdoc-json`. None of this will change.
-
 The update/publishing process will be moved to T-Rustdoc. In the medium term, I (`@aDotInTheVoid`) will still do it, but
-- In an offical capacity
+- In an official capacity
 - With bus factor for when I stop.
 
 ## Actual Mechanics of the move
 
 ### Github
 
-Github has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transfering repositories.
+Github has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transferring repositories.
 
 
 - When you transfer a repository that you own to another personal account, the new owner will receive a confirmation email. The confirmation email includes instructions for accepting the transfer. If the new owner doesn't accept the transfer within one day, the invitation will expire.
-   - N/A: Not transfering to 
+   - N/A: Not transferring to another personal account
 - To transfer a repository that you own to an organization, you must have permission to create a repository in the target organization.
    - I (`@aDotInTheVoid`) don't have create-repo perms in the `rust-lang` org. Therefore I'll add a member of T-Infra as an owner to `aDotInTheVoid/rustdoc-types` (I can't add teams, as it's not in an org). They'll then move it to the repo to the `rust-lang` org. Once moved, T-Infra can become owners.
 - The target account must not have a repository with the same name, or a fork in the same network.
@@ -98,12 +96,12 @@ The `rust-lang-owner` is needed because team owners cannot add new owners.
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-- We could keep `rustdoc-types` as a personal project. This preserves the status quo (and is what will happen if this RFC (or something similar) isn't addopted). This is undesirable because
-      - Bus factor: If I am unable or unwilling to maintain `rustdoc-types`, we cause a load of unnessessary churn when it becomes out of sync with 
+- We could keep `rustdoc-types` as a personal project. This preserves the status quo (and is what will happen if this RFC (or something similar) isn't adopted). This is undesirable because
+      - Bus factor: If I am unable or unwilling to maintain `rustdoc-types`, we cause a load of unnecessary churn when it becomes out of sync with the in-tree `rustdoc-json-types`
 - We could bundle `rustdoc-types` through rustup. This is undesirable as it means users can't depend on it in stable rust, and can't depend on multiple versions.
 - We could publish `rustdoc-json-types` directly from `rust-lang/rust`. However
    - `rust-lang/rust` doesn't currently publish to crates.io.
-   - `rustdoc-json-types` doesn't currently bump the version field in cargo.toml
+   - `rustdoc-json-types` doesn't currently bump the version field in `Cargo.toml`
    - It may be desirable to use different types in rustdoc vs users, eg to have a specialized version of `Id` that doesn't allocate
    - `rustdoc-types` is a nicer name, and what people already depend on.
 
@@ -112,7 +110,7 @@ The `rust-lang-owner` is needed because team owners cannot add new owners.
 [prior-art]: #prior-art
 
 - [Rust RFC 3119](https://rust-lang.github.io/rfcs/3119-rust-crate-ownership.html) establishes the Rust crate ownership policy. Under it's categories, `rustdoc-types` would be a **Intentional artifact**
-- [Some old zulip discussion about why `rustdoc-json-types` was created.](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/JSON.20Format/near/223685843) What was said then is that if T-Rustdoc want's to publish a crate, it needs to go through an RFC. This is that RFC.
+- [Some old zulip discussion about why `rustdoc-json-types` was created.](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/JSON.20Format/near/223685843) What was said then is that if T-Rustdoc wants to publish a crate, it needs to go through an RFC. This is that RFC.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -99,10 +99,10 @@ The `rust-lang-owner` is needed because team owners cannot add new owners.
    - It may be desirable to one day use different types for rustdoc serialization vs users deserialization
 
      Reasons for this:
-     - It could enable performance optmizations by avoiding allocations into strings
+     - It could enable performance optimizations by avoiding allocations into strings
      - It could help with stabilization:
-       - Allows making structs/enums `#[non_exaustive]`
-       - Allows potentially supporting multiple format verions.
+       - Allows making structs/enums `#[non_exhaustive]`
+       - Allows potentially supporting multiple format versions.
    - `rustdoc-types` is a nicer name, and what people already depend on.
 
 # Prior art
@@ -115,8 +115,8 @@ The `rust-lang-owner` is needed because team owners cannot add new owners.
   command gives JSON information about a cargo package. The
   [cargo-metadata](https://docs.rs/cargo_metadata/latest/cargo_metadata/) crate
   provides access to this. Instead of being a export of the cargo-side type declarations,
-  it's manually written, and not officially maintained. This has [lead to compatibilty issues](https://github.com/oli-obk/cargo_metadata/issues/240)
-  in the past. Desipite being stable, the exact compatibilty story [isn't yet determined](https://github.com/rust-lang/cargo/issues/12377).
+  it's manually written, and not officially maintained. This has [lead to compatibility issues](https://github.com/oli-obk/cargo_metadata/issues/240)
+  in the past. Despite being stable, the exact compatibility story [isn't yet determined](https://github.com/rust-lang/cargo/issues/12377).
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -82,7 +82,7 @@ crates.io ownership is managed [via the command line](https://doc.rust-lang.org/
 I will run the following commands to move ownership.
 
 ```
-cargo owner --add github:rust-lang:owners
+cargo owner --add github:rust-lang:rustdoc
 cargo owner --add rust-lang-owner
 cargo owner --remove aDotInTheVoid
 ```

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from be officialy maintained by the rustdoc team.
+The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from being privately maintained to being officially maintained by the rustdoc team.
 
 # Motivation
 [motivation]: #motivation

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -11,8 +11,23 @@ The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from b
 # Motivation
 [motivation]: #motivation
 
-[`rustdoc-types`](https://crates.io/crates/rustdoc-types) is a crate published on crates.io. It is used by users of the unstable [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578) backend to provided a type representing the output of `rustdoc --output-format json`. 
+[`rustdoc-types`](https://crates.io/crates/rustdoc-types) is a crate published on crates.io. It is used by users of the unstable [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578) backend to provided a type representing the output of `rustdoc --output-format json`.  It's published on crates.io to be used by out-of-tree tools that take rustdoc-json as an input. Eg:.
 
+| Name | Purpose |
+|--|--|
+| [awslabs/cargo-check-external-types] | Home-rolled version of [RFC 1977] "private dependencies". Checks if any types from the private dependency are used in a crate's public API. |
+| [Enselic/cargo-public-api] | Compares the public API of two crates. Used to check for semver violations. |
+| [obi1kenobi/trustfall-rustdoc-adapter] | Higher-level database-ish API for querying Rust API's. Used by [obi1kenobi/cargo-semver-checks] |
+
+[awslabs/cargo-check-external-types]: https://github.com/awslabs/cargo-check-external-types/blob/dc15c5ee7674a495d807481402fee46fdbdbb140/Cargo.toml#L16
+
+[Enselic/cargo-public-api]: https://github.com/Enselic/cargo-public-api/blob/19f15ce4146835691d489ec9db3518e021b638e8/public-api/Cargo.toml#L27
+
+[obi1kenobi/trustfall-rustdoc-adapter]: https://github.com/obi1kenobi/trustfall-rustdoc-adapter/blob/92cbbf9bc6c9dfaf40bba8adfbc56c0bb7aff12f/Cargo.toml#L15
+
+[obi1kenobi/cargo-semver-checks]: https://github.com/obi1kenobi/cargo-semver-checks
+
+[RFC 1977]: https://rust-lang.github.io/rfcs/1977-public-private-dependencies.html
 
 Currently I ([`@aDotInTheVoid`](https://github.com/aDotInTheVoid/)) maintain the `rustdoc-types` crate on [my personal github](https://github.com/aDotInTheVoid/rustdoc-types/). No-one else has either github or crates.io permissions. This means if I become unable (or more likely disinterested), the crate will not see updates.
 
@@ -29,12 +44,11 @@ This involves:
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-`rustdoc-types` is a republishing of the in-tree [`rustdoc-json-types`](https://github.com/rust-lang/rust/tree/b8536c1aa1973dd2438841815b1eeec129480e45/src/rustdoc-json-types) crate. `rustdoc-json-types` is a dependency of `librustdoc`, and is the canonical source of truth for the canonical description of the rustdoc-json output format. Changes to the format are made a a PR to `rust-lang/rust`, and will modify `src/rustdoc-json-types`, `src/librustdoc/json` and `tests/rustdoc-json`. None of this will change.
+`rustdoc-types` is a republishing of the in-tree [`rustdoc-json-types`](https://github.com/rust-lang/rust/tree/b8536c1aa1973dd2438841815b1eeec129480e45/src/rustdoc-json-types) crate. `rustdoc-json-types` is a dependency of `librustdoc`, and is the canonical source of truth for the rustdoc-json output format. Changes to the format are made a a PR to `rust-lang/rust`, and will modify `src/rustdoc-json-types`, `src/librustdoc/json` and `tests/rustdoc-json`. None of this will change.
 
-However, the publishing of this to crates.io, so that it can be used by out-of-tree tools that take rustdoc-json as an input
-([eg](https://github.com/awslabs/cargo-check-external-types/blob/dc15c5ee7674a495d807481402fee46fdbdbb140/Cargo.toml#L16),
-[eg](https://github.com/Enselic/cargo-public-api/blob/19f15ce4146835691d489ec9db3518e021b638e8/public-api/Cargo.toml#L27),
-[eg](https://github.com/obi1kenobi/trustfall-rustdoc-adapter/blob/92cbbf9bc6c9dfaf40bba8adfbc56c0bb7aff12f/Cargo.toml#L15)). This is done with [a scipt](https://github.com/aDotInTheVoid/rustdoc-types/blob/577a774c2433beda669271102a201910c4169c0c/update.sh) so that it is as low maintence as possible. This also ensures that all format/documentation changes happen in the rust-lang/rust repo, and go through the normal review process there.
+Republishing `rustdoc-json-types` as `rustdoc-types` is done with [a script](https://github.com/aDotInTheVoid/rustdoc-types/blob/577a774c2433beda669271102a201910c4169c0c/update.sh) so that it is as low maintenance as possible. This also ensures that all format/documentation changes happen in the rust-lang/rust repo, and go through the normal review process there.
+
+`rustdoc-types` is a republishing of the in-tree [`rustdoc-json-types`](https://github.com/rust-lang/rust/tree/b8536c1aa1973dd2438841815b1eeec129480e45/src/rustdoc-json-types) crate. `rustdoc-json-types` is a dependency of `librustdoc`, and is the canonical source of truth for the canonical description of the rustdoc-json output format. Changes to the format are made a a PR to `rust-lang/rust`, and will modify `src/rustdoc-json-types`, `src/librustdoc/json` and `tests/rustdoc-json`. None of this will change.
 
 The update/publishing process will be moved to T-Rustdoc. In the medium term, I (`@aDotInTheVoid`) will still do it, but
 - In an offical capacity
@@ -50,7 +64,7 @@ Github has a [list of requirements](https://docs.github.com/en/repositories/crea
 - When you transfer a repository that you own to another personal account, the new owner will receive a confirmation email. The confirmation email includes instructions for accepting the transfer. If the new owner doesn't accept the transfer within one day, the invitation will expire.
    - N/A: Not transfering to 
 - To transfer a repository that you own to an organization, you must have permission to create a repository in the target organization.
-   - I (`@aDotInTheVoid`) don't have create-repo perms in the `rust-lang` org. Therefor I'll add a member of T-Infra as an owner to `aDotInTheVoid/rustdoc-types` (I can't add teams, as it's not in an org). They'll then move it to the repo to the `rust-lang` org. Once moved, T-Infra can become owners.
+   - I (`@aDotInTheVoid`) don't have create-repo perms in the `rust-lang` org. Therefore I'll add a member of T-Infra as an owner to `aDotInTheVoid/rustdoc-types` (I can't add teams, as it's not in an org). They'll then move it to the repo to the `rust-lang` org. Once moved, T-Infra can become owners.
 - The target account must not have a repository with the same name, or a fork in the same network.
    - OK.
 - The original owner of the repository is added as a collaborator on the transferred repository. Other collaborators to the transferred repository remain intact.
@@ -62,7 +76,7 @@ At the end of this we should have a crate in the rust-lang github org with T-Rus
 
 ### crates.io
 
-crats.io ownership is managed [via the command line](https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-owner).
+crates.io ownership is managed [via the command line](https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-owner).
 
 I will run the following commands to move ownership.
 
@@ -72,13 +86,13 @@ cargo owner --add rust-lang-owner
 cargo owner --remove aDotInTheVoid
 ```
 
-The `rust-lang-owner` is neaded because team owners cannot add new owners. 
+The `rust-lang-owner` is needed because team owners cannot add new owners. 
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- Adds additional maintenence burden to rustdoc team.
-- One-time maintenece burden to infra team to support move.
+- Adds additional maintenance burden to rustdoc team.
+- One-time maintenance burden to infra team to support move.
 
 
 # Rationale and alternatives
@@ -108,5 +122,5 @@ None yet
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-When the rustdoc-json feature is stabilized, we'll should release 1.0.0 to crates.io. How we can evolve the format post stabilization is an unanswered question. It's a blocker for stabilization, but not this RFC
+When the rustdoc-json feature is stabilized, we should release 1.0.0 to crates.io. How we can evolve the format post stabilization is an unanswered question. It's a blocker for stabilization, but not this RFC
 

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -1,0 +1,112 @@
+- Feature Name: `rustdoc_types_maintainers`
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+The [rustdoc-types](https://crates.io/crates/rustdoc-types) crate will go from be officialy maintained by the rustdoc team.
+
+# Motivation
+[motivation]: #motivation
+
+[`rustdoc-types`](https://crates.io/crates/rustdoc-types) is a crate published on crates.io. It is used by users of the unstable [rustdoc JSON](https://github.com/rust-lang/rust/issues/76578) backend to provided a type representing the output of `rustdoc --output-format json`. 
+
+
+Currently I ([`@aDotInTheVoid`](https://github.com/aDotInTheVoid/)) maintain the `rustdoc-types` crate on [my personal github](https://github.com/aDotInTheVoid/rustdoc-types/). No-one else has either github or crates.io permissions. This means if I become unable (or more likely disinterested), the crate will not see updates.
+
+Additionally, if an update to `rustdoc-json-types` happens while i'm away from a computer for an extended period of time, their will be a delay in this update being published on crates.io. [This almost happened](https://github.com/aDotInTheVoid/rustdoc-types/issues/25), but was avoided due to the bors queue being quiet at the time.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+This involves:
+
+1. Moving the [github.com/aDotInTheVoid/rustdoc-types](https://github.com/aDotInTheVoid/rustdoc-types/) repo to the `rust-lang` organization, and make `rust-lang/rustdoc` maintainers/owners.
+2. Move overship of `rustdoc-types` on crates.io to the rustdoc team.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+`rustdoc-types` is a republishing of the in-tree [`rustdoc-json-types`](https://github.com/rust-lang/rust/tree/b8536c1aa1973dd2438841815b1eeec129480e45/src/rustdoc-json-types) crate. `rustdoc-json-types` is a dependency of `librustdoc`, and is the canonical source of truth for the canonical description of the rustdoc-json output format. Changes to the format are made a a PR to `rust-lang/rust`, and will modify `src/rustdoc-json-types`, `src/librustdoc/json` and `tests/rustdoc-json`. None of this will change.
+
+However, the publishing of this to crates.io, so that it can be used by out-of-tree tools that take rustdoc-json as an input
+([eg](https://github.com/awslabs/cargo-check-external-types/blob/dc15c5ee7674a495d807481402fee46fdbdbb140/Cargo.toml#L16),
+[eg](https://github.com/Enselic/cargo-public-api/blob/19f15ce4146835691d489ec9db3518e021b638e8/public-api/Cargo.toml#L27),
+[eg](https://github.com/obi1kenobi/trustfall-rustdoc-adapter/blob/92cbbf9bc6c9dfaf40bba8adfbc56c0bb7aff12f/Cargo.toml#L15)). This is done with [a scipt](https://github.com/aDotInTheVoid/rustdoc-types/blob/577a774c2433beda669271102a201910c4169c0c/update.sh) so that it is as low maintence as possible. This also ensures that all format/documentation changes happen in the rust-lang/rust repo, and go through the normal review process there.
+
+The update/publishing process will be moved to T-Rustdoc. In the medium term, I (`@aDotInTheVoid`) will still do it, but
+- In an offical capacity
+- With bus factor for when I stop.
+
+## Actual Mechanics of the move
+
+### Github
+
+Github has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transfering repositories.
+
+
+- When you transfer a repository that you own to another personal account, the new owner will receive a confirmation email. The confirmation email includes instructions for accepting the transfer. If the new owner doesn't accept the transfer within one day, the invitation will expire.
+   - N/A: Not transfering to 
+- To transfer a repository that you own to an organization, you must have permission to create a repository in the target organization.
+   - I (`@aDotInTheVoid`) don't have create-repo perms in the `rust-lang` org. Therefor I'll add a member of T-Infra as an owner to `aDotInTheVoid/rustdoc-types` (I can't add teams, as it's not in an org). They'll then move it to the repo to the `rust-lang` org. Once moved, T-Infra can become owners.
+- The target account must not have a repository with the same name, or a fork in the same network.
+   - OK.
+- The original owner of the repository is added as a collaborator on the transferred repository. Other collaborators to the transferred repository remain intact.
+   - OK. After the transfer. T-Rustdoc should be added as a colaborator, and I should be removed so that I only have permissions via my membership in T-Rustdoc. 
+- Single repositories forked from a private upstream network cannot be transferred.
+   - OK.
+
+At the end of this we should have a crate in the rust-lang github org with T-Rustdoc as contributors, and T-infra as owners.
+
+### crates.io
+
+crats.io ownership is managed [via the command line](https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-owner).
+
+I will run the following commands to move ownership.
+
+```
+cargo owner --add github:rust-lang:owners
+cargo owner --add rust-lang-owner
+cargo owner --remove aDotInTheVoid
+```
+
+The `rust-lang-owner` is neaded because team owners cannot add new owners. 
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- Adds additional maintenence burden to rustdoc team.
+- One-time maintenece burden to infra team to support move.
+
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- We could keep `rustdoc-types` as a personal project. This preserves the status quo (and is what will happen if this RFC (or something similar) isn't addopted). This is undesirable because
+      - Bus factor: If I am unable or unwilling to maintain `rustdoc-types`, we cause a load of unnessessary churn when it becomes out of sync with 
+- We could bundle `rustdoc-types` through rustup. This is undesirable as it means users can't depend on it in stable rust, and can't depend on multiple versions.
+- We could publish `rustdoc-json-types` directly from `rust-lang/rust`. However
+   - `rust-lang/rust` doesn't currently publish to crates.io.
+   - `rustdoc-json-types` doesn't currently bump the version field in cargo.toml
+   - It may be desirable to use different types in rustdoc vs users, eg to have a specialized version of `Id` that doesn't allocate
+   - `rustdoc-types` is a nicer name, and what people already depend on.
+
+
+# Prior art
+[prior-art]: #prior-art
+
+- [Rust RFC 3119](https://rust-lang.github.io/rfcs/3119-rust-crate-ownership.html) establishes the Rust crate ownership policy. Under it's categories, `rustdoc-types` would be a **Intentional artifact**
+- [Some old zulip discussion about why `rustdoc-json-types` was created.](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/JSON.20Format/near/223685843) What was said then is that if T-Rustdoc want's to publish a crate, it needs to go through an RFC. This is that RFC.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+None yet
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+When the rustdoc-json feature is stabilized, we'll should release 1.0.0 to crates.io. How we can evolve the format post stabilization is an unanswered question. It's a blocker for stabilization, but not this RFC
+

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -55,8 +55,10 @@ The update/publishing process will be moved to T-Rustdoc. In the medium term, I 
 - In an official capacity
 - With bus factor for when I stop.
 
-We will continue to publish new version of the `rustdoc-types` crate every time
-the upstream implementation changes.
+We (T-Rustdoc) will continue to publish new version of the `rustdoc-types` crate
+every time the upstream implementation changes, and these will be versioned with
+normal semver. Changes to rustdoc-json in `rust-lang/rust` will not be accepted
+if they would make it not possible to publish `rustdoc-types`.
 
 ## Actual Mechanics of the move
 

--- a/text/0000-rustdoc-types-maintainers.md
+++ b/text/0000-rustdoc-types-maintainers.md
@@ -67,9 +67,8 @@ if they would make it not possible to publish `rustdoc-types`.
 GitHub has a [list of requirements](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) for transferring repositories. T-infra will handle the permissions of moving the repository into the rust-lang GitHub organization.
 
 At the end of this we should have a moved the [`aDotInTheVoid/rustdoc-types`]
-repo into the rust-lang GitHub org. T-rustdoc will have contributors
-permissions, and T-infra (or rust-lang-owner) will have GitHub admin permissions
-to the repo.
+repo into the rust-lang GitHub org. T-rustdoc will have `maintain` permissions
+(via the [team repo](https://github.com/rust-lang/team/)).
 
 ### crates.io
 


### PR DESCRIPTION
[Rendered](https://github.com/aDotInTheVoid/rfcs/blob/rustdoc-types-maintainers/text/0000-rustdoc-types-maintainers.md)

CC @rust-lang/rustdoc @rust-lang/infra