### PR TITLE
Deprecate `static mut`

### DIFF
--- a/text/3560-deprecate-static-mut.md
+++ b/text/3560-deprecate-static-mut.md
@@ -58,7 +58,7 @@ fn main() {
 }
 ```
 
-Here, since the X is not an atomic (with predictable and defined relative ordering) nor synchronised with a `Mutex` or `RwLock', a data race takes place, printing numbers between 0 and 16 in a vaguely increasing fashion, data races are undefined behaviour and mean that our code is not correct. This and the previous example show that UB is almost trivial to cause with `static mut`, making it prone to occur by accident in a large codebase.
+Here, since the X is not an atomic (with predictable and defined relative ordering) nor synchronised with a `Mutex` or `RwLock`, a data race takes place, printing numbers between 0 and 16 in a vaguely increasing fashion, data races are undefined behaviour and mean that our code is not correct. This and the previous example show that UB is almost trivial to cause with `static mut`, making it prone to occur by accident in a large codebase.
 
 Let's try to use `static mut` for FFI purposes (a typical application of it); this is usually achieved in this fashion:
 ```rust


### PR DESCRIPTION
Pre-RFC on [IRLO](https://internals.rust-lang.org/t/pre-rfc-deprecate-then-remove-static-mut/20072).

[Results](https://www.surveyhero.com/results/1749245/qsry7n7amfk9t2dbanw15vfyo0x06tzj) from research survey to inform discussion with respect to perception of the feature. (JS required)

[Rendered](https://github.com/rust-lang/rfcs/blob/c1d963f9ecad897cc3269f5e16bc9a8fe54c1190/text/3560-deprecate-static-mut.md)