### PR TITLE
Async Drop

### DIFF
--- a/text/0000-async-drop.md
+++ b/text/0000-async-drop.md
@@ -1,0 +1,113 @@
+# Async Drop RFC
+
+- Feature Name: `async-drop`
+- Start Date: 2023-12-12
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: TBD
+
+# Summary
+[summary]: #summary
+
+This RFC proposes the introduction of native async drop support in Rust. The feature aims to extend Rust's resource management capabilities to include asynchronous dropping of values, aligning the language more closely with the needs of asynchronous programming paradigms. Additionally, it acknowledges the existence of the [`async_dropper`](https://github.com/t3hmrman/async-dropper) crate, which provides an external implementation of async drop behavior. The RFC further proposes the introduction of an `AsyncDrop` trait similar to the existing `Drop` trait.
+
+# Motivation
+[motivation]: #motivation
+
+The motivation behind introducing native async drop is to provide a standardized and integrated solution for asynchronous resource cleanup in Rust. While the `async_dropper` crate offers an external solution, having native support in the language simplifies the adoption of async drop functionality and ensures a consistent user experience. This feature addresses the gap in Rust's support for async lifetimes, making it more versatile for modern asynchronous applications.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Native async drop introduces the `async fn drop` method as part of the `Drop` trait, enabling asynchronous cleanup during the dropping of values. While the `async_dropper` crate provides a workaround, native support ensures a more seamless integration into Rust's syntax and semantics. We can leverage async drop without relying on external crates, simplifying the codebase and reducing dependency management overhead.
+
+```rust
+use async_trait::async_trait;
+use tokio::time::{sleep, Duration};
+
+// This trait should be implement internally
+#[async_trait]
+trait AsyncDrop {
+    async fn drop(&mut self);
+}
+
+// Define an AsyncResource struct implementing AsyncDrop
+struct AsyncResource {
+    data: String,
+}
+
+// Implement AsyncDrop for AsyncResource
+#[async_trait]
+impl AsyncDrop for AsyncResource {
+    async fn drop(&mut self) {
+        println!("Async cleanup for AsyncResource: {}", self.data);
+        // Asynchronous cleanup logic, e.g., releasing resources
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    {
+        let _async_res = AsyncResource {
+            data: String::from("Example Data"),
+        };
+        // drop will be triggered here
+    }
+    // AsyncResource is dropped as it goes out of scope, and its asynchronous drop logic may be executed later by the Tokio runtime
+
+    // Sleep to ensure `drop` completed its execution
+    sleep(Duration::from_secs(2)).await;
+    println!("Main function completed");
+}
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The design introduces native support for async drop through the addition of the `async fn drop` method within the `AsyncDrop` trait. This method is called when the value goes out of scope in an asynchronous context, providing a standardized way to handle asynchronous cleanup. The implementation ensures that the asynchronous drop logic is executed in the appropriate context, facilitating proper resource cleanup in async scenarios.
+
+Additionally, this RFC proposes the introduction of an `AsyncDrop` trait, parallel to the existing `Drop` trait. This trait would enable Rust developers to define asynchronous cleanup behavior for their types.
+
+```rust
+trait AsyncDrop {
+    async fn drop(&mut self);
+}
+
+struct CustomAsyncResource {
+    // Fields of the struct
+
+    // Implementing AsyncDrop for custom asynchronous cleanup
+}
+
+#[async_trait]
+impl AsyncDrop for CustomAsyncResource {
+    async fn drop(&mut self) {
+        // Asynchronous cleanup logic
+    }
+}
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Introducing native async drop may increase the complexity of the language and impose additional implementation overhead. However, the benefits of providing a standard solution for asynchronous resource cleanup, along with the proposed `AsyncDrop` trait, outweigh these drawbacks.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+The chosen design for native async drop and the introduction of the `AsyncDrop` trait are considered the best approach, as they align with Rust's focus on providing control over resources while accommodating the needs of asynchronous programming. While alternative solutions, such as relying on external libraries like `async_dropper`, exist, having native support ensures a more consistent and streamlined experience for Rust developers.
+
+# Prior art
+[prior-art]: #prior-art
+
+The `async_dropper` crate provides an external implementation of async drop behavior. While this crate is a valuable resource, native support in Rust, along with the proposed `AsyncDrop` trait, reduces external dependencies and fosters a more integrated and standardized approach to asynchronous resource cleanup.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- The specific syntax and implementation details of native async drop and the proposed `AsyncDrop` trait may require further refinement through the RFC process.
+- The impact on existing codebases and the interaction with other language features need thorough consideration.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+The introduction of native async drop and the `AsyncDrop` trait set the stage for potential extensions related to asynchronous resource management. Future possibilities include optimizations in the async drop process, integration with other async-related features, and exploration of async lifetimes to further enhance the language's capabilities in asynchronous scenarios.

--- a/text/3541-async-drop.md
+++ b/text/3541-async-drop.md
@@ -2,7 +2,7 @@
 
 - Feature Name: `async-drop`
 - Start Date: 2023-12-12
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3541](https://github.com/rust-lang/rfcs/pull/3541)
 - Rust Issue: TBD
 
 # Summary

--- a/text/3541-async-drop.md
+++ b/text/3541-async-drop.md
@@ -1,183 +1,147 @@
-# Async Drop RFC
+# Async Drop
 
 - Feature Name: `async-drop`
 - Start Date: 2023-12-12
 - RFC PR: [rust-lang/rfcs#3541](https://github.com/rust-lang/rfcs/pull/3541)
 - Rust Issue: TBD
 
-# Summary
+## Summary
 [summary]: #summary
 
-This RFC proposes the introduction of native async drop support in Rust. The feature aims to extend Rust's resource management capabilities to include asynchronous dropping of values, aligning the language more closely with the needs of asynchronous programming paradigms. Additionally, it acknowledges the existence of the [`async_dropper`](https://github.com/t3hmrman/async-dropper) crate, which provides an external implementation of async drop behavior. The RFC further proposes the introduction of an `AsyncDrop` trait similar to the existing `Drop` trait.
+This RFC is a comprehensive proposal to introduce native support for asynchronous resource cleanup in Rust through the `AsyncDrop` trait. The need for this enhancement arises from the growing significance of asynchronous programming paradigms in modern software development (e.g. Async cleanup on observable sequence termination) [^1^]. Currently, some developers are relying on external solutions like the [`async_dropper`](https://github.com/t3hmrman/async-dropper) crate to manage resources asynchronously [^2^]. This proposal aims to streamline and standardize asynchronous cleanup by introducing a native trait that allows developers to define custom asynchronous cleanup logic for their types.
 
-# Motivation
+The introduction of the `AsyncDrop` trait aligns with Rust's commitment to providing robust resource management capabilities while adapting to the evolving needs of the programming landscape. By integrating native support for asynchronous resource cleanup, Rust aims to simplify the codebase and reduce dependency management overhead associated with external crates. The proposed enhancement focuses on empowering Rust developers to write more expressive, maintainable, and performant asynchronous code, enhancing Rust's suitability for modern software development.
+
+## Motivation
 [motivation]: #motivation
 
-The motivation behind introducing native async drop is to provide a standardized and integrated solution for asynchronous resource cleanup in Rust. While the `async_dropper` crate offers an external solution, having native support in the language simplifies the adoption of async drop functionality and ensures a consistent user experience. This feature addresses the gap in Rust's support for async lifetimes, making it more versatile for modern asynchronous applications.
+The motivation behind this RFC is rooted in the increasing prevalence of asynchronous programming and the challenges developers face in managing resources within this paradigm. Asynchronous programming introduces unique complexities, especially regarding resource cleanup. The existing reliance on external solutions, such as the `async_dropper` crate, highlights the need for a standardized and integrated solution within the Rust language. The motivation is not just to address a specific pain point but to provide a holistic and coherent approach to asynchronous resource management, reinforcing Rust's position as a language that evolves with the changing needs of developers.
 
-# Guide-level explanation
-[guide-level-explanation]: #guide-level-explanation
-
-Native async drop introduces the `async fn drop` method as part of the `Drop` trait, enabling asynchronous cleanup during the dropping of values. While the `async_dropper` crate provides a workaround, native support ensures a more seamless integration into Rust's syntax and semantics. We can leverage async drop without relying on external crates, simplifying the codebase and reducing dependency management overhead.
+Consider a scenario where a database connection is established asynchronously, and proper cleanup is necessary when the connection goes out of scope. With the proposed `AsyncDrop` trait, developers can encapsulate the necessary cleanup logic within the type, promoting encapsulation and code organization. For instance:
 
 ```rust
 use async_trait::async_trait;
-use tokio::time::{sleep, Duration};
 
-// This trait should be implement internally
 #[async_trait]
 trait AsyncDrop {
     async fn drop(&mut self);
 }
 
-// Define an AsyncResource struct implementing AsyncDrop
-struct AsyncResource {
-    data: String,
+struct DatabaseConnection {
+    // Fields of the struct
+
+    // Implementing AsyncDrop for custom asynchronous cleanup
 }
 
-// Implement AsyncDrop for AsyncResource
 #[async_trait]
-impl AsyncDrop for AsyncResource {
+impl AsyncDrop for DatabaseConnection {
     async fn drop(&mut self) {
-        println!("Async cleanup for AsyncResource: {}", self.data);
-        // Asynchronous cleanup logic, e.g., releasing resources
+        // Asynchronous cleanup logic for releasing database resources
     }
-}
-
-#[tokio::main]
-async fn main() {
-    {
-        let _async_res = AsyncResource {
-            data: String::from("Example Data"),
-        };
-        // drop will be triggered here
-    }
-    // AsyncResource is dropped as it goes out of scope, and its asynchronous drop logic may be executed later by the Tokio runtime
-
-    // Sleep to ensure `drop` completed its execution
-    sleep(Duration::from_secs(2)).await;
-    println!("Main function completed");
 }
 ```
 
-Moreover, to seamlessly integrate native async drop support into Rust, it is essential to outline how executors should handle asynchronous resource cleanup. This section also provides guidelines for developers using executors to ensure consistent and correct execution of async drop logic.
+This example illustrates how the `AsyncDrop` trait allows developers to encapsulate asynchronous cleanup logic within the type, fostering a more modular and organized code structure.
+**Detailed Explanation:**
 
-1. **Recognition of AsyncDrop Trait**
-   Futures, such as those utilized in async Rust programming, should be updated to recognize types implementing the `AsyncDrop` trait. This can be achieved through a mechanism such as trait bounds or associated types to identify futures that require special handling for asynchronous cleanup.
+let's now consider a real-world example. The [`IggyClient`](https://github.com/iggy-rs/iggy/blob/master/iggy/src/clients/client.rs#L78) type within the `Iggy` crate stands as a concrete representation of a client entity in the broader context of the `Iggy` crate. As part of the ongoing effort to align with modern asynchronous programming paradigms, the developers have sought to implement the `AsyncDrop` trait for the `IggyClient` type. This trait, decorated with the `#[async_trait]` attribute, signifies its ability to handle asynchronous cleanup operations when instances of the `IggyClient` type go out of scope.
 
-   ```rust
-   trait AsyncDrop {
-       async fn drop(&mut self);
-   }
+The central piece of this implementation is the `async_drop` method defined within the `AsyncDrop` trait for the `IggyClient`. This method encapsulates the logic responsible for initiating asynchronous cleanup. Specifically, it orchestrates a logout operation for the client by calling the `logout_user` method on the asynchronously obtained client reference. This operation, in turn, triggers the execution of the logout process, facilitating proper resource cleanup associated with the `IggyClient`.
 
-   impl AsyncDrop for MyFuture {
-       // Your asynchronous cleanup logic goes here
-       async fn drop(&mut self) {
-           println!("Async cleanup executed");
-       }
-   }
-   ```
-
-   Here, the `AsyncDrop` trait declares an asynchronous `drop` method, which should be implemented internally, allowing futures to define their asynchronous cleanup logic independently. In the example implementation for `MyFuture`, the `AsyncDrop` trait is implemented, and the asynchronous cleanup logic is executed when the `drop` method is called. This approach provides flexibility in handling resource management during asynchronous execution for different types of futures.
-
-1. **Async Drop Invocation**
-   Executors must ensure that the async `drop` method is invoked when a future implementing the `AsyncDrop` trait goes out of scope or completes. This involves tracking the lifecycle of futures and, upon termination, triggering the async drop logic before releasing associated resources.
-
-   ```rust
-   async fn execute_future<T: AsyncDrop + Future + Copy>(&self, mut fut: T) {
-       // Execute the future
-       let result = fut.await;
-
-       // Perform async drop before releasing resources
-       fut.drop().await;
-   }
-   ```
-
-   The `fut.await` call will execute the future (`fut`), pausing the current thread until the future completes and produces a result. Following the completion of the future's execution, the executor invokes the `drop` method on the future (`fut`). This ensures the execution of asynchronous drop logic, allowing the future to perform any necessary cleanup operations before resources are released. The `Copy` trait is used here to allow the future (`fut`) to be moved into the await call without consuming its ownership, ensuring that it can still be used later.
-
-1. **Context Propagation**
-   To maintain a consistent execution context for async drops, executors should propagate the appropriate `Waker` and `Context` information to the async drop method. This ensures that async drops can interact with the executor environment and make executor-specific decisions during cleanup.
-
-   ```rust
-   async fn execute_future<T: AsyncDrop + Future + Copy>(&self, fut: T) {
-       // Set up the execution context
-       let waker = Waker::noop();
-       let mut cx = Context::from_waker(&waker);
-       
-       // Execute the future with the provided context
-       let mut pinned = std::pin::pin!(fut);
-       let _ = pinned.as_mut().poll(&mut cx); 
-       
-       // Perform async drop within the same context
-       fut.drop().await;
-   }
-   ```
-
-   After the future is polled, the `drop` method of the future (`fut`) is invoked. This ensures that the async drop logic is executed in the same context established earlier.
-
-Here is a fully working example:
+The crucial aspect highlighted by this example is the reliance on the `async_dropper` crate as a pragmatic workaround. In the absence of native support for asynchronous dropping in Rust at the time of this implementation, developers turn to external solutions to fulfill the need for proper asynchronous resource cleanup. The `async_dropper` crate, which is not part of the standard Rust library, offers a mechanism to define and execute asynchronous cleanup logic when values go out of scope.
 
 ```rust
-#![feature(noop_waker)]
+#[async_trait]
+impl AsyncDrop for IggyClient {
+    async fn async_drop(&mut self) {
+        let _ = self.client.read().await.logout_user(&LogoutUser {}).await;
+    }
+}
+```
 
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
+In this code snippet, the `IggyClient` type implements the `AsyncDrop` trait, and the `async_drop` method encapsulates the logout logic. The method is asynchronous, denoted by the `async` keyword, allowing it to seamlessly integrate into asynchronous codebases. The usage of the `async_dropper` crate encapsulates the asynchronous cleanup process, adhering to the limitations posed by Rust's existing support for asynchronous resource management.
 
-// AsyncDrop trait that should be implemented internally
+This implementation serves as a testament to the practical challenges faced by developers in handling asynchronous resource cleanup and the innovative approaches they employ, such as leveraging external crates like `async_dropper`. The existence of such workarounds underscores the importance of introducing native async drop support in Rust, providing a standardized, integrated, and idiomatic solution to address these challenges.
+
+## Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+### Async Drop Trait
+
+The proposed `AsyncDrop` trait serves as the cornerstone of this enhancement. Similar to the existing `Drop` trait, it enables developers to define custom asynchronous cleanup logic for their types. This trait is annotated with the [`async_trait`](https://docs.rs/async-trait) attribute to indicate its compatibility with asynchronous operations. For example:
+
+```rust
+use async_trait::async_trait;
+
+#[async_trait]
 trait AsyncDrop {
     async fn drop(&mut self);
 }
+```
 
-// Future type for demonstration purposes
-#[derive(Clone, Copy)]
-struct MyFuture;
+Here, the `AsyncDrop` trait declares a single method, `async fn drop(&mut self)`, which developers can implement to define asynchronous cleanup logic specific to their types.
 
-impl Future for MyFuture {
-    type Output = ();
+### Async Drop in Structs
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // Your custom future's poll logic goes here
-        Poll::Ready(())
-    }
+Understanding how native async drop operates within a struct is crucial for developers. In Rust, the compiler ensures that fields within a struct are dropped in a Last-In-First-Out (LIFO) order. To illustrate, consider the following example:
+
+```rust
+struct DataStorage {
+    data: AsyncData,
+    index: AsyncIndex,
 }
 
-impl AsyncDrop for MyFuture {
-    async fn drop(&mut self) {
-        // Your asynchronous cleanup logic goes here
-        println!("Async cleanup executed");
-    }
+async fn process_data() -> usize {
+    let storage = DataStorage::new();
+    return storage.process().await;
 }
+```
 
-// Custom executor
-async fn execute_future<T: AsyncDrop + Future + Copy>(mut fut: T) {
+In this scenario, the `DataStorage` struct contains two asynchronous resources, `AsyncData` and `AsyncIndex`. The Rust compiler guarantees that these fields are dropped in a LIFO order when the `DataStorage` instance goes out of scope, facilitating predictable and proper asynchronous resource cleanup (`index` is droped first, followed by the `data` field).
+
+### Async Drop Invocation
+
+For futures with async drop logic, executors must recognize the `AsyncDrop` trait and invoke the `drop` method appropriately. This involves integrating async drop invocation into the executor's lifecycle. Consider the following example:
+
+```rust
+async fn execute_future<T: AsyncDrop + Future>(mut fut: T) {
+    // Execute the future
+    let result = fut.await;
+
+    // Perform async drop before releasing resources
+    fut.drop().await;
+}
+```
+
+In this example, the `execute_future` function takes a generic parameter `T` that must implement both the `AsyncDrop` trait and the `Future` trait. After the future completes its execution, the executor invokes the `drop` method on the future, ensuring proper resource cleanup. This explicit invocation aligns with Rust's emphasis on manual control over resource management.
+
+### Context Propagation
+
+Maintaining a consistent execution context for async drops is crucial to ensure predictable and coherent asynchronous resource cleanup. To achieve this, executors should propagate the appropriate `Waker` and `Context` information. Here's an example illustrating context propagation:
+
+```rust
+async fn execute_future<T: AsyncDrop + Future>(fut: T) {
     // Set up the execution context
     let waker = Waker::noop();
     let mut cx = Context::from_waker(&waker);
-
-    // Execute the future
+    
+    // Execute the future with the provided context
     let mut pinned = std::pin::pin!(fut);
-    let _ = pinned.as_mut().poll(&mut cx);
-
-    // Perform async drop
+    let _ = pinned.as_mut().poll(&mut cx); 
+    
+    // Perform async drop within the same context
     fut.drop().await;
-}
-
-#[tokio::main]
-async fn main() {
-    let my_future = MyFuture;
-    execute_future(my_future).await;
 }
 ```
 
-By following these recommendations, executors can seamlessly integrate with the native async drop support, providing a standardized and reliable mechanism for handling asynchronous resource cleanup in Rust. These guidelines ensure that async drops are executed appropriately within the executor's lifecycle, enhancing the overall consistency and predictability of asynchronous resource management in Rust.
+In this example, the `execute_future` function sets up a `Waker` with the `noop` method from the `Waker` trait, creating a placeholder waker with no associated behavior. This waker is then used to create a `Context`, and the future is executed within this context. After the future is polled, the `drop` method of the future is invoked, ensuring that the async drop logic is executed within the same context established earlier. This crucial context propagation guarantees consistent and predictable execution of asynchronous drop logic.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
 The design introduces native support for async drop through the addition of the `async fn drop` method within the `AsyncDrop` trait. This method is called when the value goes out of scope in an asynchronous context, providing a standardized way to handle asynchronous cleanup. The implementation ensures that the asynchronous drop logic is executed in the appropriate context, facilitating proper resource cleanup in async scenarios.
 
-Additionally, this RFC proposes the introduction of an `AsyncDrop` trait, parallel to the existing `Drop` trait. This trait would enable Rust developers to define asynchronous cleanup behavior for their types.
+Additionally, the introduction of the `AsyncDrop` trait, running in parallel with the established `Drop` trait, represents a pivotal advancement in Rust's capabilities for managing resources in asynchronous scenarios. This trait, defined with the asynchronous `drop` method, empowers Rust developers to articulate specialized asynchronous cleanup procedures for their custom types. Asynchronous cleanup logic, encapsulated within the `drop` method, can address the complexities of releasing resources in a concurrent and non-blocking fashion, contributing to more expressive and maintainable asynchronous code.
 
 ```rust
 trait AsyncDrop {
@@ -198,28 +162,70 @@ impl AsyncDrop for CustomAsyncResource {
 }
 ```
 
+In this example, the type `CustomAsyncResource` implements the `AsyncDrop` trait, showcasing how developers can leverage this trait to define custom asynchronous cleanup logic. The `drop` method within the implementation becomes the designated space to orchestrate the necessary cleanup operations for instances of `CustomAsyncResource`. This addition to Rust's feature set not only aligns with the language's commitment to safety and efficiency but also reflects its adaptability to the evolving landscape of modern asynchronous programming paradigms.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Introducing native async drop may increase the complexity of the language and impose additional implementation overhead. However, the benefits of providing a standard solution for asynchronous resource cleanup, along with the proposed `AsyncDrop` trait, outweigh these drawbacks.
+While the introduction of native async drop enhances Rust's support for asynchronous programming, potential drawbacks include an increase in language complexity and potential additional implementation overhead. The complexity may arise from the need to manage asynchronous resource cleanup alongside other language features, potentially impacting the learning curve for new developers. Moreover, the implementation overhead may affect the overall performance of the language, requiring careful consideration during the design and implementation phases.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-The chosen design for native async drop and the introduction of the `AsyncDrop` trait are considered the best approach, as they align with Rust's focus on providing control over resources while accommodating the needs of asynchronous programming. While alternative solutions, such as relying on external libraries like `async_dropper`, exist, having native support ensures a more consistent and streamlined experience for Rust developers.
+The chosen design for incorporating native async drop and introducing the `AsyncDrop` trait is considered the optimal approach, aligning cohesively with Rust's overarching emphasis on resource control and responsiveness to the demands of asynchronous programming. This design is driven by the objective of presenting a standardized solution that seamlessly integrates into the current set of language features. The aim is to develop a unified and intuitive development experience, streamlining the process for developers as they navigate the complexities of managing resources asynchronously.
+
+As mentioned, an alternative approach could involve further reliance on external crates like `async_dropper`. While external solutions can address the immediate need for asynchronous resource cleanup, they may introduce fragmentation within the Rust ecosystem, leading to inconsistencies in coding practices. Native support ensures a more consistent and standardized approach, reducing external dependencies and making Rust more self-contained.
 
 # Prior art
 [prior-art]: #prior-art
 
 The `async_dropper` crate provides an external implementation of async drop behavior. While this crate is a valuable resource, native support in Rust, along with the proposed `AsyncDrop` trait, reduces external dependencies and fosters a more integrated and standardized approach to asynchronous resource cleanup.
 
+Considering prior art involves examining practices from other programming languages supporting native async drop or similar features. Analyzing how languages like C# handle asynchronous resource cleanup offers valuable insights into best practices and potential challenges. However, it's imperative to tailor any insights from other languages to align with Rust's unique design principles and community expectations.
+
+In the exploration of prior art, a relevant resource is the article titled "Learn .NET Advanced Programming Memory Management" [^3^]. This article delves into the implementation of advanced memory management techniques in `.NET` and introduces the `System.IAsyncDisposable` interface, a feature integrated as part of C# 8.0. Specifically, the article comprehensively covers the implementation of the `IAsyncDisposable.DisposeAsync` method, enabling resource cleanup with the capability for asynchronous operations. Notably, this method returns a `ValueTask`, symbolizing the asynchronous disposal operation. The article also delves into the practice of implementing both synchronous and asynchronous disposal, with the `IAsyncDisposable` interface designed to accommodate either scenario. While it's not obligatory to incorporate both types of disposal, the guidance for implementing the disposal/drop pattern remains consistent, assuming a foundational understanding of implementing a Dispose method.
+
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- The specific syntax and implementation details of native async drop and the proposed `AsyncDrop` trait may require further refinement through the RFC process.
-- The impact on existing codebases and the interaction with other language features need thorough consideration.
+Several aspects of the proposed enhancement may require further exploration and refinement through the RFC process:
+
+1. **Syntax and Implementation Details:**
+   The specific syntax and implementation details of native async drop and the proposed `AsyncDrop` trait may require iterative refinement. Ensuring that the chosen syntax aligns with Rust's overall design philosophy and is intuitive for developers is crucial.
+
+1. **Impact on Existing Codebases:**
+   The potential impact on existing codebases needs careful consideration. Developers should be able to seamlessly transition to the new feature without significant disruptions. Compatibility with existing code and libraries is crucial.
+
+1. **Performance Considerations:**
+   The performance implications of introducing native async drop need careful examination. Ensuring that the feature does not introduce undue overhead and aligns with Rust's commitment to efficiency is critical.
+
+1. **Community Feedback and Adoption:**
+   The success of the native async drop feature depends on community acceptance and adoption. Soliciting and incorporating feedback from the Rust community during the RFC process is essential to address concerns, refine design choices, and ensure widespread support.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-The introduction of native async drop and the `AsyncDrop` trait set the stage for potential extensions related to asynchronous resource management. Future possibilities include optimizations in the async drop process, integration with other async-related features, and exploration of async lifetimes to further enhance the language's capabilities in asynchronous scenarios.
+The introduction of native async drop and the `AsyncDrop` trait lays the foundation for potential future extensions and optimizations related to asynchronous resource management in Rust. Several possibilities include:
+
+1. **Optimizations in Async Drop Process:**
+   Future iterations could explore optimizations in the async drop process. Enhancements to make asynchronous resource cleanup more efficient and responsive to different scenarios could be considered.
+
+1. **Integration with Other Async Features:**
+   The proposed feature sets the stage for potential integration with other asynchronous features in Rust. Exploring synergies with async lifetimes or async-specific constructs could further enhance the language's capabilities.
+
+1. **Tooling and Documentation Improvements:**
+   As the feature matures, improvements in tooling and documentation can provide developers with better support and guidance. Tools for analyzing and optimizing asynchronous resource cleanup could be developed, and comprehensive documentation can aid in widespread adoption.
+
+1. **Ecosystem-wide Adoption:**
+   Encouraging and supporting the adoption of native async drop across the Rust ecosystem is crucial. Establishing best practices, providing migration guides, and fostering community awareness can contribute to the widespread and successful adoption of the feature.
+
+1. **Feedback-Driven Refinement:**
+   Ongoing refinement based on community feedback and real-world usage is integral to the success of the feature. Regular feedback loops with the Rust community will help identify areas for improvement, address unforeseen challenges, and ensure the feature remains aligned with evolving programming practices.
+
+In conclusion, the proposed native async drop feature is not just a standalone enhancement but a step towards a more versatile and resilient asynchronous programming experience in Rust. As the feature evolves, it opens up exciting possibilities for the language, shaping its trajectory in the dynamic landscape of modern software development.
+
+[^1^]: Async cleanup on observable sequence termination, Stack Overflow thread, Asked 6 years, 4 months ago. [Link](https://stackoverflow.com/questions/45407562/async-cleanup-on-observable-sequence-termination)
+
+[^2^]: Iggy-Rs. (n.d.). iggy/iggy/src/clients/client.rs at master · iggy-rs/iggy. GitHub. https://github.com/iggy-rs/iggy/blob/master/iggy/src/clients/client.rs#L797-L802
+
+[^3^]: IEvangelist. (2023, May 12). Implement a DisposeAsync method - .NET. Microsoft Learn. https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync


### PR DESCRIPTION
## Introduction

This PR proposes the introduction of native async drop support in Rust by adding the `async fn drop` method to the `Drop` trait. Additionally, it suggests the creation of an `AsyncDrop` trait, allowing us to define custom asynchronous cleanup logic.

## Motivation

The primary motivation is to standardize asynchronous resource cleanup in Rust, streamlining adoption and reducing dependency management overhead. This enhancement addresses the current gap in Rust's support for async lifetimes, making the language more versatile for modern asynchronous applications.

## Implementation and Benefits

The design introduces native async drop support through the `async fn drop` method, providing a standardized way to handle asynchronous cleanup. The proposal also outlines an `AsyncDrop` trait, enabling us to define custom asynchronous cleanup logic for our types. This native support simplifies codebases, reduces external dependencies, and fosters a more consistent and streamlined experience for us working with asynchronous resource management.

[Rendered](https://github.com/wiseaidev/rfcs/blob/async-drop/text/3541-async-drop.md)