### PR TITLE
Update actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Install mdbook
@@ -20,7 +20,7 @@ jobs:
       run: |
         ./generate-book.py
     - name: Upload Artifact
-      uses: actions/upload-pages-artifact@v1.0.8
+      uses: actions/upload-pages-artifact@v3.0.1
       with:
         path: ./book
 
@@ -38,4 +38,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v2.0.0
+        uses: actions/deploy-pages@v4.0.4


### PR DESCRIPTION
This updates the GitHub actions to their latest versions. This should remove the warnings that are displayed with the old versions. From testing on my fork, it seems to work.

checkout changelog: https://github.com/actions/checkout/blob/main/CHANGELOG.md#v410
upload-pages-artifact changes: https://github.com/actions/upload-pages-artifact/releases
deploy-pages changes: https://github.com/actions/deploy-pages/releases
