### PR TITLE
RFC: Make Cargo respect minimum supported Rust version (MSRV) when selecting dependencies

### DIFF
--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -722,7 +722,7 @@ Instead of `resolver = "3"` changing the behavior to `CARGO_RESOLVER_PRECEDENCE=
 it is changed to `CARGO_RESOLVER_PRECEDENCE=rustc` where the resolver selects packages compatible with current toolchain,
 matching the `cargo build` incompatible dependency error.
 - We would still support `CARGO_RESOLVER_PRECEDENCE=rust-version` to help "Extended MSRV" users
-- We'd drop from this proposal `cargo update [--ignore-rust-version|--update-rust-version]` as they don't make sense with this new defaul
+- We'd drop from this proposal `cargo update [--ignore-rust-version|--update-rust-version]` as they don't make sense with this new default
 
 This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "auto"`, `cargo build` error to diagnostic).
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1133,7 +1133,7 @@ To get the error reporting to be of sufficient quality will require major work i
 This would block stabilization indefinitely.
 We could adopt this approach in the future, if desired
 
-Affects on workflows (including non-resolver behavior):
+Effects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
   - ✅ `cargo new` setting `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ❌ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -796,7 +796,7 @@ Those flags will also be added to `cargo generate-lockfile`
 ## Syncing `Cargo.toml` to `Cargo.lock` on any Cargo command
 
 In addition to the `cargo update` output to report when things are held back (both MSRV and semver),
-We can attempt to have resolves to call out the new dependency versions that were held back from MSRV or semver.
+we will try having dependency resolves highlight newly selected dependency versions that were held back due to MSRV or semver.
 Whether we do this and how much will be subject to factors like noisy output, performance, etc.
 
 Some approaches we can take for doing this include:

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -877,7 +877,7 @@ Misc alternatives
   - This expansion of scope is for consistency
   - Being a flag to turn the `deny` into an `allow` is a high friction workflow that we expect users to not be too negatively impacted by this expansion.
   - With the resolver config and the configurable lint, we also expect the flag on compilation commands to be diminished in value.  Maybe in the future we could even deprecate it and/or hide it.
-- `--update-rust-version` picks `rustc --version`-compatible dependencies so users, no matter their `rustc` version, can easily walk the treadmill of updating their dependencies / MSRV
+- `--update-rust-version` picks `rustc --version`-compatible dependencies so users can easily walk the treadmill of updating their dependencies / MSRV , no matter their `rustc` version.
   - There is little reason to select an MSRV higher than their Rust toolchain
   - We should still be warning the user that new dependencies are available if they upgrade their Rust toolchain
   - This comes at the cost of inconsistency with `--ignore-rust-version`.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -790,8 +790,6 @@ with potential values being:
   - `<x>[.<y>[.<z>]]`: manually override the version used
 
 If a `rust-version` value is used, we'd switch to `maximum` when `--ignore-rust-version` is set.
-This will let users effectively pass `--ignore-rust-version` to all commands,
-without having to support the flag on every single command.
 
 ## `cargo build`
 
@@ -890,6 +888,9 @@ and only in the sense that the user needs to know to explicitly take action to a
 Misc alternatives
 - Dependencies with unspecified `package.rust-version`: we could mark these as always-compatible or always-incompatible; there really isn't a right answer here.
 - The resolver doesn't support backtracking as that is extra complexity that we can always adopt later as we've reserved the right to make adjustments to what `cargo generate-lockfile` will produce over time.
+- `CARGO_RESOLVER_PRECEDENCE` is used, rather than a CLI option
+  - This is unlikely to be used in one-off cases but across whole interactions which is better suited for config / env variables, rather than CLI options
+  - Minimize CLI clutter
 - `CARGO_RESOLVER_PRECEDENCE=rust-version` implies maximal resolution among MSRV-compatible dependencies.   Generally MSRV doesn't decrease over versions, so minimal resolution will likely pick packages with compatible rust-versions.
   - `cargo add` helps by selecting rust-version-compatible minimum bounds
   - This bypasses a lot of complexity either from exploding the number of states we support or giving users control over the fallback by making the field an array of strategies.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -204,7 +204,10 @@ Some design criteria we can use for evaluating workflows:
 - Cargo should not make major breaking changes
 - Low barrier to entry
 - The costs of “non-recommended” setups should focused on those that need them
-- Encourage a standard of quality within the ecosystem
+- Encourage a standard of quality within the ecosystem, including
+  - Assumption that things will work as advertised (e.g. our success with MSRV)
+  - A pleasant experience (e.g. meaningful error messages)
+  - Secure
 - Every feature has a cost and we should balance the cost against the value we expect
   - Features can further constrain what can be done in the future due to backwards compatibility
   - Features increase maintenance burden

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -359,6 +359,17 @@ one lockfile can be used but it can be difficult to edit the `Cargo.lock` to ens
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
+We are introducing several new concepts
+- A v3 resolver (`package.resolver`) that will prefer packages compatible with your `package.rust-version` over those that aren't
+  - If `package.rust-version` is unset, then your current Rust toolchain version will be used
+  - This resolver version will be the default for the next edition
+  - A `.cargo/config.toml` field will be added to disable this, e.g. for CI
+- Cargo will ensure users are aware their dependencies are behind the latest in a unobtrusive way
+- `cargo add` will select version requirements that can be met by a dependency with a compatible version
+- A new value for `package.rust-version`, `"auto"`, which will advertise in your published package your current toolchain version as the minimum-supported Rust version
+  - `cargo new` will default to `package.rust-version = "auto"`
+- A deny-by-default lint will replace the build error from a package having an incompatible Rust version, allowing users to opt-in to overriding it
+
 ## Example documentation updates
 
 ### The `rust-version` field

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -14,6 +14,18 @@ Provide a happy path for developers needing to work with older versions of Rust 
 
 Note: `cargo install` is intentionally left out for now to decouple discussions on how to handle the security ramifications.
 
+**Note:** Approval of this RFC does not mean everything is set in stone, like with all RFCs.
+This RFC will be rolled out gradually as we stabilize each piece.
+In particular, we expect to make the `cargo new` change last as it is dependent on the other changes to work well.
+In evaluating stabilization, we take into account changes in the ecosystem and feedback from testing unstable features.
+Based on that evaluation, we may make changes from what this RFC says.
+Whether we make changes or not, stabilization will then require approval of the cargo team to merge
+(explicit acknowledgement from all but 2 members with no concerns from any member)
+followed by a 10 days Final Comment Period (FCP) for the remaining 2 team members and the wider community.
+Cargo FCPs are now tracked in This Week in Rust to ensure the community is aware and can participate.
+Even then, a change like `cargo new` can be reverted without an RFC,
+likely only needing to follow the FCP process.
+
 # Motivation
 [motivation]: #motivation
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1127,7 +1127,7 @@ Instead of *preferring* MSRV-compatible dependencies, the resolver could hard er
 
 In addition to errors, differences from the "preference" solutions include:
 - Increase the chance of an MSRV-compatible `Cargo.lock` because the resolver can backtrack on MSRV-incompatible transitive dependencies, trying alternative versions of direct dependencies
-- When a workspace members have different MSRVs, dependencies exclusive to a higher MSRV package can use higher versions
+- When workspace members have different MSRVs, dependencies exclusive to a higher MSRV package can use higher versions
 
 To get the error reporting to be of sufficient quality will require major work in a complex, high risk area of Cargo (the resolver).
 This would block stabilization indefinitely.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -662,6 +662,10 @@ identifiers such as -nightly will be ignored while checking the Rust version.
 The `rust-version` must be equal to or newer than the version that first
 introduced the configured `edition`.
 
+The Rust version can also be `"auto"`.
+This will act the same as if it was set to the version of your toolchain.
+When publishing, `"auto"` will be replaced by the version of your toolchain in your published manifest.
+
 The `rust-version` may be ignored using the `--ignore-rust-version` option.
 
 Setting the `rust-version` key in `[package]` will affect all targets/crates in

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -555,6 +555,10 @@ Misc alternatives
     We couldn't want this to be like sparse registries where a setting exists and we change the default and people hardly notice (besides any improvements)
 - `cargo build` will treat incompatible MSRVs as a workspace-level lint, rather than a package level lint, to avoid the complexity of mapping the package to a workspace-member for `[lint]` and dealing with unifying conflicting levels in `[lint]`.
 - `--ignore-rust-version` picks absolutely the latest dependencies to support (1) users on latest rustc and (2) users wanting "unsupported" dependencies, at the cost of users not on the latest rustc but still want latest more up-to-date dependencies than their MSRV allows
+- Compilation commands (e.g. `cargo check`) will take on two meanings for `--ignore-rust-version`, (1) `allow` the workspace diagnostic and (2) resolve changed dependencies to latest when syncing `Cargo.toml` to `Cargo.lock`.
+  - This expansion of scope is for consistency
+  - Being a flag to turn the `deny` into an `allow` is a high friction workflow that we expect users to not be too negatively impacted by this expansion.
+  - With the resolver config and the configurable lint, we also expect the flag on compilation commands to be diminished in value.  Maybe in the future we could even deprecate it and/or hide it.
 - `--update-rust-version` picks `rustc --version`-compatible dependencies so users, no matter their `rustc` version, can easily walk the treadmill of updating their dependencies / MSRV
   - There is little reason to select an MSRV higher than their Rust toolchain
   - We should still be warning the user that new dependencies are available if they upgrade their Rust toolchain

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -395,7 +395,7 @@ After some time, I get back to my project and decide to add completion support:
 $ cargo add clap_complete
 Adding clap_complete 5.10.40
 warning: clap_complete 5.11.0 exists but requires Rust 1.93 while you are running 1.92.
-To use the clap_complete@5.11.0 with a compatible Rust version, run `rustup && cargo add clap_complete@5.11.0`.
+To use the clap_complete@5.11.0 with a compatible Rust version, run `rustup update && cargo add clap_complete@5.11.0`.
 To force the use of clap_complete@5.11.0 independent of your toolchain, run `cargo add clap_complete@5.11.0`
 ```
 Wanting to be on the latest version, I run
@@ -426,7 +426,7 @@ And away I go:
 ```console
 $ cargo check
 Warning: adding clap_complete@5.10.40 because 5.11.0 requires Rust 1.93 while you are running 1.92.
-To use the clap_complete@5.11.0 with a compatible Rust version, run `rustup && cargo update`.
+To use the clap_complete@5.11.0 with a compatible Rust version, run `rustup update && cargo update`.
 To force the use of clap_complete@5.11.0 independent of your toolchain, run `cargo update --ignore-rust-version`
 ```
 But I am in a hurry and don't want to disrupt my flow.
@@ -442,7 +442,7 @@ Name          Current Latest Note
 ============= ======= ====== ==================
 clap          5.10.30 5.11.0 requires Rust 1.93
 clap_complete 5.10.40 5.11.0 requires Rust 1.93
-note: To use the latest depednencies, run `rustup && cargo update`.
+note: To use the latest depednencies, run `rustup update && cargo update`.
 To force the use of the latest dependencies, independent of your toolchain, run `cargo update --ignore-rust-version`
 $ rustup update
 Downloading and install 1.94
@@ -490,7 +490,7 @@ rust-version = "auto"
 $ cargo add clap -F derive
 Adding clap 5.10.30
 warning: clap 5.11.0 exists but requires Rust 1.93 while you are running 1.92.
-To use the clap@5.11.0 with a compatible Rust version, run `rustup && cargo add clap@5.10.0`.
+To use the clap@5.11.0 with a compatible Rust version, run `rustup update && cargo add clap@5.10.0`.
 To force the use of clap_complete@5.11.0 independent of your toolchain, run `cargo add clap@5.10.0`
 ```
 At this point, I have a couple of options
@@ -566,7 +566,7 @@ Name          Current Latest Note
 ============= ======= ====== ==================
 clap          5.10.30 5.11.0 requires Rust 1.93
 clap_complete 5.10.40 5.11.0 requires Rust 1.93
-note: To use the latest depednencies, run `rustup && cargo update`.
+note: To use the latest depednencies, run `rustup update && cargo update`.
 To force the use of the latest dependencies, independent of your toolchain, run `cargo update --ignore-rust-version`
 ```
 We've EOLed the last embedded target that supported 1.92 and so we can update our `package.rust-version`,
@@ -624,7 +624,7 @@ Name          Current Latest Note
 ============= ======= ====== ==================
 clap          5.10.30 5.11.0 requires Rust 1.93
 clap_complete 5.10.40 5.11.0 requires Rust 1.93
-note: To use the latest depednencies, run `rustup && cargo update`.
+note: To use the latest depednencies, run `rustup update && cargo update`.
 To force the use of the latest dependencies, independent of your toolchain, run `cargo update --ignore-rust-version`
 ```
 At this point, 1.95 is out, so I'm fine updating my MSRV and I run:

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -797,6 +797,19 @@ The config field is fairly rough
   - The values are awkward
   - Should we instead just have a `resolver.rust-version = true`?
 
+`rust-version = "auto"`'s field name is unsettled and deciding on it is not blocking for stabilization.
+Ideally, we make it clear that this this is not inferred from syntax,
+that this is the currently running toolchain,
+that we ignore pre-release toolchains,
+and the name works well for resolver config if we decide to add "resolve to toolchain version" and want these consistent.
+Some options include:
+- `auto` can imply "infer from syntactic minimum"
+- `latest` can imply "latest globally (ie from rust-lang.org)
+- `stable` can imply "latest globally (ie from rust-lang.org)
+- `toolchain` might look weird?
+- `local` implies a `remote`
+- `current` is like `latest` but a little softer and might work
+
 Whether we report stale dependencies only on `cargo update` or on every command.
 
 # Future possibilities

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -353,7 +353,9 @@ one lockfile can be used but it can be difficult to edit the `Cargo.lock` to ens
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-## The `rust-version` field
+## Example documentation updates
+
+### The `rust-version` field
 
 *(update to [manifest documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field))*
 
@@ -383,7 +385,7 @@ The `rust-version` may be ignored using the `--ignore-rust-version` option.
 Setting the `rust-version` key in `[package]` will affect all targets/crates in
 the package, including test suites, benchmarks, binaries, examples, etc.
 
-## Rust Version
+### Rust Version
 
 *(update to [Dependency Resolution's Other Constraints documentation](https://doc.rust-lang.org/cargo/reference/resolver.html))*
 
@@ -392,7 +394,7 @@ cargo will prefer those with a compatible `package.rust-version` over those that
 aren't compatible.
 Some details may change over time though `cargo check && rustup update && cargo check` should not cause `Cargo.lock` to change.
 
-#### `resolver.precedence`
+##### `resolver.precedence`
 
 *(update to [Configuration](https://doc.rust-lang.org/cargo/reference/config.html))*
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -379,8 +379,8 @@ We are introducing several new concepts
   - A `.cargo/config.toml` field will be added to disable this, e.g. for CI
 - Cargo will ensure users are aware their dependencies are behind the latest in a unobtrusive way
 - `cargo add` will select version requirements that can be met by a dependency with a compatible version
-- A new value for `package.rust-version`, `"auto"`, which will advertise in your published package your current toolchain version as the minimum-supported Rust version
-  - `cargo new` will default to `package.rust-version = "auto"`
+- A new value for `package.rust-version`, `"<tbd-name-representing-currently-running-rust-toolchain>"`, which will advertise in your published package your current toolchain version as the minimum-supported Rust version
+  - `cargo new` will default to `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`
 - A deny-by-default lint will replace the build error from a package having an incompatible Rust version, allowing users to opt-in to overriding it
 
 ## Example documentation updates
@@ -407,9 +407,9 @@ identifiers such as -nightly will be ignored while checking the Rust version.
 The `rust-version` must be equal to or newer than the version that first
 introduced the configured `edition`.
 
-The Rust version can also be `"auto"`.
+The Rust version can also be `"<tbd-name-representing-currently-running-rust-toolchain>"`.
 This will act the same as if it was set to the version of your Rust toolchain.
-Your published manifest will have `"auto"` replaced with the version of your Rust toolchain.
+Your published manifest will have `"<tbd-name-representing-currently-running-rust-toolchain>"` replaced with the version of your Rust toolchain.
 
 Setting the `rust-version` key in `[package]` will affect all targets/crates in
 the package, including test suites, benchmarks, binaries, examples, etc.
@@ -469,7 +469,7 @@ $ cat foo/Cargo.toml
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "auto"
+rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -508,7 +508,7 @@ Here, we can shortcut some questions about version requirements because clap ali
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "auto"
+rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -582,7 +582,7 @@ $ cat foo/Cargo.toml
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "auto"
+rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -632,7 +632,7 @@ $ cat foo/Cargo.toml
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "auto"
+rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -661,7 +661,7 @@ I make the prescribed changes:
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92"  # <-- was "auto" before I edited it
+rust-version = "1.92"  # <-- was "<tbd-name-representing-currently-running-rust-toolchain>" before I edited it
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -715,7 +715,7 @@ I've decided on an "N-2" MSRV policy:
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92"  # <-- was "auto" before I edited it
+rust-version = "1.92"  # <-- was "<tbd-name-representing-currently-running-rust-toolchain>" before I edited it
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -835,7 +835,7 @@ without requiring `--ignore-rust-version` on every invocation.
 Ideally, we present all of the MSRV issues upfront to be resolved together.
 At minimum, we should present a top-down message, rather than bottom up.
 
-If `package.rust-version` is unset or `"auto"`, the diagnostic should suggest setting it
+If `package.rust-version` is unset or `"<tbd-name-representing-currently-running-rust-toolchain>"`, the diagnostic should suggest setting it
 to help raise awareness of `package.rust-version` being able to reduce future
 resolution errors.
 This would benefit from knowing the oldest MSRV.
@@ -891,11 +891,11 @@ Users may pass
 
 ## `cargo publish`
 
-`package.rust-version` will gain support for an `"auto"` value, in addition to partial versions.
-On `cargo publish` / `cargo package`, the generated `*.crate`s `Cargo.toml` will have `"auto"` replaced with `rustc --version`.
+`package.rust-version` will gain support for an `"<tbd-name-representing-currently-running-rust-toolchain>"` value, in addition to partial versions.
+On `cargo publish` / `cargo package`, the generated `*.crate`s `Cargo.toml` will have `"<tbd-name-representing-currently-running-rust-toolchain>"` replaced with `rustc --version`.
 If `rustc --version` is a pre-release, publish will fail.
 
-`cargo new` will include `package.rust-version = "auto"`.
+`cargo new` will include `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -945,7 +945,7 @@ Misc alternatives
   - There is little reason to select an MSRV higher than their Rust toolchain
   - We should still be warning the user that new dependencies are available if they upgrade their Rust toolchain
   - This comes at the cost of inconsistency with `--ignore-rust-version`.
-- Nightly `cargo publish` with `auto` fails because there isn't a good value to use and this gives us flexibility to change it later (e.g. just leaving the `rust-version` as unset).
+- Nightly `cargo publish` with `"<tbd-name-representing-currently-running-rust-toolchain>"` fails because there isn't a good value to use and this gives us flexibility to change it later (e.g. just leaving the `rust-version` as unset).
 
 ## Ensuring the registry Index has `rust-version` without affecting quality
 
@@ -954,7 +954,7 @@ Ensuring we have `package.rust-version` populated more often (while maintaining
 quality of that data) is an important problem but does not have to be solved to
 get value out of this RFC and can be handled separately.
 
-We chose an opt-in for populating `package.rust-version` based on `rustc --version` (`"auto"`).
+We chose an opt-in for populating `package.rust-version` based on `rustc --version` (`"<tbd-name-representing-currently-running-rust-toolchain>"`).
 This will encourage a baseline of quality as users are developing with that version and `cargo publish` will do a verification step, by default.
 This will help seed the Index with more `package.rust-version` data for the resolver to work with.
 The downside is that the `package.rust-version` will likely be higher than it absolutely needs.
@@ -968,7 +968,7 @@ When missing, `cargo publish` could inject `package.rust-version` using the vers
 workaround it is to set `CARGO_RESOLVER_PRECEDENCE=maximum` which will then lose
 all other protections.
 As we said, this is likely fine but then there will be no way to opt-out for the subset of maintainers who want to keep their support definition vague.
-As things evolve, we could re-evaluate making `"auto"` the default.
+As things evolve, we could re-evaluate making `"<tbd-name-representing-currently-running-rust-toolchain>"` the default.
 
 ~~We could encourage people to set their MSRV by having `cargo new` default `package.rust-version`.~~
 **However**, if people aren't committed to verifying that was implicitly set,
@@ -1038,11 +1038,11 @@ allows us to move forward without having to figure out all of these details.
 
 Affects of current solution on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
-  - ✅ `cargo new` setting `package.rust-version = "auto"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
+  - ✅ `cargo new` setting `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ✅ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)
 2. Latest Rust as the MSRV
   - ✅ Packages can more easily keep their MSRV up-to-date with
-    - `package.rust-version = "auto"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
+    - `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
     - `cargo update --update-rust-version` (e.g. when updating minor version) though this is dependent on what you dependencies are using for an MSRV
   - ✅ Packages can more easily offer unofficial support for an MSRV due to shifting the building with MSRV-incompatible dependencies from an error to a `deny` diagnostic
 3. Extended MSRV
@@ -1060,17 +1060,17 @@ Instead of adding `resolver = "3"`, we could keep the default resolver the same 
   - `cargo generate-lockfile`
 - We'd drop from this proposal `cargo update [--ignore-rust-version|--update-rust-version]` as they don't make sense with this new default
 
-This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "auto"`, `cargo build` error to diagnostic).
+This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`, `cargo build` error to diagnostic).
 
 Affects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
-  - ✅ `cargo new` setting `package.rust-version = "auto"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
+  - ✅ `cargo new` setting `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - 🟰 ~~Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)~~
 2. Latest Rust as the MSRV
   - ✅ Packages can more easily keep their MSRV up-to-date with
-    - `package.rust-version = "auto"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
+    - `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
     - ~~`cargo update --update-rust-version` (e.g. when updating minor version) though this is dependent on what you dependencies are using for an MSRV~~
-  - ❌ Without `cargo update --update-rust-version`, `"auto"` will be more of a default path, leading to more maintainers updating their MSRV more aggressively and waiting until minors
+  - ❌ Without `cargo update --update-rust-version`, `"<tbd-name-representing-currently-running-rust-toolchain>"` will be more of a default path, leading to more maintainers updating their MSRV more aggressively and waiting until minors
   - ✅ Packages can more easily offer unofficial support for an MSRV due to shifting the building with MSRV-incompatible dependencies from an error to a `deny` diagnostic
 3. Extended MSRV
   - ✅ Users will be able to opt-in to MSRV-compatible dependencies, in a `.cargo/config.toml`
@@ -1087,7 +1087,7 @@ matching the `cargo build` incompatible dependency error.
 - We would still support `CARGO_RESOLVER_PRECEDENCE=rust-version` to help "Extended MSRV" users
 - We'd drop from this proposal `cargo update [--ignore-rust-version|--update-rust-version]` as they don't make sense with this new default
 
-This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "auto"`, `cargo build` error to diagnostic).
+This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`, `cargo build` error to diagnostic).
 
 This is an auto-adapting variant where
 - If they are on the latest toolchain, they get the current behavior
@@ -1095,13 +1095,13 @@ This is an auto-adapting variant where
 
 Affects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
-  - ✅ `cargo new` setting `package.rust-version = "auto"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
+  - ✅ `cargo new` setting `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ✅ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)
 2. Latest Rust as the MSRV
   - ✅ Packages can more easily keep their MSRV up-to-date with
-    - `package.rust-version = "auto"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
+    - `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
     - ~~`cargo update --update-rust-version` (e.g. when updating minor version) though this is dependent on what you dependencies are using for an MSRV~~
-  - ❌ Without `cargo update --update-rust-version`, `"auto"` will be more of a default path, leading to more maintainers updating their MSRV more aggressively and waiting until minors
+  - ❌ Without `cargo update --update-rust-version`, `"<tbd-name-representing-currently-running-rust-toolchain>"` will be more of a default path, leading to more maintainers updating their MSRV more aggressively and waiting until minors
   - ✅ Packages can more easily offer unofficial support for an MSRV due to shifting the building with MSRV-incompatible dependencies from an error to a `deny` diagnostic
 3. Extended MSRV
   - ✅ Users will be able to opt-in to MSRV-compatible dependencies, in a `.cargo/config.toml`
@@ -1127,11 +1127,11 @@ We could adopt this approach in the future, if desired
 
 Affects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
-  - ✅ `cargo new` setting `package.rust-version = "auto"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
+  - ✅ `cargo new` setting `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ❌ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)
 2. Latest Rust as the MSRV
   - ✅ Packages can more easily keep their MSRV up-to-date with
-    - `package.rust-version = "auto"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
+    - `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
     - `cargo update --update-rust-version` (e.g. when updating minor version) though this is dependent on what you dependencies are using for an MSRV
   - ✅ Packages can more easily offer unofficial support for an MSRV due to shifting the building with MSRV-incompatible dependencies from an error to a `deny` diagnostic
 3. Extended MSRV
@@ -1166,13 +1166,13 @@ The config field is fairly rough
   - If we later add "resolve to toolchain" version, this might be confusing.
   - Maybe enumeration, like `resolver.rust-version = <manifest|toolchain|ignore>`?
 
-`rust-version = "auto"`'s field name is unsettled and deciding on it is not blocking for stabilization.
+`rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`'s field name is unsettled and deciding on it is not blocking for stabilization.
 Ideally, we make it clear that this this is not inferred from syntax,
 that this is the currently running toolchain,
 that we ignore pre-release toolchains,
 and the name works well for resolver config if we decide to add "resolve to toolchain version" and want these consistent.
 Some options include:
-- `auto` can imply "infer from syntactic minimum"
+- `"<tbd-name-representing-currently-running-rust-toolchain>"` can imply "infer from syntactic minimum"
 - `latest` can imply "latest globally (ie from rust-lang.org)
 - `stable` can imply "latest globally (ie from rust-lang.org)
 - `toolchain` might look weird?

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -797,7 +797,7 @@ In addition to the `cargo update` output to report when things are held back (bo
 We can attempt to have resolves to call out the new dependency versions that were held back from MSRV or semver.
 Whether we do this and how much will be subject to factors like noisy output, performance, etc.
 
-Implementation ideas...
+Some approaches we can take for doing this include:
 
 We then do a depth-first diff of the trees, stopping and reporting on the first different node.
 This would let us report on any command that changes the way the tree is resolved

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -968,7 +968,7 @@ Some alternative solutions include:
 
 When missing, `cargo publish` could inject `package.rust-version` using the version of rustc used during publish.
 **However**, this will err on the side of a higher MSRV than necessary and the only way to
-workaround it is to set `CARGO_RESOLVER_PRECEDENCE=maximum` which will then lose
+work around it is to set `CARGO_RESOLVER_PRECEDENCE=maximum` which will then lose
 all other protections.
 As we said, this is likely fine but then there will be no way to opt-out for the subset of maintainers who want to keep their support definition vague.
 As things evolve, we could re-evaluate making `"tbd-name-representing-currently-running-rust-toolchain"` the default.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -872,7 +872,7 @@ Misc alternatives
   - Either way, the big care about is there being attention drawn to the change.
     We couldn't want this to be like sparse registries where a setting exists and we change the default and people hardly notice (besides any improvements)
 - `cargo build` will treat incompatible MSRVs as a workspace-level lint, rather than a package level lint, to avoid the complexity of mapping the dependency to a workspace-member to select `[lint]` tables to respect and then dealing with unifying conflicting levels in between `[lint]` tables among members.
-- `--ignore-rust-version` picks absolutely the latest dependencies to support (1) users on latest rustc and (2) users wanting "unsupported" dependencies, at the cost of users not on the latest rustc but still want latest more up-to-date dependencies than their MSRV allows
+- `--ignore-rust-version` picks absolutely the latest dependencies to support both users on latest rustc and users wanting "unsupported" dependencies, at the cost of users not on the latest rustc but still want latest more up-to-date dependencies than their MSRV allows
 - Compilation commands (e.g. `cargo check`) will take on two meanings for `--ignore-rust-version`, (1) `allow` the workspace diagnostic and (2) resolve changed dependencies to latest when syncing `Cargo.toml` to `Cargo.lock`.
   - This expansion of scope is for consistency
   - Being a flag to turn the `deny` into an `allow` is a high friction workflow that we expect users to not be too negatively impacted by this expansion.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -760,7 +760,7 @@ This will be less optimal for workspaces with multiple MSRVs and dependencies un
 Users can workaround this by raising the version requirement or using `cargo update --precise`.
 
 When `rust-version` is unset,
-we'll fallback to `rustc --version`.
+we'll fallback to `rustc --version` if its not a pre-release.
 This is primarily targeted at helping users with a
 [`rust-toolchain.toml` file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)
 (to reduce duplication)
@@ -1143,6 +1143,9 @@ Some options include:
 - `toolchain` might look weird?
 - `local` implies a `remote`
 - `current` is like `latest` but a little softer and might work
+
+Resolving with an unset `package.rust-version` falls back to `rustc --version` only if its a non-pre-release.
+Should we instead pick the previous stable release (e.g. nightly 1.77 would resolve for 1.76)?
 
 Whether we report stale dependencies only on `cargo update` or on every command.
 See "Syncing `Cargo.toml` to `Cargo.lock` on any Cargo command".

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -516,7 +516,7 @@ Users may pass
 
 We will add `"auto"` for `package.rust-version`.
 On `cargo publish` / `cargo package`, the generated `*.crate`s `Cargo.toml` will have `"auto"` replaced with `rustc --version`.
-If `rustc --version` is a pre-release, it will be left as unspecified.
+If `rustc --version` is a pre-release, it will be left as unspecified with a warning.
 
 `cargo new` will include `package.rust-version = "auto"`.
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -830,7 +830,7 @@ Users may pass
 
 ## `cargo publish`
 
-We will add `"auto"` for `package.rust-version`.
+`package.rust-version` will gain support for an `"auto"` value, in addition to partial versions.
 On `cargo publish` / `cargo package`, the generated `*.crate`s `Cargo.toml` will have `"auto"` replaced with `rustc --version`.
 If `rustc --version` is a pre-release, it will be left as unspecified with a warning.
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1178,7 +1178,7 @@ The config field is fairly rough
 Ideally, we make it clear that this this is not inferred from syntax,
 that this is the currently running toolchain,
 that we ignore pre-release toolchains,
-and the name works well for resolver config if we decide to add "resolve to toolchain version" and want these consistent.
+and the name works well for resolver config if we decide to add "resolve to toolchain version" and want these to be consistent.
 Some options include:
 - `"tbd-name-representing-currently-running-rust-toolchain"` can imply "infer from syntactic minimum"
 - `latest` can imply "latest globally (ie from rust-lang.org)

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -371,29 +371,27 @@ selected version of the Rust compiler is older than the stated version, cargo
 will exit with an error, telling the user what version is required.
 To support this, Cargo will prefer dependencies that are compatible with your `rust-version`.
 
-The first version of Cargo that supports this field was released with Rust 1.56.0.
-In older releases, the field will be ignored, and Cargo will display a warning.
-
 ```toml
 [package]
 # ...
 rust-version = "1.56"
 ```
 
-The Rust version must be a bare version number with two or three components; it
+The Rust version can be a bare version number with two or three components; it
 cannot include semver operators or pre-release identifiers. Compiler pre-release
 identifiers such as -nightly will be ignored while checking the Rust version.
 The `rust-version` must be equal to or newer than the version that first
 introduced the configured `edition`.
 
 The Rust version can also be `"auto"`.
-This will act the same as if it was set to the version of your toolchain.
-When publishing, `"auto"` will be replaced by the version of your toolchain in your published manifest.
-
-The `rust-version` may be ignored using the `--ignore-rust-version` option.
+This will act the same as if it was set to the version of your Rust toolchain.
+Your published manifest will have `"auto"` replaced with the version of your Rust toolchain.
 
 Setting the `rust-version` key in `[package]` will affect all targets/crates in
 the package, including test suites, benchmarks, binaries, examples, etc.
+
+*Note: The first version of Cargo that supports this field was released with Rust 1.56.0.
+In older releases, the field will be ignored, and Cargo will display a warning.*
 
 ### Rust Version
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1175,7 +1175,7 @@ The config field is fairly rough
   - Maybe enumeration, like `resolver.rust-version = <manifest|toolchain|ignore>`?
 
 `rust-version = "tbd-name-representing-currently-running-rust-toolchain"`'s field name is unsettled and deciding on it is not blocking for stabilization.
-Ideally, we make it clear that this this is not inferred from syntax,
+Ideally, we make it clear that this is not inferred from syntax,
 that this is the currently running toolchain,
 that we ignore pre-release toolchains,
 and the name works well for resolver config if we decide to add "resolve to toolchain version" and want these to be consistent.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -784,10 +784,6 @@ This would benefit from knowing the oldest MSRV.
 `cargo update` will inform users when an MSRV or semver incompatible version is available.
 `cargo update --dry-run` will also report this information so that users can check on the status of this at any time.
 
-**Note:** other operations that cause `Cargo.lock` entries to be changed (like
-editing `Cargo.toml` and running `cargo check`) may not inform the user.
-If they want to check the status of things, they can run `cargo update -n`.
-
 Users may pass
 - `--ignore-rust-version` to pick the latest dependencies, ignoring all `rust-version` fields (your own and from dependencies)
 - `--update-rust-version` to pick the `rustc --version`-compatible dependencies, updating your `package.rust-version` if needed to match the highest of your dependencies

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -483,6 +483,14 @@ The MSRV-compatibility build check will be demoted from an error to a `deny`-by-
 allowing users to intentionally use dependencies on an unsupported (or less supported) version of Rust
 without requiring `--ignore-rust-version` on every invocation.
 
+Ideally, we present all of the MSRV issues upfront to be resolved together.
+At minimum, we should present a top-down message, rather than bottom up.
+
+If `package.rust-version` is unset or `"auto"`, the diagnostic should suggest setting it
+to help raise awareness of `package.rust-version` being able to reduce future
+resolution errors.
+This would benefit from knowing the oldest MSRV.
+
 ## `cargo update`
 
 `cargo update` will inform users when an MSRV or semver incompatible version is available.
@@ -694,9 +702,6 @@ Instead of adding `resolver = "3"`, we could keep the default resolver the same 
   The next corrective step (and suggestion from cargo) depends on what the user is doing and could be either
   - `git checkout main -- Cargo.lock && cargo check`
   - `cargo generate-lockfile`
-- We should update the "incompatible rust-version" checks to be top-down, rather
-  than bottom up,
-  so users see the root of their problem, rather than the leaves.
 - We'd drop from this proposal `cargo update [--ignore-rust-version|--update-rust-version]` as they don't make sense with this new default
 
 This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "auto"`, `cargo build` error to diagnostic).

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -888,7 +888,7 @@ and only in the sense that the user needs to know to explicitly take action to a
 Misc alternatives
 - Dependencies with unspecified `package.rust-version`: we could mark these as always-compatible or always-incompatible; there really isn't a right answer here.
 - The resolver doesn't support backtracking as that is extra complexity that we can always adopt later as we've reserved the right to make adjustments to what `cargo generate-lockfile` will produce over time.
-- `CARGO_RESOLVER_PRECEDENCE` is used, rather than a CLI option
+- `CARGO_RESOLVER_PRECEDENCE` is used, rather than a CLI option (e.g. ensuring every command has `--ignore-rust-version` or a `--rust-version <x.y.z>`)
   - This is unlikely to be used in one-off cases but across whole interactions which is better suited for config / env variables, rather than CLI options
   - Minimize CLI clutter
 - `CARGO_RESOLVER_PRECEDENCE=rust-version` implies maximal resolution among MSRV-compatible dependencies.   Generally MSRV doesn't decrease over versions, so minimal resolution will likely pick packages with compatible rust-versions.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -382,8 +382,8 @@ We are introducing several new concepts
   - A `.cargo/config.toml` field will be added to disable this, e.g. for CI
 - Cargo will ensure users are aware their dependencies are behind the latest in a unobtrusive way
 - `cargo add` will select version requirements that can be met by a dependency with a compatible version
-- A new value for `package.rust-version`, `"<tbd-name-representing-currently-running-rust-toolchain>"`, which will advertise in your published package your current toolchain version as the minimum-supported Rust version
-  - `cargo new` will default to `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`
+- A new value for `package.rust-version`, `"tbd-name-representing-currently-running-rust-toolchain"`, which will advertise in your published package your current toolchain version as the minimum-supported Rust version
+  - `cargo new` will default to `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"`
 - A deny-by-default lint will replace the build error from a package having an incompatible Rust version, allowing users to opt-in to overriding it
 
 ## Example documentation updates
@@ -410,9 +410,9 @@ identifiers such as -nightly will be ignored while checking the Rust version.
 The `rust-version` must be equal to or newer than the version that first
 introduced the configured `edition`.
 
-The Rust version can also be `"<tbd-name-representing-currently-running-rust-toolchain>"`.
+The Rust version can also be `"tbd-name-representing-currently-running-rust-toolchain"`.
 This will act the same as if it was set to the version of your Rust toolchain.
-Your published manifest will have `"<tbd-name-representing-currently-running-rust-toolchain>"` replaced with the version of your Rust toolchain.
+Your published manifest will have `"tbd-name-representing-currently-running-rust-toolchain"` replaced with the version of your Rust toolchain.
 
 Setting the `rust-version` key in `[package]` will affect all targets/crates in
 the package, including test suites, benchmarks, binaries, examples, etc.
@@ -472,7 +472,7 @@ $ cat foo/Cargo.toml
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"
+rust-version = "tbd-name-representing-currently-running-rust-toolchain"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -511,7 +511,7 @@ Here, we can shortcut some questions about version requirements because clap ali
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"
+rust-version = "tbd-name-representing-currently-running-rust-toolchain"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -585,7 +585,7 @@ $ cat foo/Cargo.toml
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"
+rust-version = "tbd-name-representing-currently-running-rust-toolchain"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -635,7 +635,7 @@ $ cat foo/Cargo.toml
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"
+rust-version = "tbd-name-representing-currently-running-rust-toolchain"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -664,7 +664,7 @@ I make the prescribed changes:
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92"  # <-- was "<tbd-name-representing-currently-running-rust-toolchain>" before I edited it
+rust-version = "1.92"  # <-- was "tbd-name-representing-currently-running-rust-toolchain" before I edited it
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -718,7 +718,7 @@ I've decided on an "N-2" MSRV policy:
 name = "foo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92"  # <-- was "<tbd-name-representing-currently-running-rust-toolchain>" before I edited it
+rust-version = "1.92"  # <-- was "tbd-name-representing-currently-running-rust-toolchain" before I edited it
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -838,7 +838,7 @@ without requiring `--ignore-rust-version` on every invocation.
 Ideally, we present all of the MSRV issues upfront to be resolved together.
 At minimum, we should present a top-down message, rather than bottom up.
 
-If `package.rust-version` is unset or `"<tbd-name-representing-currently-running-rust-toolchain>"`, the diagnostic should suggest setting it
+If `package.rust-version` is unset or `"tbd-name-representing-currently-running-rust-toolchain"`, the diagnostic should suggest setting it
 to help raise awareness of `package.rust-version` being able to reduce future
 resolution errors.
 This would benefit from knowing the oldest MSRV.
@@ -894,11 +894,11 @@ Users may pass
 
 ## `cargo publish`
 
-`package.rust-version` will gain support for an `"<tbd-name-representing-currently-running-rust-toolchain>"` value, in addition to partial versions.
-On `cargo publish` / `cargo package`, the generated `*.crate`s `Cargo.toml` will have `"<tbd-name-representing-currently-running-rust-toolchain>"` replaced with `rustc --version`.
+`package.rust-version` will gain support for an `"tbd-name-representing-currently-running-rust-toolchain"` value, in addition to partial versions.
+On `cargo publish` / `cargo package`, the generated `*.crate`s `Cargo.toml` will have `"tbd-name-representing-currently-running-rust-toolchain"` replaced with `rustc --version`.
 If `rustc --version` is a pre-release, publish will fail.
 
-`cargo new` will include `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`.
+`cargo new` will include `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"`.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -948,7 +948,7 @@ Misc alternatives
   - There is little reason to select an MSRV higher than their Rust toolchain
   - We should still be warning the user that new dependencies are available if they upgrade their Rust toolchain
   - This comes at the cost of inconsistency with `--ignore-rust-version`.
-- Nightly `cargo publish` with `"<tbd-name-representing-currently-running-rust-toolchain>"` fails because there isn't a good value to use and this gives us flexibility to change it later (e.g. just leaving the `rust-version` as unset).
+- Nightly `cargo publish` with `"tbd-name-representing-currently-running-rust-toolchain"` fails because there isn't a good value to use and this gives us flexibility to change it later (e.g. just leaving the `rust-version` as unset).
 
 ## Ensuring the registry Index has `rust-version` without affecting quality
 
@@ -957,7 +957,7 @@ Ensuring we have `package.rust-version` populated more often (while maintaining
 quality of that data) is an important problem but does not have to be solved to
 get value out of this RFC and can be handled separately.
 
-We chose an opt-in for populating `package.rust-version` based on `rustc --version` (`"<tbd-name-representing-currently-running-rust-toolchain>"`).
+We chose an opt-in for populating `package.rust-version` based on `rustc --version` (`"tbd-name-representing-currently-running-rust-toolchain"`).
 This will encourage a baseline of quality as users are developing with that version and `cargo publish` will do a verification step, by default.
 This will help seed the Index with more `package.rust-version` data for the resolver to work with.
 The downside is that the `package.rust-version` will likely be higher than it absolutely needs.
@@ -971,7 +971,7 @@ When missing, `cargo publish` could inject `package.rust-version` using the vers
 workaround it is to set `CARGO_RESOLVER_PRECEDENCE=maximum` which will then lose
 all other protections.
 As we said, this is likely fine but then there will be no way to opt-out for the subset of maintainers who want to keep their support definition vague.
-As things evolve, we could re-evaluate making `"<tbd-name-representing-currently-running-rust-toolchain>"` the default.
+As things evolve, we could re-evaluate making `"tbd-name-representing-currently-running-rust-toolchain"` the default.
 
 ~~We could encourage people to set their MSRV by having `cargo new` default `package.rust-version`.~~
 **However**, if people aren't committed to verifying that was implicitly set,
@@ -1041,11 +1041,11 @@ allows us to move forward without having to figure out all of these details.
 
 Affects of current solution on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
-  - ✅ `cargo new` setting `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
+  - ✅ `cargo new` setting `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ✅ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)
 2. Latest Rust as the MSRV
   - ✅ Packages can more easily keep their MSRV up-to-date with
-    - `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
+    - `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
     - `cargo update --update-rust-version` (e.g. when updating minor version) though this is dependent on what you dependencies are using for an MSRV
   - ✅ Packages can more easily offer unofficial support for an MSRV due to shifting the building with MSRV-incompatible dependencies from an error to a `deny` diagnostic
 3. Extended MSRV
@@ -1068,17 +1068,17 @@ Instead of adding `resolver = "3"`, we could keep the default resolver the same 
   - `cargo generate-lockfile`
 - We'd drop from this proposal `cargo update [--ignore-rust-version|--update-rust-version]` as they don't make sense with this new default
 
-This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`, `cargo build` error to diagnostic).
+This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"`, `cargo build` error to diagnostic).
 
 Affects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
-  - ✅ `cargo new` setting `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
+  - ✅ `cargo new` setting `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - 🟰 ~~Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)~~
 2. Latest Rust as the MSRV
   - ✅ Packages can more easily keep their MSRV up-to-date with
-    - `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
+    - `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
     - ~~`cargo update --update-rust-version` (e.g. when updating minor version) though this is dependent on what you dependencies are using for an MSRV~~
-  - ❌ Without `cargo update --update-rust-version`, `"<tbd-name-representing-currently-running-rust-toolchain>"` will be more of a default path, leading to more maintainers updating their MSRV more aggressively and waiting until minors
+  - ❌ Without `cargo update --update-rust-version`, `"tbd-name-representing-currently-running-rust-toolchain"` will be more of a default path, leading to more maintainers updating their MSRV more aggressively and waiting until minors
   - ✅ Packages can more easily offer unofficial support for an MSRV due to shifting the building with MSRV-incompatible dependencies from an error to a `deny` diagnostic
 3. Extended MSRV
   - ✅ Users will be able to opt-in to MSRV-compatible dependencies, in a `.cargo/config.toml`
@@ -1095,7 +1095,7 @@ matching the `cargo build` incompatible dependency error.
 - We would still support `CARGO_RESOLVER_PRECEDENCE=rust-version` to help "Extended MSRV" users
 - We'd drop from this proposal `cargo update [--ignore-rust-version|--update-rust-version]` as they don't make sense with this new default
 
-This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`, `cargo build` error to diagnostic).
+This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"`, `cargo build` error to diagnostic).
 
 This is an auto-adapting variant where
 - If they are on the latest toolchain, they get the current behavior
@@ -1103,13 +1103,13 @@ This is an auto-adapting variant where
 
 Affects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
-  - ✅ `cargo new` setting `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
+  - ✅ `cargo new` setting `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ✅ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)
 2. Latest Rust as the MSRV
   - ✅ Packages can more easily keep their MSRV up-to-date with
-    - `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
+    - `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
     - ~~`cargo update --update-rust-version` (e.g. when updating minor version) though this is dependent on what you dependencies are using for an MSRV~~
-  - ❌ Without `cargo update --update-rust-version`, `"<tbd-name-representing-currently-running-rust-toolchain>"` will be more of a default path, leading to more maintainers updating their MSRV more aggressively and waiting until minors
+  - ❌ Without `cargo update --update-rust-version`, `"tbd-name-representing-currently-running-rust-toolchain"` will be more of a default path, leading to more maintainers updating their MSRV more aggressively and waiting until minors
   - ✅ Packages can more easily offer unofficial support for an MSRV due to shifting the building with MSRV-incompatible dependencies from an error to a `deny` diagnostic
 3. Extended MSRV
   - ✅ Users will be able to opt-in to MSRV-compatible dependencies, in a `.cargo/config.toml`
@@ -1135,11 +1135,11 @@ We could adopt this approach in the future, if desired
 
 Affects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
-  - ✅ `cargo new` setting `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
+  - ✅ `cargo new` setting `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ❌ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)
 2. Latest Rust as the MSRV
   - ✅ Packages can more easily keep their MSRV up-to-date with
-    - `package.rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
+    - `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` (no policy around when it is changed) though this is dependent on your Rust toolchain being up-to-date (see "Latest Rust with no MSRV" for more)
     - `cargo update --update-rust-version` (e.g. when updating minor version) though this is dependent on what you dependencies are using for an MSRV
   - ✅ Packages can more easily offer unofficial support for an MSRV due to shifting the building with MSRV-incompatible dependencies from an error to a `deny` diagnostic
 3. Extended MSRV
@@ -1174,13 +1174,13 @@ The config field is fairly rough
   - If we later add "resolve to toolchain" version, this might be confusing.
   - Maybe enumeration, like `resolver.rust-version = <manifest|toolchain|ignore>`?
 
-`rust-version = "<tbd-name-representing-currently-running-rust-toolchain>"`'s field name is unsettled and deciding on it is not blocking for stabilization.
+`rust-version = "tbd-name-representing-currently-running-rust-toolchain"`'s field name is unsettled and deciding on it is not blocking for stabilization.
 Ideally, we make it clear that this this is not inferred from syntax,
 that this is the currently running toolchain,
 that we ignore pre-release toolchains,
 and the name works well for resolver config if we decide to add "resolve to toolchain version" and want these consistent.
 Some options include:
-- `"<tbd-name-representing-currently-running-rust-toolchain>"` can imply "infer from syntactic minimum"
+- `"tbd-name-representing-currently-running-rust-toolchain"` can imply "infer from syntactic minimum"
 - `latest` can imply "latest globally (ie from rust-lang.org)
 - `stable` can imply "latest globally (ie from rust-lang.org)
 - `toolchain` might look weird?

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -19,6 +19,8 @@ Note: `cargo install` is intentionally left out for now to decouple discussions 
 
 ## Status Quo
 
+<details><summary>Ensuring you have a `Cargo.lock` with dependencies compatible with your minimum-supported Rust version (MSRV) is an arduous task of running `cargo update <dep> --precise <ver>` until it works.</summary>
+
 Let's step through a simple scenario where a user develops with the
 latest Rust version but production uses an older version:
 ```console
@@ -142,6 +144,8 @@ $ cargo +1.64.0 check
     Finished dev [unoptimized + debuginfo] target(s) in 2.96s
 ```
 Success! Mixed with many tears and less hair.
+
+</details>
 
 How wide spread is this?  Take this with a grain of salt but based on crates.io user agents:
 
@@ -364,6 +368,8 @@ We'll step through several scenarios to highlight the changes in the user experi
 I'm learning Rust and wanting to write my first application.
 The book suggested I install using `rustup`.
 
+<details><summary>Expand for step through of this workflow</summary>
+
 I've recently updated my toolchain
 ```console
 $ rustup update
@@ -465,12 +471,16 @@ If I look on crates.io, the new 0.1.0 version shows up with a rust-version of 1.
 without me having to manual update the field and
 relying on the `cargo publish`s verify step to verify the correctness of that MSRV.
 
+</details>
+
 ### Extended "MSRV" with an application
 
 I am developing an application using a certified toolchain.
 I specify this toolchain using a `rust-toolchain.toml` file.
 
 Rust 1.94 is the latest but my certified toolchain is 1.92.
+
+<details><summary>Expand for step through of this workflow</summary>
 
 At some point, I start a project:
 ```console
@@ -502,12 +512,16 @@ At this point, I have a couple of options
 
 Assuming (1) or (2) applies, I ignore the warning and move on.
 
+</details>
+
 ### Extended MSRV with an application targeting multiple Rust versions
 
 *(this is a re-imagining of the Motivation's example)*
 
 I'm building an application that is deployed to multiple embedded Linux targets.
 Each target's image builder uses a different Rust toolchain version to avoid re-validating the image.
+
+<details><summary>Expand for step through of this workflow</summary>
 
 I've recently updated my toolchain
 ```console
@@ -579,9 +593,13 @@ Updating clap 5.10.30 to 5.11.0
 Updating foo's rust-version from 1.92 to 1.93
 ```
 
+</details>
+
 ### Extended MSRV for a Library
 
 I'm developing a new library and am willing to take on some costs for supporting people on older toolchains.
+
+<details><summary>Expand for step through of this workflow</summary>
 
 I've recently updated my toolchain
 ```console
@@ -636,6 +654,8 @@ Updating clap 5.10.30 to 5.11.0
 Updating foo's rust-version from 1.92 to 1.93
 ```
 Instead, if a newer clap version was out needing 1.94 or 1.95, I would instead edit `Cargo.toml` myself.
+
+</details>
 
 ## Example documentation updates
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -862,7 +862,7 @@ Misc alternatives
 - Dependencies with unspecified `package.rust-version`: we could mark these as always-compatible or always-incompatible; there really isn't a right answer here.
 - The resolver doesn't support backtracking as that is extra complexity that we can always adopt later as we've reserved the right to make adjustments to what `cargo generate-lockfile` will produce over time.
 - `CARGO_RESOLVER_PRECEDENCE=rust-version` implies maximal resolution among MSRV-compatible dependencies.   Generally MSRV doesn't decrease over versions, so minimal resolution will likely pick packages with compatible rust-versions.
-  - `cargo add` selecting rust-version-compatible minimum bounds helps
+  - `cargo add` helps by selecting rust-version-compatible minimum bounds
   - This bypasses a lot of complexity either from exploding the number of states we support or giving users control over the fallback by making the field an array of strategies.
 - Instead of `resolver = "3"`, we could just change the default for everyone
   - The number of maintainers verifying latest dependencies is likely

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -229,8 +229,8 @@ And keeping in mind
 
 Some implications:
 - "Support" in MSRV implies the same quality and responsiveness to bug reports, regardless of Rust version
-- MSRV applies to all interactions with a project
-  (including registry dependency, git dependency, `cargo install`, contributor experience),
+- MSRV applies to all interactions with a project within the maintainers control
+  (including as a registry dependency, `cargo install --locked`, as a git dependency, contributor experience; excluding transitive dependencies, rust-analyzer, etc),
   unless documented otherwise like
   - Some projects may document that enabling a feature will affect the MSRV (e.g. [moka](https://docs.rs/moka/0.12.1/moka/#minimum-supported-rust-versions))
   - Some projects may have a higher MSRV for building the repo (e.g. `Cargo.lock` with newer dependencies, reliance on cargo features that get stripped on publish)

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -939,7 +939,7 @@ Misc alternatives
   - Either way, the big care about is there being attention drawn to the change.
     We couldn't want this to be like sparse registries where a setting exists and we change the default and people hardly notice (besides any improvements)
 - `cargo build` will treat incompatible MSRVs as a workspace-level lint, rather than a package level lint, to avoid the complexity of mapping the dependency to a workspace-member to select `[lint]` tables to respect and then dealing with unifying conflicting levels in between `[lint]` tables among members.
-- `--ignore-rust-version` picks absolutely the latest dependencies to support both users on latest rustc and users wanting "unsupported" dependencies, at the cost of users not on the latest rustc but still want latest more up-to-date dependencies than their MSRV allows
+- `--ignore-rust-version` picks absolutely the latest dependencies to support both users on latest rustc and users wanting "unsupported" dependencies, at the cost of users not on the latest rustc but still wanting latest more up-to-date dependencies than their MSRV allows
 - Compilation commands (e.g. `cargo check`) will take on two meanings for `--ignore-rust-version`, (1) `allow` the workspace diagnostic and (2) resolve changed dependencies to latest when syncing `Cargo.toml` to `Cargo.lock`.
   - This expansion of scope is for consistency
   - Being a flag to turn the `deny` into an `allow` is a high friction workflow that we expect users to not be too negatively impacted by this expansion.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -359,6 +359,66 @@ one lockfile can be used but it can be difficult to edit the `Cargo.lock` to ens
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
+## Example documentation updates
+
+### The `rust-version` field
+
+*(update to [manifest documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field))*
+
+The `rust-version` field is an optional key that tells cargo what version of the
+Rust language and compiler your package can be compiled with. If the currently
+selected version of the Rust compiler is older than the stated version, cargo
+will exit with an error, telling the user what version is required.
+To support this, Cargo will prefer dependencies that are compatible with your `rust-version`.
+
+The first version of Cargo that supports this field was released with Rust 1.56.0.
+In older releases, the field will be ignored, and Cargo will display a warning.
+
+```toml
+[package]
+# ...
+rust-version = "1.56"
+```
+
+The Rust version must be a bare version number with two or three components; it
+cannot include semver operators or pre-release identifiers. Compiler pre-release
+identifiers such as -nightly will be ignored while checking the Rust version.
+The `rust-version` must be equal to or newer than the version that first
+introduced the configured `edition`.
+
+The Rust version can also be `"auto"`.
+This will act the same as if it was set to the version of your toolchain.
+When publishing, `"auto"` will be replaced by the version of your toolchain in your published manifest.
+
+The `rust-version` may be ignored using the `--ignore-rust-version` option.
+
+Setting the `rust-version` key in `[package]` will affect all targets/crates in
+the package, including test suites, benchmarks, binaries, examples, etc.
+
+### Rust Version
+
+*(update to [Dependency Resolution's Other Constraints documentation](https://doc.rust-lang.org/cargo/reference/resolver.html))*
+
+When multiple versions of a dependency satisfy all version requirements,
+cargo will prefer those with a compatible `package.rust-version` over those that
+aren't compatible.
+Some details may change over time though `cargo check && rustup update && cargo check` should not cause `Cargo.lock` to change.
+
+##### `resolver.precedence`
+
+*(update to [Configuration](https://doc.rust-lang.org/cargo/reference/config.html))*
+
+* Type: string
+* Default: "rust-version"
+* Environment: `CARGO_RESOLVER_PRECEDENCE`
+
+Controls how `Cargo.lock` gets updated on changes to `Cargo.toml` and with `cargo update`.  This does not affect `cargo install`.
+
+* `maximum`: prefer the highest compatible versions of dependencies
+* `rust-version`: prefer dependencies where their `package.rust-version` is less than or equal to your `package.rust-version`
+
+`rust-version` can be overridden with `--ignore-rust-version` which will fallback to `maximum`.
+
 ## Example workflows
 
 We'll step through several scenarios to highlight the changes in the user experience.
@@ -656,66 +716,6 @@ Updating foo's rust-version from 1.92 to 1.93
 Instead, if a newer clap version was out needing 1.94 or 1.95, I would instead edit `Cargo.toml` myself.
 
 </details>
-
-## Example documentation updates
-
-### The `rust-version` field
-
-*(update to [manifest documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field))*
-
-The `rust-version` field is an optional key that tells cargo what version of the
-Rust language and compiler your package can be compiled with. If the currently
-selected version of the Rust compiler is older than the stated version, cargo
-will exit with an error, telling the user what version is required.
-To support this, Cargo will prefer dependencies that are compatible with your `rust-version`.
-
-The first version of Cargo that supports this field was released with Rust 1.56.0.
-In older releases, the field will be ignored, and Cargo will display a warning.
-
-```toml
-[package]
-# ...
-rust-version = "1.56"
-```
-
-The Rust version must be a bare version number with two or three components; it
-cannot include semver operators or pre-release identifiers. Compiler pre-release
-identifiers such as -nightly will be ignored while checking the Rust version.
-The `rust-version` must be equal to or newer than the version that first
-introduced the configured `edition`.
-
-The Rust version can also be `"auto"`.
-This will act the same as if it was set to the version of your toolchain.
-When publishing, `"auto"` will be replaced by the version of your toolchain in your published manifest.
-
-The `rust-version` may be ignored using the `--ignore-rust-version` option.
-
-Setting the `rust-version` key in `[package]` will affect all targets/crates in
-the package, including test suites, benchmarks, binaries, examples, etc.
-
-### Rust Version
-
-*(update to [Dependency Resolution's Other Constraints documentation](https://doc.rust-lang.org/cargo/reference/resolver.html))*
-
-When multiple versions of a dependency satisfy all version requirements,
-cargo will prefer those with a compatible `package.rust-version` over those that
-aren't compatible.
-Some details may change over time though `cargo check && rustup update && cargo check` should not cause `Cargo.lock` to change.
-
-##### `resolver.precedence`
-
-*(update to [Configuration](https://doc.rust-lang.org/cargo/reference/config.html))*
-
-* Type: string
-* Default: "rust-version"
-* Environment: `CARGO_RESOLVER_PRECEDENCE`
-
-Controls how `Cargo.lock` gets updated on changes to `Cargo.toml` and with `cargo update`.  This does not affect `cargo install`.
-
-* `maximum`: prefer the highest compatible versions of dependencies
-* `rust-version`: prefer dependencies where their `package.rust-version` is less than or equal to your `package.rust-version`
-
-`rust-version` can be overridden with `--ignore-rust-version` which will fallback to `maximum`.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -793,9 +793,11 @@ Affects on workflows (including non-resolver behavior):
 [unresolved-questions]: #unresolved-questions
 
 The config field is fairly rough
-  - The name isn't very clear
-  - The values are awkward
-  - Should we instead just have a `resolver.rust-version = true`?
+- The name isn't very clear
+- The values are awkward
+- Should we instead just have a `resolver.rust-version = true`?
+  - If we later add "resolve to toolchain" version, this might be confusing.
+  - Maybe enumeration, like `resolver.rust-version = <manifest|toolchain|ignore>`?
 
 `rust-version = "auto"`'s field name is unsettled and deciding on it is not blocking for stabilization.
 Ideally, we make it clear that this this is not inferred from syntax,

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -776,7 +776,7 @@ This would benefit from knowing the oldest MSRV.
 ## `cargo update`
 
 `cargo update` will inform users when an MSRV or semver incompatible version is available.
-`cargo update -n` will also report this information so that users can check on the status of this at any time.
+`cargo update --dry-run` will also report this information so that users can check on the status of this at any time.
 
 **Note:** other operations that cause `Cargo.lock` entries to be changed (like
 editing `Cargo.toml` and running `cargo check`) may not inform the user.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -493,6 +493,9 @@ If they want to check the status of things, they can run `cargo update -n`.
 Users may pass
 - `--ignore-rust-version` to pick the latest dependencies, ignoring all `rust-version` fields (your own and from dependencies)
 - `--update-rust-version` to pick the `rustc --version`-compatible dependencies, updating your `package.rust-version` if needed to match the highest of your dependencies
+- `<pkgname> --precise <version>` to pick a specific version, independent of the `rust-version` field
+
+We expect the notice to inform users of these options for allowing them to upgrade.
 
 Those flags will also be added to `cargo generate-lockfile`
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -841,7 +841,8 @@ If `rustc --version` is a pre-release, it will be left as unspecified with a war
 
 Users upgrading to the next Edition (or changing to `resolver = '3"`), will have to manually update their CI to test the latest dependencies with `CARGO_RESOLVER_PRECEDENCE=maximum`.
 
-Workspaces have no `edition`, so its easy for users to not realize they need to set `resolver = "3"` or to update their `resolver = "2"` to `"3"`.
+Workspaces have no `edition`, so its easy for users to not realize they need to set `resolver = "3"` or to update their `resolver = "2"` to `"3"`
+(Cargo only warns on [virtual manifests without an explicit `workspace.resolver`](https://github.com/rust-lang/cargo/pull/10910)).
 
 While we hope this will give maintainers more freedom to upgrade their MSRV,
 this could instead further entrench rust-version stagnation in the ecosystem.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -889,24 +889,24 @@ Ensuring we have `package.rust-version` populated more often (while maintaining
 quality of that data) is an important problem but does not have to be solved to
 get value out of this RFC and can be handled separately.
 
-We chose an opt-in for populating `package.rust-version` based on `rustc --version`.
-This will encourage a baseline of quality as are developing with that version and `cargo publish` will do a verification step, by default.
+We chose an opt-in for populating `package.rust-version` based on `rustc --version` (`"auto"`).
+This will encourage a baseline of quality as users are developing with that version and `cargo publish` will do a verification step, by default.
 This will help seed the Index with more `package.rust-version` data for the resolver to work with.
 The downside is that the `package.rust-version` will likely be higher than it absolutely needs.
 However, considering our definition of "support" and that the user isn't bothering to set an MSRV themself,
 aggressively updating is likely fine in this case, especially since we'll let dependents override the build failure for MSRV-incompatible packages.
 
-Alternatively...
+Some alternative solutions include:
 
-~~When missing, `cargo publish` could inject `package.rust-version` using the version of rustc used during publish.~~
-However, this will err on the side of a higher MSRV than necessary and the only way to
+When missing, `cargo publish` could inject `package.rust-version` using the version of rustc used during publish.
+**However**, this will err on the side of a higher MSRV than necessary and the only way to
 workaround it is to set `CARGO_RESOLVER_PRECEDENCE=maximum` which will then lose
 all other protections.
 As we said, this is likely fine but then there will be no way to opt-out for the subset of maintainers who want to keep their support definition vague.
 As things evolve, we could re-evaluate making `"auto"` the default.
 
 ~~We could encourage people to set their MSRV by having `cargo new` default `package.rust-version`.~~
-However, if people aren't committed to verifying it,
+**However**, if people aren't committed to verifying that was implicitly set,
 it is likely to go stale and will claim an MSRV much older than what is used in practice.
 If we had the hard-error resolver mode and
 [clippy warning people when using API items stabilized after their MSRV](https://github.com/rust-lang/rust-clippy/issues/6324),
@@ -914,9 +914,11 @@ this will at least annoy people into either being somewhat compatible or removin
 
 ~~When missing, `cargo publish` could inject `package.rust-version` inferred from
 `package.edition` and/or other `Cargo.toml` fields.~~
-However, this will err on the side of too low of an MSRV.
-While this might help with in this situation,
-it would lock us in to inaccurate information which might limit what analysis we could do in the future.
+**However**, this will err on the side of too low of an MSRV.
+These fields have an incomplete picture.
+While this helps ensure there is more data for the MSRV-aware resolver,
+future analysis wouldn't be able to distinguish between inferred and explicit `package.rust-version`s.
+We'd also need an explicit opt-out for those who intentionally don't want one set.
 
 Alternatively, `cargo publish` / the registry could add new fields to the Index
 to represent an inferred MSRV, the published version, etc

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -237,7 +237,7 @@ A user runs `cargo new` and starts development.
 A maintainer may also want to avoid constraining their dependents, for a variety of reasons, and leave MSRV support as a gray area.
 
 **Priority 1 because:**
-- No MSRV is fine as pushing people to have an MSRV would lead to either
+- ✅ No MSRV is fine as pushing people to have an MSRV would lead to either
   - an inaccurate reported MSRV from it going stale which would lower the quality of the ecosystem
   - raise the barrier to entry by requiring more process for packages and pushing the cost of old Rust versions on people who don't care
 
@@ -259,10 +259,10 @@ Due to the pain points listed below, the target audience for this workflow is li
 likely pushing them to not specify their MSRV.
 
 **Priority 2 because:**
-- Low barrier to maintaining a high quality of support for their MSRV
-- Being willing to advertising an MSRV, even if latest, improves the information available to developers, increasing the quality of the ecosystem
-- Costs for dealing with old Rust toolchains is shifted from the maintainer and the users on a supported toolchain to those on an unsupported toolchain
-- By focusing new development on latest MSRV, this provides a carrot to encourage others to actively upgrading
+- ✅ Low barrier to maintaining a high quality of support for their MSRV
+- ✅ Being willing to advertising an MSRV, even if latest, improves the information available to developers, increasing the quality of the ecosystem
+- ✅ Costs for dealing with old Rust toolchains is shifted from the maintainer and the users on a supported toolchain to those on an unsupported toolchain
+- ✅ By focusing new development on latest MSRV, this provides a carrot to encourage others to actively upgrading
 
 **Pain points (in addition to the prior workflow):**
 
@@ -306,10 +306,10 @@ The way they verify dependencies is restricted as they can't rely on always upda
 Maintainers likely only need to do a compilation check for MSRV as their regular CI runs ensure that the behavior (which is usually independent of rust version) is correct for the MSRV-compatible dependencies.
 
 **Priority 3 because:**
-- Several use cases for this workflow have little alternative
-- MSRV applies to all interactions to the project which also means that the level of "support" is consistent
-- This implies stagnation and there are cases where people could more easily use newer toolchains, like Debian users, but that is less so the case for other users
-- For library and tool maintainers, they are absorbing costs from these less common use cases
+- ✅ Several use cases for this workflow have little alternative
+- ✅ MSRV applies to all interactions to the project which also means that the level of "support" is consistent
+- ❌ This implies stagnation and there are cases where people could more easily use newer toolchains, like Debian users, but that is less so the case for other users
+- ❌ For library and tool maintainers, they are absorbing costs from these less common use cases
   - They could shift these costs to those that need old versions by switching to the "Latest MSRV" workflow by allowing their users to backport fixes to prior MSRV releases
 
 **Pain points:**
@@ -334,13 +334,13 @@ the fact that the tests are verifying (on a newer toolchain) that the build/norm
 Compared to the above workflow, this is likely targeted at just library and tool maintainers as other use cases don't have access to the latest version or they are needing the repo to be compatible with their MSRV.
 
 **Priority 4 because:**
-- The MSRV has various carve outs, providing an inconsistent experience compared to other packages using other workflows and affecting the quality of the ecosystem
+- ❌ The MSRV has various carve outs, providing an inconsistent experience compared to other packages using other workflows and affecting the quality of the ecosystem
   - For workspaces with bins, `cargo install --locked` is expected to work with the MSRV but won't
   - If they use new Cargo features, then `[patch]`ing in a git source for the dependency won't work
   - For contributors, they must be on an unspecified Rust toolchain version
-- The caveats involved in this approach (see prior item) would lead to worse documentation which lowers the quality to users
-- This still leads to stagnation despite being able to use the latest dependencies as they are limited in what they can use from them and they can't use features from the latest Rust toolchain
-- These library and tool maintainers are absorbing costs from the less common use cases of their dependents
+- ❌ The caveats involved in this approach (see prior item) would lead to worse documentation which lowers the quality to users
+- ❌ This still leads to stagnation despite being able to use the latest dependencies as they are limited in what they can use from them and they can't use features from the latest Rust toolchain
+- ❌ These library and tool maintainers are absorbing costs from the less common use cases of their dependents
   - They could shift these costs to those that need old versions by switching to the "Latest MSRV" workflow by allowing their users to backport fixes to prior MSRV releases
 
 **Pain points:**

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -859,7 +859,6 @@ and only in the sense that the user needs to know to explicitly take action to a
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 Misc alternatives
-- Config was put under `build` to associate it with local development, as compared with `install` which could be supported in the future
 - Dependencies with unspecified `package.rust-version`: we could mark these as always-compatible or always-incompatible; there really isn't a right answer here.
 - The resolver doesn't support backtracking as that is extra complexity that we can always adopt later as we've reserved the right to make adjustments to what `cargo generate-lockfile` will produce over time.
 - `CARGO_RESOLVER_PRECEDENCE=rust-version` assumes maximal resolution as generally minimal resolution will pick packages with compatible rust-versions as rust-version tends to (but doesn't always) increase over time.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -10,6 +10,7 @@
 Provide a happy path for developers needing to work with older versions of Rust by
 - Preferring MSRV (minimum-supported-rust-version) compatible dependencies when Cargo resolves dependencies
 - Ensuring compatible version requirements when `cargo add` auto-selects a version
+- Smoothing out the path for setting and maintaining a verified MSRV so the above will be more likely to pick a working version.
 
 Note: `cargo install` is intentionally left out for now to decouple discussions on how to handle the security ramifications.
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1070,7 +1070,7 @@ Instead of adding `resolver = "3"`, we could keep the default resolver the same 
 
 This has no impact on the other proposals (`cargo add` picking compatible versions, `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"`, `cargo build` error to diagnostic).
 
-Affects on workflows (including non-resolver behavior):
+Effects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
   - ✅ `cargo new` setting `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - 🟰 ~~Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)~~

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -393,7 +393,7 @@ We are introducing several new concepts
 *(update to [manifest documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field))*
 
 The `rust-version` field is an optional key that tells cargo what version of the
-Rust language and compiler your package can be compiled with. If the currently
+Rust language and compiler your support compiling your package with. If the currently
 selected version of the Rust compiler is older than the stated version, cargo
 will exit with an error, telling the user what version is required.
 To support this, Cargo will prefer dependencies that are compatible with your `rust-version`.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -37,6 +37,7 @@ $ cargo add clap
 $ git commit -a -m "WIP" && git push
 ...
 ```
+
 After 30 minutes, CI fails.
 The first step is to reproduce this locally
 ```console
@@ -46,6 +47,7 @@ $ cargo +1.64.0 check
     Updating crates.io index
        Fetch [===============>         ]  67.08%, (28094/50225) resolving deltas
 ```
+
 After waiting several minutes, cursing being stuck on a version from before sparse registry support was added...
 ```console
 $ cargo +1.64.0 check
@@ -60,6 +62,7 @@ $ cargo +1.64.0 check
 error: package `clap_builder v4.4.8` cannot be built because it requires rustc 1.70.0 or newer, while the currently ac
 tive rustc version is 1.64.0
 ```
+
 Thankfully, crates.io now shows [supported Rust versions](https://crates.io/crates/clap_builder/versions), so I pick v4.3.24.
 ```console
 $ cargo update -p clap_builder --precise 4.3.24
@@ -71,6 +74,7 @@ required by package `clap v4.4.8`
     ... which satisfies dependency `clap = "^4.4.8"` (locked to 4.4.8) of package `msrv-resolver v0.1.0 (/home/epage/src/personal/dump/msrv-resolver)`
 perhaps a crate was updated and forgotten to be re-vendored?
 ```
+
 After browsing on some forums, I edit my `Cargo.toml` to roll back to `clap = "4.3.24"` and try again
 ```console
 $ cargo update -p clap --precise 4.3.24
@@ -100,6 +104,7 @@ $ cargo +1.64.0 check
 error: package `anstyle-parse v0.2.2` cannot be built because it requires rustc 1.70.0 or newer, while the currently a
 ctive rustc version is 1.64.0
 ```
+
 Again, consulting [crates.io](https://crates.io/crates/anstyle-parse/versions)
 ```console
 $ cargo update -p anstyle-parse --precise 0.2.1
@@ -109,6 +114,7 @@ $ cargo +1.64.0 check
 error: package `clap_lex v0.5.1` cannot be built because it requires rustc 1.70.0 or newer, while the currently active
  rustc version is 1.64.0
 ```
+
 Again, consulting [crates.io](https://crates.io/crates/clap_lex/versions)
 ```console
 $ cargo update -p clap_lex --precise 0.5.0
@@ -118,6 +124,7 @@ $ cargo +1.64.0 check
 error: package `anstyle v1.0.4` cannot be built because it requires rustc 1.70.0 or newer, while the currently active
 rustc version is 1.64.0
 ```
+
 Again, consulting [crates.io](https://crates.io/crates/anstyle/versions)
 ```console
 cargo update -p anstyle --precise 1.0.2
@@ -143,6 +150,7 @@ $ cargo +1.64.0 check
     Checking msrv-resolver v0.1.0 (/home/epage/src/personal/dump/msrv-resolver)
     Finished dev [unoptimized + debuginfo] target(s) in 2.96s
 ```
+
 Success! Mixed with many tears and less hair.
 
 </details>
@@ -450,6 +458,7 @@ At some point, I start a project:
 $ cargo new foo
 $ cat foo/Cargo.toml
 ```
+
 ```toml
 [package]
 name = "foo"
@@ -461,10 +470,12 @@ rust-version = "auto"
 
 [dependencies]
 ```
+
 ```console
 $ cargo add clap -F derive
 Adding clap 5.10.30
 ```
+
 *(note: this user would traditionally be a "Latest Rust" user but `package.rust-version` automatically them moved to "Latest Rust with MSRV" without extra validation effort or risk of their MSRV going stale)*
 
 After some time, I get back to my project and decide to add completion support:
@@ -475,6 +486,7 @@ warning: clap_complete 5.11.0 exists but requires Rust 1.93 while you are runnin
 To use the clap_complete@5.11.0 with a compatible Rust version, run `rustup update && cargo add clap_complete@5.11.0`.
 To force the use of clap_complete@5.11.0 independent of your toolchain, run `cargo add clap_complete@5.11.0`
 ```
+
 Wanting to be on the latest version, I run
 ```console
 $ rustup update
@@ -499,6 +511,7 @@ rust-version = "auto"
 clap = { version = "5.10.30", features = ["derive"] }
 clap_complete = "5.10"  # <-- new
 ```
+
 And away I go:
 ```console
 $ cargo check
@@ -506,6 +519,7 @@ Warning: adding clap_complete@5.10.40 because 5.11.0 requires Rust 1.93 while yo
 To use the clap_complete@5.11.0 with a compatible Rust version, run `rustup update && cargo update`.
 To force the use of clap_complete@5.11.0 independent of your toolchain, run `cargo update --ignore-rust-version`
 ```
+
 But I am in a hurry and don't want to disrupt my flow.
 `clap_complete@5.10.40` is likely fine.
 I am running `clap@5.10.30` and that has been working for me.
@@ -536,6 +550,7 @@ $ $EDITOR `Cargo.toml`
 $ cargo publish
 Published foo 0.1.0
 ```
+
 If I look on crates.io, the new 0.1.0 version shows up with a rust-version of 1.94
 without me having to manual update the field and
 relying on the `cargo publish`s verify step to verify the correctness of that MSRV.
@@ -556,6 +571,7 @@ At some point, I start a project:
 $ cargo new foo
 $ cat foo/Cargo.toml
 ```
+
 ```toml
 [package]
 name = "foo"
@@ -567,6 +583,7 @@ rust-version = "auto"
 
 [dependencies]
 ```
+
 ```console
 $ cargo add clap -F derive
 Adding clap 5.10.30
@@ -574,6 +591,7 @@ warning: clap 5.11.0 exists but requires Rust 1.93 while you are running 1.92.
 To use the clap@5.11.0 with a compatible Rust version, run `rustup update && cargo add clap@5.10.0`.
 To force the use of clap_complete@5.11.0 independent of your toolchain, run `cargo add clap@5.10.0`
 ```
+
 At this point, I have a couple of options
 1. I check and clap advertises that they "support" Rust 1.92 by cherry-picking fixes into 5.10 and I feel comfortable with that
 2. I check `cargo deny` and don't see any vulnerabilities and that is good enough for me, knowing that the majority of my users are likely on newer versions
@@ -603,6 +621,7 @@ At some point, I start a project:
 $ cargo new foo
 $ cat foo/Cargo.toml
 ```
+
 ```toml
 [package]
 name = "foo"
@@ -614,13 +633,14 @@ rust-version = "auto"
 
 [dependencies]
 ```
+
 ```console
 $ cargo add clap -F derive
 Adding clap 5.11.0
 ```
 
 I send this to my image builder and I get this failure for one of my embedded targets:
-```
+```console
 $ cargo build
 error: clap 5.11.0 requires Rust 1.93.0 while you are running 1.92.0
 
@@ -629,6 +649,7 @@ note: set `package.rust-version = "1.92.0"` to ensure compatible versions are se
 note: lint `cargo::incompatible-msrv` is denied by default
 
 ```
+
 I make the prescribed changes:
 ```toml
 [package]
@@ -642,6 +663,7 @@ rust-version = "1.92"  # <-- was "auto" before I edited it
 [dependencies]
 clap = { version = "5.10.30", features = ["derive"] }  # <-- downgraded
 ```
+
 And my image build works!
 
 After some time, I run:
@@ -654,6 +676,7 @@ clap_complete 5.10.40 5.11.0 requires Rust 1.93
 note: To use the latest depednencies, run `rustup update && cargo update`.
 To force the use of the latest dependencies, independent of your toolchain, run `cargo update --ignore-rust-version`
 ```
+
 We've EOLed the last embedded target that supported 1.92 and so we can update our `package.rust-version`,
 so we can update it and our dependencies:
 ```console
@@ -680,6 +703,7 @@ At some point, I start a project:
 ```console
 $ cargo new foo --lib
 ```
+
 I've decided on an "N-2" MSRV policy:
 ```toml
 [package]
@@ -692,6 +716,7 @@ rust-version = "1.92"  # <-- was "auto" before I edited it
 
 [dependencies]
 ```
+
 ```console
 $ cargo add clap -F derive
 Adding clap 5.10.30
@@ -699,6 +724,7 @@ warning: clap 5.11.0 exists but requires Rust 1.93 while `foo` has `package.rust
 To use clap@5.11.0 with a compatible package.rust-version, run `cargo add clap@5.11.0 --update-rust-version`
 To force the use of clap@5.11.0 independent of your toolchain, run `cargo add clap@5.11.0`
 ```
+
 At this point, I have a couple of options
 1. I check and clap advertises that they "support" Rust 1.92 by cherry-picking fixes into 5.10 and I feel comfortable with that
 2. I check `cargo deny` and don't see any vulnerabilities and that is good enough for me, knowing that the majority of my users are likely on newer versions
@@ -716,12 +742,14 @@ clap_complete 5.10.40 5.11.0 requires Rust 1.93
 note: To use the latest depednencies, run `rustup update && cargo update`.
 To force the use of the latest dependencies, independent of your toolchain, run `cargo update --ignore-rust-version`
 ```
+
 At this point, 1.95 is out, so I'm fine updating my MSRV and I run:
 ```console
 $ cargo update --update-rust-version
 Updating clap 5.10.30 to 5.11.0
 Updating foo's rust-version from 1.92 to 1.93
 ```
+
 Instead, if a newer clap version was out needing 1.94 or 1.95, I would instead edit `Cargo.toml` myself.
 
 </details>
@@ -777,6 +805,7 @@ We'll add a `resolver.precedence ` field to `.cargo/config.toml` which will cont
 [build]
 resolver.precedence = "rust-version"  # Default with `v3`
 ```
+
 with potential values being:
 - `maximum`: behavior today (default for v1 and v2 resolvers)
   - Needed for [verifying latest dependencies](https://doc.rust-lang.org/nightly/cargo/guide/continuous-integration.html#verifying-latest-dependencies)

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -916,7 +916,7 @@ this introduces another form of drift from the latest dependencies
 (in addition to [lockfiles](https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control)).
 However, we already recommend people
 [verify their latest dependencies](https://doc.rust-lang.org/nightly/cargo/guide/continuous-integration.html#verifying-latest-dependencies),
-so the only scenario this degrades it further is when lockfiles are verified by always updating to the latest, like with RenovateBot,
+so the only scenario this further degrades is when lockfiles are verified by always updating to the latest, like with RenovateBot,
 and only in the sense that the user needs to know to explicitly take action to add another verification job to CI.
 
 # Rationale and alternatives

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -713,7 +713,7 @@ resolved dependencies always get preference.
 This can be overridden with `--ignore-rust-version` and config's `resolver.precedence`.
 
 Implications
-- If you use do `cargo update --precise <msrv-incompatible-ver>`, it will work
+- If you use `cargo update --precise <msrv-incompatible-ver>`, it will work
 - If you use `--ignore-rust-version` once, you don't need to specify it again to keep those dependencies though you might need it again on the next edit of `Cargo.toml` or `cargo update` run
 - If a dependency doesn't specify `package.rust-version` but its transitive dependencies specify an incompatible `package.rust-version`,
   we won't backtrack to older versions of the dependency to find one with a MSRV-compatible transitive dependency.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -206,7 +206,7 @@ And keeping in mind
 - Even keeping upgrade costs low, there is still a re-validation cost that mission critical applications must pay
 - Dependencies in `Cargo.lock` are not expected to change from contributors using different versions of the Rust toolchain without an explicit action like changing `Cargo.toml` or running `cargo update`
   - e.g. If the maintainer does `cargo add foo && git commit && git push`,
-    then a contributor doing `git pull && cargo check` should not have a different selection of dependencies.
+    then a contributor doing `git pull && cargo check` should not have a different selection of dependencies, independent of their toolchain versions (which might mean the second user sees an error about an incompatible package).
 
 Some implications:
 - "Support" in MSRV implies the same quality and responsiveness to bug reports, regardless of Rust version

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -852,7 +852,7 @@ Users may pass
 
 `package.rust-version` will gain support for an `"auto"` value, in addition to partial versions.
 On `cargo publish` / `cargo package`, the generated `*.crate`s `Cargo.toml` will have `"auto"` replaced with `rustc --version`.
-If `rustc --version` is a pre-release, it will be left as unspecified with a warning.
+If `rustc --version` is a pre-release, publish will fail.
 
 `cargo new` will include `package.rust-version = "auto"`.
 
@@ -901,6 +901,7 @@ Misc alternatives
   - There is little reason to select an MSRV higher than their Rust toolchain
   - We should still be warning the user that new dependencies are available if they upgrade their Rust toolchain
   - This comes at the cost of inconsistency with `--ignore-rust-version`.
+- Nightly `cargo publish` with `auto` fails because there isn't a good value to use and this gives us flexibility to change it later (e.g. just leaving the `rust-version` as unset).
 
 ## Ensuring the registry Index has `rust-version` without affecting quality
 

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -871,7 +871,7 @@ Misc alternatives
     Therefore, we could probably get away with treating this as a minor incompatibility
   - Either way, the big care about is there being attention drawn to the change.
     We couldn't want this to be like sparse registries where a setting exists and we change the default and people hardly notice (besides any improvements)
-- `cargo build` will treat incompatible MSRVs as a workspace-level lint, rather than a package level lint, to avoid the complexity of mapping the package to a workspace-member for `[lint]` and dealing with unifying conflicting levels in `[lint]`.
+- `cargo build` will treat incompatible MSRVs as a workspace-level lint, rather than a package level lint, to avoid the complexity of mapping the dependency to a workspace-member to select `[lint]` tables to respect and then dealing with unifying conflicting levels in between `[lint]` tables among members.
 - `--ignore-rust-version` picks absolutely the latest dependencies to support (1) users on latest rustc and (2) users wanting "unsupported" dependencies, at the cost of users not on the latest rustc but still want latest more up-to-date dependencies than their MSRV allows
 - Compilation commands (e.g. `cargo check`) will take on two meanings for `--ignore-rust-version`, (1) `allow` the workspace diagnostic and (2) resolve changed dependencies to latest when syncing `Cargo.toml` to `Cargo.lock`.
   - This expansion of scope is for consistency

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -168,6 +168,11 @@ How wide spread is this?  Take this with a grain of salt but based on crates.io 
 
 *([source](https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/cargo.20version.20usage/near/401440149))*
 
+This was aided by the presence of `package.rust-version`.
+Of all packages (137,569), only 8,857 (6.4%) have that field set.
+When limiting to the 61,758 "recently" published packages (an upload since the start of 2023),
+only 8,550 (13.8%) have the field set.
+
 People have tried to reduce the pain from MSRV with its own costs:
 - Treating it as a breaking change:
   - This leads to extra churn in the ecosystem when a fraction of users are likely going to benefit

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1101,7 +1101,7 @@ This is an auto-adapting variant where
 - If they are on the latest toolchain, they get the current behavior
 - If their toolchain matches their MSRV, they get an MSRV-aware resolver
 
-Affects on workflows (including non-resolver behavior):
+Effects on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
   - ✅ `cargo new` setting `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ✅ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -17,6 +17,8 @@ Note: `cargo install` is intentionally left out for now to decouple discussions 
 # Motivation
 [motivation]: #motivation
 
+## Status Quo
+
 Let's step through a simple scenario where a user develops with the
 latest Rust version but production uses an older version:
 ```console

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -902,3 +902,10 @@ Ideally, we'd at least facilitate people in setting their MSRV.  Some data that 
 
 Once people have more data to help them in picking an MSRV policy,
 it would help to also document trade-offs on whether an MSRV policy should proactive or reactive on when to bump it.
+
+## Warn when adding dependencies with unspecified MSRVs
+
+When adding packages without an MSRV,
+its not clear whether it will work with your project.
+Knowing that they haven't declared support for your toolchain version could be important,
+after we've made it easier to declare an MSRV.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1039,7 +1039,7 @@ allows us to move forward without having to figure out all of these details.
 
 ## Resolver behavior
 
-Affects of current solution on workflows (including non-resolver behavior):
+Effects of current solution on workflows (including non-resolver behavior):
 1. Latest Rust with no MSRV
   - ✅ `cargo new` setting `package.rust-version = "tbd-name-representing-currently-running-rust-toolchain"` moves most users to "Latest Rust as the MSRV" with no extra maintenance cost
   - ✅ Dealing with incompatible dependencies will have a friendlier face because the hard build error after changing dependencies is changed to a notification during update suggesting they upgrade to get the new dependency because we fallback to `rustc --version` when `package.rust-version` is unset (as a side effect of us capturing `rust-toolchain.toml`)

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1054,6 +1054,11 @@ Affects of current solution on workflows (including non-resolver behavior):
   - ❌ Maintainers will have to opt-in to latest dependencies, in a `.cargo/config.toml`
   - ✅ Verifying MSRV will no longer require juggling `Cargo.lock` files or using unstable features
 
+A short term benefit (hence why this is separate) is that an MSRV-aware resolver by default is that we can use it as a polyfill for
+[`cfg(version)`](https://dev-doc.rust-lang.org/stable/unstable-book/language-features/cfg-version.html)
+(which will likely need a lot of work in cargo after we finish stabilizing it for rustc).
+A polyfill package can exist that has multiple maintained semver-compatible versions with different MSRVs with the older ones leveraging external libraries while the newer ones leverage the standard library.
+
 ### Make this opt-in rather than opt-out
 
 Instead of adding `resolver = "3"`, we could keep the default resolver the same as today but allow opt-in to MSRV-aware resolver via `CARGO_RESOLVER_PRECEDENCE=rust-version`.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -393,7 +393,7 @@ We are introducing several new concepts
 *(update to [manifest documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field))*
 
 The `rust-version` field is an optional key that tells cargo what version of the
-Rust language and compiler your support compiling your package with. If the currently
+Rust language and compiler you support compiling your package with. If the currently
 selected version of the Rust compiler is older than the stated version, cargo
 will exit with an error, telling the user what version is required.
 To support this, Cargo will prefer dependencies that are compatible with your `rust-version`.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -1282,3 +1282,13 @@ When adding packages without an MSRV,
 its not clear whether it will work with your project.
 Knowing that they haven't declared support for your toolchain version could be important,
 after we've made it easier to declare an MSRV.
+
+## Track version maintenance status on crates.io
+
+If you `cargo add` a dependency and it says that a newer version is available but it supports a dramatically different MSRV than you,
+it would be easy to assume there is a mismatch in expectations and you shouldn't use that dependency.
+However, you may still be supported via an LTS but that information can only be captured in documentation which is not within the flow of the developer.
+
+If crates.io had a mutable package and package version metadata database,
+maintainers could report the maintenance status of specific versions (or maybe encode their maintenance policy),
+allowing cargo to report not just whether you are on latest, but whether you are supported.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -830,7 +830,7 @@ Whether we do this and how much will be subject to factors like noisy output, pe
 
 Some approaches we can take for doing this include:
 
-We then do a depth-first diff of the trees, stopping and reporting on the first different node.
+After resolving, we can do a depth-first diff of the trees, stopping and reporting on the first different node.
 This would let us report on any command that changes the way the tree is resolved
 (from explicit changes with `cargo update` to `cargo build` syncing `Cargo.toml` changes to `Cargo.lock`).
 We'd likely want to limit the output to only the sub-tree that changed.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -219,7 +219,7 @@ Some design criteria we can use for evaluating workflows:
   - This also means feedback can come more quickly, making it easier and cheaper to pivot with user needs
   - Spreading the cost of upgrades over time makes forced-upgrades (e.g. for a security vulnerability) less of an emergency
   - Our commitment to compatibility helps keep the cost of upgrade low
-- When not competing with the above, we should do the right thing for the user rather than disrupt their flow to telling them what they should instead do
+- When not competing with the above, we should do the right thing for the user rather than disrupt their flow to tell them what they should instead do
 
 And keeping in mind
 - The Rust project only supports the latest version

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -936,8 +936,8 @@ Misc alternatives
     relatively low and they are more likely to be "in the know",
     making them less likely to be negatively affected by this.
     Therefore, we could probably get away with treating this as a minor incompatibility
-  - Either way, the big care about is there being attention drawn to the change.
-    We couldn't want this to be like sparse registries where a setting exists and we change the default and people hardly notice (besides any improvements)
+  - Either way, the concern is to ensure that the change receives attention.
+    We wouldn't want this to be like sparse registries where a setting exists and we change the default and people hardly notice (besides any improvements)
 - `cargo build` will treat incompatible MSRVs as a workspace-level lint, rather than a package level lint, to avoid the complexity of mapping the dependency to a workspace-member to select `[lint]` tables to respect and then dealing with unifying conflicting levels in between `[lint]` tables among members.
 - `--ignore-rust-version` picks absolutely the latest dependencies to support both users on latest rustc and users wanting "unsupported" dependencies, at the cost of users not on the latest rustc but still wanting latest more up-to-date dependencies than their MSRV allows
 - Compilation commands (e.g. `cargo check`) will take on two meanings for `--ignore-rust-version`, (1) `allow` the workspace diagnostic and (2) resolve changed dependencies to latest when syncing `Cargo.toml` to `Cargo.lock`.

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -237,7 +237,7 @@ A maintainer may also want to avoid constraining their dependents, for a variety
 
 **Pain points:**
 
-We do not provide a way to help users know new versions are available, to support the users in staying up-to-date.
+The Rust toolchain does not provide a way to help users know new dependency versions are available, to support the users in staying up-to-date.
 MSRV build errors from new dependency versions is one way to do it though not ideal as this disrupts the user.
 Otherwise, they must actively run `rustup update` or follow Rust news.
 
@@ -260,7 +260,7 @@ likely pushing them to not specify their MSRV.
 
 **Pain points (in addition to the prior workflow):**
 
-In addition to their toolchain version, we do not help these users with keeping
+In addition to their toolchain version, the Rust toolchain does not help these users with keeping
 their MSRV up-to-date.
 They can use other tools like
 [RenovateBot](https://github.com/rust-lang/cargo/blob/87eb374d499100bc945dc0e50ae5194ae539b964/.github/renovate.json5#L12-L24)

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -861,7 +861,7 @@ and only in the sense that the user needs to know to explicitly take action to a
 Misc alternatives
 - Dependencies with unspecified `package.rust-version`: we could mark these as always-compatible or always-incompatible; there really isn't a right answer here.
 - The resolver doesn't support backtracking as that is extra complexity that we can always adopt later as we've reserved the right to make adjustments to what `cargo generate-lockfile` will produce over time.
-- `CARGO_RESOLVER_PRECEDENCE=rust-version` assumes maximal resolution as generally minimal resolution will pick packages with compatible rust-versions as rust-version tends to (but doesn't always) increase over time.
+- `CARGO_RESOLVER_PRECEDENCE=rust-version` implies maximal resolution among MSRV-compatible dependencies.   Generally MSRV doesn't decrease over versions, so minimal resolution will likely pick packages with compatible rust-versions.
   - `cargo add` selecting rust-version-compatible minimum bounds helps
   - This bypasses a lot of complexity either from exploding the number of states we support or giving users control over the fallback by making the field an array of strategies.
 - Instead of `resolver = "3"`, we could just change the default for everyone

--- a/text/3537-msrv-resolver.md
+++ b/text/3537-msrv-resolver.md
@@ -765,7 +765,7 @@ Instead, if a newer clap version was out needing 1.94 or 1.95, I would instead e
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-We expect these changes to be independent enough and beneficial on there own that they can be stabilized as each is completed.
+We expect these changes to be independent enough and beneficial on their own that they can be stabilized as each is completed.
 
 ## Cargo Resolver
 


### PR DESCRIPTION
[Rendered](https://github.com/epage/rfcs/blob/msrv/text/3537-msrv-resolver.md)
[FCP](https://github.com/rust-lang/rfcs/pull/3537#issuecomment-1899285501)

---

*taken from a [post](https://github.com/rust-lang/rfcs/pull/3537#issuecomment-1889675810)*

If the proposed resolver solution is still not to your liking, I would recommend focusing the discussion on (in priority order)
1. Whether there are disagreements on the [core principles](https://github.com/epage/rfcs/blob/msrv/text/3537-msrv-resolver.md#workflows)
2. If agreement above, whether there is disagreement with the [evaluation of the workflows based on the above principles](https://github.com/epage/rfcs/blob/msrv/text/3537-msrv-resolver.md#latest-rust-with-no-msrv)
3. If agreement above, whether there is disagreement with the [workflow prioritization based on the above evaluation](https://github.com/epage/rfcs/blob/msrv/text/3537-msrv-resolver.md#latest-rust-with-no-msrv)
4. If agreement above, whether there is disagreement with the [evaluation of the solutions impact on the workflows, based on the principles](https://github.com/epage/rfcs/blob/msrv/text/3537-msrv-resolver.md#resolver-behavior)
5. If agreement above, whether there is disagreement with the [selected solution based on the evaluation](https://github.com/epage/rfcs/blob/msrv/text/3537-msrv-resolver.md#resolver-behavior)

In some cases, there is a need for a lot of digging in to understand concerns and use cases.  Asynchronous back and forth can be wearing.  I do host  [Office Hours](https://github.com/rust-lang/cargo/wiki/Office-Hours) for some synchronous communication.  If none of those times work, feel free to reach out to me on Zulip to see if we can find another time.