### PR TITLE
Make top-level special pages part of the web version of the book

### DIFF
--- a/generate-book.py
+++ b/generate-book.py
@@ -32,10 +32,16 @@ def main():
 
     for path in os.listdir('text'):
         symlink(f'../text/{path}', f'src/{path}')
+    symlink(f'../compiler_changes.md', f'src/compiler_changes.md')
+    symlink(f'../lang_changes.md', f'src/lang_changes.md')
+    symlink(f'../libs_changes.md', f'src/libs_changes.md')
     symlink('../README.md', 'src/introduction.md')
 
     with open('src/SUMMARY.md', 'w') as summary:
         summary.write('[Introduction](introduction.md)\n\n')
+        summary.write('- [Guidelines for compiler changes](compiler_changes.md)\n')
+        summary.write('- [Guidelines for language changes](lang_changes.md)\n')
+        summary.write('- [Guidelines for library changes](libs_changes.md)\n')
         collect(summary, 'text', 0)
 
     subprocess.call(['mdbook', 'build'])


### PR DESCRIPTION
This PR fixes this 404 error:

![Bildschirmfoto_2023-12-23_10-28-27](https://github.com/rust-lang/rfcs/assets/2690845/a88af99d-122c-454e-9565-42c47fc30a90)

… which results from clicking this link:

![Bildschirmfoto_2023-12-23_10-43-32](https://github.com/rust-lang/rfcs/assets/2690845/353b112e-69ba-4269-99ae-26064314c26e)

Alternatives considered:
- Move the "changes" files into `text/`: That would make it a bit more confusing for everyone
- Change the root `collect` invocation to run on `'.'` instead of `'text'`: That would require detecting and special-casing README.md inside `collect`. I prefer explicit enumeration of positives instead of special-casing negatives.