### PR TITLE
Fix RFC numbers and pull request links

### DIFF
--- a/text/0218-empty-struct-with-braces.md
+++ b/text/0218-empty-struct-with-braces.md
@@ -1,6 +1,6 @@
 - Start Date: 2014-08-28
-- RFC PR: [rust-lang/rfcs#218](https://github.com/rust-lang/rfcs/pull/218/files)
-- Rust Issue: [rust-lang/rust#218](https://github.com/rust-lang/rust/issues/24266)
+- RFC PR: [rust-lang/rfcs#218](https://github.com/rust-lang/rfcs/pull/218)
+- Rust Issue: [rust-lang/rust#24266](https://github.com/rust-lang/rust/issues/24266)
 
 # Summary
 

--- a/text/0326-restrict-xXX-to-ascii.md
+++ b/text/0326-restrict-xXX-to-ascii.md
@@ -1,5 +1,5 @@
 - Start Date: 2014-09-26
-- RFC PR: 326
+- RFC PR: [rust-lang/rfcs#326](https://github.com/rust-lang/rfcs/pull/326)
 - Rust Issue: [rust-lang/rust#18062](https://github.com/rust-lang/rust/issues/18062)
 
 # Summary

--- a/text/0601-replace-be-with-become.md
+++ b/text/0601-replace-be-with-become.md
@@ -1,5 +1,5 @@
 - Start Date: 2015-01-20
-- RFC PR: [rust-lang/rfcs#601](https://github.com/rust-lang/rfcs/pull/601/)
+- RFC PR: [rust-lang/rfcs#601](https://github.com/rust-lang/rfcs/pull/601)
 - Rust Issue: [rust-lang/rust#22141](https://github.com/rust-lang/rust/issues/22141)
 
 # Summary

--- a/text/1298-incremental-compilation.md
+++ b/text/1298-incremental-compilation.md
@@ -1,7 +1,7 @@
 - Feature Name: incremental-compilation
 - Start Date: 2015-08-04
-- RFC PR: (leave this empty)
-- Rust Issue: (leave this empty)
+- RFC PR: [rust-lang/rfcs#1298](https://github.com/rust-lang/rfcs/pull/1298)
+- Rust Issue: [rust-lang/rust-roadmap-2017#4](https://github.com/rust-lang/rust-roadmap-2017/issues/4)
 
 # Summary
 

--- a/text/1728-north-star.md
+++ b/text/1728-north-star.md
@@ -1,6 +1,6 @@
 - Feature Name: north_star
 - Start Date: 2016-08-07
-- RFC PR: #1728
+- RFC PR: [rust-lang/rfcs#1728](https://github.com/rust-lang/rfcs/pull/1728)
 - Rust Issue: N/A
 
 # Summary

--- a/text/2396-target-feature-1.1.md
+++ b/text/2396-target-feature-1.1.md
@@ -1,6 +1,6 @@
 - Feature Name: `#[target_feature]` 1.1
 - Start Date: 2018-04-06
-- RFC PR: [rust-lang/rust#2396](https://github.com/rust-lang/rfcs/pull/2396)
+- RFC PR: [rust-lang/rfcs#2396](https://github.com/rust-lang/rfcs/pull/2396)
 - Rust Issue: [rust-lang/rust#69098](https://github.com/rust-lang/rust/issues/69098)
 
 # Summary

--- a/text/2436-style-guide.md
+++ b/text/2436-style-guide.md
@@ -1,6 +1,6 @@
 - Feature Name: N/A
 - Start Date: 2018-05-04
-- RFC PR: #2436
+- RFC PR: [rust-lang/rfcs#2436](https://github.com/rust-lang/rfcs/pull/2436)
 - Rust Issue: N/A
 
 # Summary

--- a/text/2476-clippy-uno.md
+++ b/text/2476-clippy-uno.md
@@ -1,7 +1,7 @@
 - Feature Name: `clippy_uno`
 - Start Date: 2018-06-14
-- RFC PR: [rust-lang/rfcs#2539](https://github.com/rust-lang/rfcs/pull/2539)
-- Rust Issue: [rust-lang-nursery/rust-clippy#54881](https://github.com/rust-lang-nursery/rust-clippy/issues/3343)
+- RFC PR: [rust-lang/rfcs#2476](https://github.com/rust-lang/rfcs/pull/2476)
+- Rust Issue: [rust-lang-nursery/rust-clippy#3343](https://github.com/rust-lang-nursery/rust-clippy/issues/3343)
 
 # Summary
 [summary]: #summary

--- a/text/3327-lang-team-advisors.md
+++ b/text/3327-lang-team-advisors.md
@@ -4,8 +4,8 @@ title: Lang team advisors RFC
 
 - Feature Name: N/A
 - Start Date: 2022-09-21
-- RFC PR: [rust-lang/rfcs#3327](https://github.com/rust-lang/rfcs/pull/0000)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- RFC PR: [rust-lang/rfcs#3327](https://github.com/rust-lang/rfcs/pull/3327)
+- Rust Issue: N/A
 
 # Summary
 [summary]: #summary

--- a/text/3368-diagnostic-attribute-namespace.md
+++ b/text/3368-diagnostic-attribute-namespace.md
@@ -1,7 +1,7 @@
 - Feature Name: The `#[diagnostic]` attribute namespace
 - Start Date: 2023-01-06
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- RFC PR: [rust-lang/rfcs#3368](https://github.com/rust-lang/rfcs/pull/3368)
+- Rust Issue: [rust-lang/rust#111996](https://github.com/rust-lang/rust/issues/111996)
 
 
 # Summary


### PR DESCRIPTION
Found by searching every document for one of the following formats:

```markdown
RFC PR: [rust-lang/rfcs#N](https://github.com/rust-lang/rfcs/pull/N)
RFC PR: [#N](https://github.com/rust-lang/rfcs/pull/N)
RFC PR: [N](https://github.com/rust-lang/rfcs/pull/N)
RFC PR: https://github.com/rust-lang/rfcs/pull/N
RFC PR: (https://github.com/rust-lang/rfcs/pull/N)
RFC PR #: [rust-lang/rfcs#N](https://github.com/rust-lang/rfcs/pull/N)
RFC PR #: [#N](https://github.com/rust-lang/rfcs/pull/N)
RFC PR #: [N](https://github.com/rust-lang/rfcs/pull/N)
RFC PR #: https://github.com/rust-lang/rfcs/pull/N
RFC PR #: (https://github.com/rust-lang/rfcs/pull/N)
```

`for n in $(ls text/[0-9][0-9][0-9][0-9]-*.md | sed 's,text/\(....\).*,\1,' | sort -u); do rg --files-without-match "RFC PR( #)?: (\[((rust-lang/rfcs)?#)?${n##+(0)}\]\(https://github\.com/rust-lang/rfcs/pull/${n##+(0)}\)|https://github\.com/rust-lang/rfcs/pull/${n##+(0)}\b|\(https://github\.com/rust-lang/rfcs/pull/${n##+(0)}\))" text/$n-*.md; done`