### PR TITLE
Fix "higher kinded" -> "higher ranked" in RFC 3498

### DIFF
--- a/text/3498-lifetime-capture-rules-2024.md
+++ b/text/3498-lifetime-capture-rules-2024.md
@@ -288,7 +288,7 @@ impl<T> Foo<T> {
 
 ### Capturing lifetimes from `for<..>` binders
 
-Once higher kinded lifetime bounds on nested opaque types are supported in Rust (see [#104288][]), the following code will become legal:
+Once higher ranked lifetime bounds on nested opaque types are supported in Rust (see [#104288][]), the following code will become legal:
 
 ```rust
 trait Trait<'a> {
@@ -309,7 +309,7 @@ fn foo() -> impl for<'a> Trait<'a, Assoc = impl Sized> {
 
 That is, the `'a` lifetime parameter from the higher ranked trait bounds (HRTBs) `for<..>` binder is in scope for the `impl Sized` opaque type, so it is captured under the rules of this RFC.
 
-Note that support for higher kinded lifetime bounds is not required by this RFC and is not a blocker to stabilizing the rules specified in this RFC.
+Note that support for higher ranked lifetime bounds is not required by this RFC and is not a blocker to stabilizing the rules specified in this RFC.
 
 [#104288]: https://github.com/rust-lang/rust/issues/104288
 


### PR DESCRIPTION
In RFC 3498 "Lifetime Capture Rules 2024" we specify that lifetime parameters from `for<..>` binders are captured under the rules.

Currently opaque types in Rust do not support capturing these.  In early drafts of the document, we had called the missing feature "higher ranked lifetime bounds on nested opaque types".  However, we had then noticed that the relevant error message in `rustc` called these "higher kinded" instead:

> error: higher kinded lifetime bounds on nested opaque types are not supported yet

We changed later drafts to follow that language.  But that language was wrong.  These are definitely "higher ranked" lifetime bounds, not "higher kinded" ones, whatever that might mean.  We've now fixed the error message emitted by `rustc` in:

- https://github.com/rust-lang/rust/pull/122100

Correspondingly, let's now fix this error in the RFC.

[Rendered](https://github.com/rust-lang/rfcs/blob/TC/fix-higher-ranked-not-higher-kinded/text/3498-lifetime-capture-rules-2024.md)

cc @oli-obk @compiler-errors