### PR TITLE
RFC: Allow type inference for const or static

### DIFF
--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -19,7 +19,7 @@ In simple cases, explicitly writing out
 the type of the const seems trivial. However, this isn't always the case:
 
 - Sometimes the constant's value is complex, making the explicit type overly verbose.
-- In some cases, the type may be unnameable.
+- In some cases, the type may be unnamable.
 - When creating macros, the precise type might not be known to the macro author.
 - Code generators may not have enough information to easily determine the type.
 
@@ -50,7 +50,7 @@ const WRAPPED_PI: MyStruct<_> = MyStruct(3.1415_f32); // Ok
 
 static MESSAGE: _ = "Hello, World!"; // inferred as &'static str
 static ARR: [u8; _] = [12, 23, 34, 45]; // inferred as [u8; 4]
-const FN: _ = std::string::String::default; // inferred as the unnameable type of ZST closure asociated with this item. Its type is reported by `type_name_of_val` as ::std::string::String::default
+const FN: _ = std::string::String::default; // inferred as the unnamable type of ZST closure associated  with this item. Its type is reported by `type_name_of_val` as ::std::string::String::default
 ```
 
 In summary, globals should have sandboxed inference context, where their type would be fully known after all constraints in const expr block has been applied; i.e. no default types for literals, nor implicit casts should be allowed.
@@ -111,7 +111,7 @@ Rust code remains more verbose than necessary, especially in complex scenarios, 
 
 Allowing the naming of function types as in [#3476](https://github.com/rust-lang/rfcs/pull/3476) may help resolve some of the cases where type inference is needed.
 
-`type_alias_impl_trait` may also partially address the problem. In particular, it helps with unnameable types
+`type_alias_impl_trait` may also partially address the problem. In particular, it helps with unnamable types
 and macro / code generator output, without the drawbacks of loss of clarity and semvar trouble.
 However, it cannot fully replace inference because
 - There are cases where we do not want the type to be hidden behind an `impl Trait`.
@@ -136,12 +136,12 @@ Const/static type inference fails to provide value for simple cases such as `con
 However, after 7 years it is now time to revisit this topic:
 
 - The things that can be done in a const expression has been greatly expanded since
-  2017, which means that it is more likely to use a complicated type or an unnameable type on const/static items.
+  2017, which means that it is more likely to use a complicated type or an unnamable type on const/static items.
 - It is now possible to use impl types in function returns (although having impl type aliases could provide a similar solution for const and statics)
 - Const and static aren't necessarily at the top level. It feels weird that the type can be elided on a let statement inside a function, but not on a const or static inside a function
 - The original RFC resolution of **postpone** was made at least partially based on
   statistics done by @schuster. This RFC was proposed with the motivation of enabling the use
-  of unnameable types in const/static items. Because this RFC enables new behaviors,
+  of unnamable types in const/static items. Because this RFC enables new behaviors,
   data on current usage isn't very useful for determining how much it might improve language
   expressiveness.
 

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -78,7 +78,7 @@ instead of emitting an error.
   especially to newcomers or when explicit types are needed to understanding the purpose of the item.
   It is my belief that this is a choice better left for the developers as in the case of `let` bindings.
 - Semver compatibilty: The API surface of the type is implicit, changing the right-hand side in subtle ways can change the type in a way that can be hard to notice, for example between different integer types. 
-  However, not all `const` or `static` items are public, and explicit typing isn't always important for semvar stability.
+  However, not all `const` or `static` items are public, and in many cases the type is obvious enough that semver isn't a concern.
   Requiring explicit typing for this reason seems a bit heavy handed.
 
 Both of these drawback could be addressed using an allow-by-default clippy lint for `const` and `static` types.

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -25,6 +25,11 @@ the type of the const seems trivial. However, this isn't always the case:
 This change aims to make Rust code more concise and maintainable, especially in scenarios where the types of
 const items are complicated or not easily expressible.
 
+Inferring constant types also improves the ergonomics of the language, particularly for new users. Some users are
+coming from languages where most (or all) types are inferred. So inferring obvious types matches their
+expectations. Other new users are focused on learning ownership, or other core Rust concepts. Reducing the
+amount of boilerplate reduces their mental load. This reduction in mental load also helps experienced programmers.
+
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -1,6 +1,6 @@
 - Feature Name: const_type_inference
 - Start Date: 2023-12-21
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3546](https://github.com/rust-lang/rfcs/pull/3546)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -71,6 +71,7 @@ instead of emitting an error.
 - Potential Loss of Clarity: In some cases, omitting the type might make the code less clear,
   especially to newcomers or in codebases where explicit types are part of the documentation style.
   It is my belief that this is a choice better left for the developers as in the case of `let` bindings.
+  This drawback could be addressed using an allow-by-default clippy lint for `const` and `static` types.
 - Anything else?
 
 # Rationale and alternatives

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -90,7 +90,7 @@ In [RFC#1623](https://github.com/rust-lang/rfcs/pull/1623) we added `'static` li
 
 Should we allow assignment of unnameable types? For example,
 ```rs
-let A = |a: u32| {
+const A = |a: u32| {
     123_i32
 };
 

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -27,7 +27,7 @@ the type of the const seems trivial. However, this isn't always the case:
 This change aims to make Rust more expressive, concise and maintainable, especially in scenarios where the types of
 const items are complicated or not easily expressible.
 
-Inferring constant types also improves the ergonomics and consistency of the language, particularly for new users. Types are already being inferred for `let` items, and not allowing inference for obvious types creates a mismatch of expectations, especially considering that const/static items may also be defined inside a function and directly next to a `let` binding.
+Inferring constant types also improves the ergonomics and consistency of the language, particularly for new users. Types are already being inferred for `let` bindings, and not allowing inference for obvious `const` or `static` items creates a mismatch of expectations, especially when `const`/`static` items may be defined inside a function, directly next to a `let` binding.
 
 
 # Guide-level explanation

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -77,7 +77,7 @@ instead of emitting an error.
 - Potential Loss of Clarity: In some cases, omitting the type might make the code less clear,
   especially to newcomers or when explicit types are needed to understanding the purpose of the item.
   It is my belief that this is a choice better left for the developers as in the case of `let` bindings.
-- Semvar compatibilty: It's a good idea that public API endpoints should be "obviously semvar stable".
+- Semver compatibilty: The API surface of the type is implicit, changing the right-hand side in subtle ways can change the type in a way that can be hard to notice, for example between different integer types. 
   However, not all `const` or `static` items are public, and explicit typing isn't always important for semvar stability.
   Requiring explicit typing for this reason seems a bit heavy handed.
 

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -12,7 +12,8 @@ Allow type inference for `const` or `static` when the type of the initial value 
 [motivation]: #motivation
 
 Rust currently requires explicit type annotations for `const` and `static` items.
-It was decided that all public API points should be "obviously semver stable" rather than "quick to type".
+It was decided that all public API and top level items must be "obviously semver stable" rather than "quick to type". However, this philosophy needs to be carefully weighted against
+language expressiveness.
 
 
 In simple cases, explicitly writing out
@@ -23,13 +24,10 @@ the type of the const seems trivial. However, this isn't always the case:
 - When creating macros, the precise type might not be known to the macro author.
 - Code generators may not have enough information to easily determine the type.
 
-This change aims to make Rust code more concise and maintainable, especially in scenarios where the types of
+This change aims to make Rust more expressive, concise and maintainable, especially in scenarios where the types of
 const items are complicated or not easily expressible.
 
-Inferring constant types also improves the ergonomics of the language, particularly for new users. Some users are
-coming from languages where most (or all) types are inferred, so inferring obvious types matches their
-expectations. Other new users are focused on learning ownership, or other core Rust concepts. Reducing the
-amount of boilerplate reduces their mental load. This reduction in mental load also helps experienced programmers.
+Inferring constant types also improves the ergonomics and consistency of the language, particularly for new users. Types are already being inferred for `let` items, and not allowing inference for obvious types creates a mismatch of expectations, especially considering that const/static items may also be defined inside a function and directly next to a `let` binding.
 
 
 # Guide-level explanation
@@ -55,6 +53,8 @@ static MESSAGE: _ = "Hello, World!"; // inferred as &'static str
 static ARR: [u8; _] = [12, 23, 34, 45]; // inferred as [u8; 4]
 const FN_PTR: _ = std::string::String::default; // inferred as fn() -> String
 ```
+
+In summary, globals should have sandboxed inference context, where their type would be fully known after all constraints in const expr block has been applied; i.e. no default types for literals, nor implicit casts should be allowed.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -106,13 +106,38 @@ Allowing the naming of function types as in [#3476](https://github.com/rust-lang
 
 `type_alias_impl_trait` may also partially address the problem. In particular, it helps with unnameable types
 and macro / code generator output, without the drawbacks of loss of clarity and semvar trouble.
-However, there might be cases where we do not want the type to be hidden behind an `impl Trait`.
-This also won't help with array lengths or types that do not implement a particular trait.
+However, it cannot fully replace inference because
+- There are cases where we do not want the type to be hidden behind an `impl Trait`.
+- Defining a trait for the const item might be difficult - for example, when the
+  const item is a function pointer with a variable number of arguments.
+- The const item might be generated from a macro, and the macro might not
+  want to require a separate trait to be defined.
+- This also won't help with array lengths or types that do not implement a particular trait.
 
 # Prior art
 [prior-art]: #prior-art
 
 In [RFC#1623](https://github.com/rust-lang/rfcs/pull/1623) we added `'static` lifetimes to every reference or generics lifetime value in `static` or `const` declarations.
+
+In [RFC#2010](https://github.com/rust-lang/rfcs/pull/2010) const/static type inference
+was proposed, but the RFC was **postponed**. The [reason](https://github.com/rust-lang/rfcs/pull/2010#issuecomment-325827854) can be summarized as follows:
+
+- Things we can do with const/static was quite limited at the time.
+Const/static type inference fails to provide value for simple cases such as `const SOMETHING = 32;`
+- The team wanted to move forward in other areas (e.g. impl Trait) before moving on to solve this problem.
+
+However, after 7 years it is now time to revisit this topic:
+
+- The things that can be done in a const expression has been greatly expanded since
+  2017, which means that it is more likely to use a complicated type or an unnameable type on const/static items.
+- It is now possible to use impl types in function returns (although having impl type aliases could provide a similar solution for const and statics)
+- Const and static aren't necessarily at the top level. It feels weird that the type can be elided on a let statement inside a function, but not on a const or static inside a function
+- The original RFC resolution of **postpone** was made at least partially based on
+  statistics done by @schuster. This RFC was proposed with the motivation of enabling the use
+  of unnameable types in const/static items. Because this RFC enables new behaviors,
+  data on current usage isn't very useful for determining how much it might improve language
+  expressiveness.
+
 
 
 # Unresolved questions

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -22,6 +22,10 @@ the type of the const seems trivial. However, this isn't always the case:
 - When creating macros, the precise type might not be known to the macro author.
 - Code generators may not have enough information to easily determine the type.
 
+This change aims to make Rust code more concise and maintainable, especially in scenarios where the types of
+const items are complicated or not easily expressible.
+
+
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
@@ -33,10 +37,6 @@ const PI = 3.1415; // inferred as f64
 static MESSAGE = "Hello, World!"; // inferred as &'static str
 const FN_PTR = std::string::String::default; // inferred as fn() -> String
 ```
-
-This change aims to make Rust code more concise and maintainable, especially in scenarios where the types of
-const items are complicated or not easily expressible.
-
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -77,7 +77,7 @@ instead of emitting an error.
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 - Impact of Not Doing This: Rust code remains more verbose than necessary, especially in complex scenarios, and macro authors face challenges with type specifications.
-
+- Alternative: Allowing the naming of function types as in [#3476](https://github.com/rust-lang/rfcs/pull/3476) may help resolve some of the cases where type inference is needed.
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -37,8 +37,9 @@ amount of boilerplate reduces their mental load. This reduction in mental load a
 
 You may declare constants and static variables without specifying their types when the type can be inferred
 from the initial value, subjecting to the following constraints:
-- All numerical types contributing to the inference must be specified.
-- The type must be partially specified. At the very least, a `_` placeholder must be used, but the `_` placeholder
+- The types of all literals must be fully constrained, which generally means numeric literals must either
+  have a type suffix, or the type must specify their type
+- The typing may not be entirely omitted. At the very least, a `_` placeholder must be used, but the `_` placeholder
   may also appear anywhere in a nested type.
 
 For example:

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -1,0 +1,114 @@
+- Feature Name: const_type_inference
+- Start Date: 2023-12-21
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Allow type inference for `const` or `static` when the type of the initial value is known.
+
+# Motivation
+[motivation]: #motivation
+
+Rust currently requires explicit type annotations for `const` and `static` items.
+
+
+In simple cases, explicitly writing out
+the type of the const seems trivial. However, this isn't always the case:
+
+- Sometimes the constant's value is complex, making the explicit type overly verbose.
+- In some cases, the type may be unnameable.
+- When creating macros, the precise type might not be known to the macro author.
+- Code generators may not have enough information to easily determine the type.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+You may declare constants and static variables without specifying their types when the type can be inferred
+from the initial value. For example:
+
+```rs
+const PI = 3.1415; // inferred as f64
+static MESSAGE = "Hello, World!"; // inferred as &'static str
+const FN_PTR = std::string::String::default; // inferred as fn() -> String
+```
+
+This change aims to make Rust code more concise and maintainable, especially in scenarios where the types of
+const items are complicated or not easily expressible.
+
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+
+The type inference for `const` and `static` will leverage Rust's existing type inference mechanisms. The compiler will infer the type exclusively based on the RHS. If the type cannot be determined or if it leads to ambiguities, the compiler will emit an error, prompting the programmer to specify the type explicitly.
+
+
+Today, the compiler already gives hint for most cases where the const or static item is missing a type:
+
+```
+802 | const A = 0;
+    |        ^ help: provide a type for the constant: `: i32`
+```
+
+
+```
+error: missing type for `const` item                                                     
+  --> file.rs:27:26
+   |
+27 |     pub const update_blas = SystemStage { system: test_system, stage: vk::Pipeli... 
+   |                          ^ help: provide a type for the constant: `: render_pass::SystemStage<for<'a> fn(ResMut<'a, AsyncQueues>)>`
+```
+
+The implementation should only need to carry over this information and set the type correspondingly
+instead of emitting an error.
+
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- Potential Loss of Clarity: In some cases, omitting the type might make the code less clear,
+  especially to newcomers or in codebases where explicit types are part of the documentation style.
+  It is my belief that this is a choice better left for the developers as in the case of `let` bindings.
+- Anything else?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Impact of Not Doing This: Rust code remains more verbose than necessary, especially in complex scenarios, and macro authors face challenges with type specifications.
+
+
+# Prior art
+[prior-art]: #prior-art
+
+In [RFC#1623](https://github.com/rust-lang/rfcs/pull/1623) we added `'static` lifetimes to every reference or generics lifetime value in `static` or `const` declarations.
+
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+Should we allow assignment of unnameable types? For example,
+```rs
+let A = |a: u32| {
+    123_i32
+};
+
+```
+
+```
+error: missing type for `const` item
+   |
+28 | const A = |a: u32| {
+   |        ^
+   |
+note: however, the inferred type `[closure@render_pass.rs:28:11]` cannot be named        
+   |
+28 |   const A = |a: u32| {
+   |  ___________^
+29 | |     1_i32
+30 | | };
+   | |_^
+```
+
+If this significantly complicates the implementation, we can leave it outside the scope of thie RFC.

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -111,4 +111,4 @@ note: however, the inferred type `[closure@render_pass.rs:28:11]` cannot be name
    | |_^
 ```
 
-If this significantly complicates the implementation, we can leave it outside the scope of thie RFC.
+If this significantly complicates the implementation, we can leave it outside the scope of this RFC.

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -12,6 +12,7 @@ Allow type inference for `const` or `static` when the type of the initial value 
 [motivation]: #motivation
 
 Rust currently requires explicit type annotations for `const` and `static` items.
+It was decided that all public API points should be "obviously semver stable" rather than "quick to type".
 
 
 In simple cases, explicitly writing out
@@ -74,10 +75,13 @@ instead of emitting an error.
 [drawbacks]: #drawbacks
 
 - Potential Loss of Clarity: In some cases, omitting the type might make the code less clear,
-  especially to newcomers or in codebases where explicit types are part of the documentation style.
+  especially to newcomers or when explicit types are needed to understanding the purpose of the item.
   It is my belief that this is a choice better left for the developers as in the case of `let` bindings.
-  This drawback could be addressed using an allow-by-default clippy lint for `const` and `static` types.
-- Anything else?
+- Semvar compatibilty: It's a good idea that public API endpoints should be "obviously semvar stable".
+  However, not all `const` or `static` items are public, and explicit typing isn't always important for semvar stability.
+  Requiring explicit typing for this reason seems a bit heavy handed.
+
+Both of these drawback could be addressed using an allow-by-default clippy lint for `const` and `static` types.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -27,7 +27,7 @@ This change aims to make Rust code more concise and maintainable, especially in 
 const items are complicated or not easily expressible.
 
 Inferring constant types also improves the ergonomics of the language, particularly for new users. Some users are
-coming from languages where most (or all) types are inferred. So inferring obvious types matches their
+coming from languages where most (or all) types are inferred, so inferring obvious types matches their
 expectations. Other new users are focused on learning ownership, or other core Rust concepts. Reducing the
 amount of boilerplate reduces their mental load. This reduction in mental load also helps experienced programmers.
 

--- a/text/0000-const-type-inference.md
+++ b/text/0000-const-type-inference.md
@@ -95,8 +95,9 @@ language expressiveness and usability.
 
 Not all `const` or `static` items are public, and in many cases the type is obvious enough that semver isn't a concern. Requiring explicit typing for this reason seems a bit heavy handed.
 
-It is for this reason that we require "opt-in" for all places where type inference is desired
-by requiring at least a "_" placeholder for top level items.
+It is for this reason that we require "opt-in" where type inference is desired
+by requiring at least a "_" placeholder for top level items. A clippy lint will also be added
+when such top level item may in fact be named.
 
 
 # Rationale and alternatives


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3546)*

Allow type inference for `const` or `static` when the RHS is known.
```rs
const PI = 3.1415; // inferred as f64
static MESSAGE = "Hello, World!"; // inferred as &'static str
const FN = std::string::String::default; // Inferred as the unnamable type of ZST closure associated with this item. Its type is reported by `type_name_of_val` as ::std::string::String::default
```

Pre-RFC discussion: #1349

cc #1623

[Rendered](https://github.com/Neo-Zhixing/rfcs/blob/const_type_inference/text/0000-const-type-inference.md)