### PR TITLE
Correct rustdoc JSON example

### DIFF
--- a/text/2963-rustdoc-json.md
+++ b/text/2963-rustdoc-json.md
@@ -877,7 +877,7 @@ pub fn references<'a>(a: &'a mut str) -> &'static MyType {}
       "type": {
         "kind": "resolved_path",
         "inner": {
-          "name": "String",
+          "name": "MyType",
           "id": "5:4936",
           "args": {
             "angle_bracketed": {


### PR DESCRIPTION
Updates type name in the JSON to correctly reflect the code snippet.

[Rendered](https://github.com/HigherOrderLogic/rust-rfcs/blob/master/text/2963-rustdoc-json.md)