### PR TITLE
request/0.9.1 -> reqwest/0.9.1

### DIFF
--- a/text/3463-crates-io-policy-update.md
+++ b/text/3463-crates-io-policy-update.md
@@ -149,7 +149,7 @@ themselves to a maximum of 1 request per second.
 We also require all API users to provide a user-agent header that allows us to
 uniquely identify your application. This allows us to more accurately monitor
 any impact your application may have on our service. Providing a user agent that
-only identifies your HTTP client library (such as `request/0.9.1`) increases the
+only identifies your HTTP client library (such as `reqwest/0.9.1`) increases the
 likelihood that we will block your traffic.
 
 It is recommended, to include contact information in your user-agent header:


### PR DESCRIPTION
Possible typo, as `User-Agent: reqwest/0.9.1` is used further down.

[Rendered](https://github.com/jiftoo/rfcs/blob/jiftoo-patch-1/text/3463-crates-io-policy-update.md)