### PR TITLE
Add renovatebot config file

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,11 @@
+{
+    extends: [
+        "config:best-practices",
+        ":pinAllExceptPeerDependencies",
+        ":maintainLockFilesWeekly",
+        ":semanticCommitsDisabled",
+        ":label(not-rfc)",
+        "regexManagers:githubActionsVersions",
+        "schedule:monthly"
+    ],
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - master
 
+env:
+  # renovate: datasource=crate depName=mdbook versioning=semver
+  MDBOOK_VERSION: 0.4.37
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir mdbook
-        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v${{ env.MDBOOK_VERSION }}/mdbook-v${{ env.MDBOOK_VERSION }}-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
     - name: Generate Book
       run: |


### PR DESCRIPTION
see https://github.com/rust-lang/rfcs/pull/3566#issuecomment-1939074653

This adds a basic config file with updates throttled to once-per-month. Once this is merged the corresponding GitHub App needs to be enabled by the infra team for this repo.