### PR TITLE
RFC: #[derive(SmartPointer)]

### DIFF
--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -807,3 +807,4 @@ like `#[pointee]` that must be annotated on the field in question.
 [`core::ops::CoerceUnsized`]: https://doc.rust-lang.org/stable/core/ops/trait.CoerceUnsized.html
 [`DispatchFromDyn`]: https://doc.rust-lang.org/stable/core/ops/trait.DispatchFromDyn.html
 [`core::ops::DispatchFromDyn`]: https://doc.rust-lang.org/stable/core/ops/trait.DispatchFromDyn.html
+[unsafe-attribute]: https://github.com/rust-lang/rfcs/pull/3325

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -268,7 +268,7 @@ are verified semantically by the compiler when checking the generated
 
 The macro will expand to two implementations, one for
 [`core::ops::CoerceUnsized`] and one for [`core::ops::DispatchFromDyn`]. This
-is enough for a type to participe in unsizing coercions and dynamic dispatch.
+is enough for a type to participate in unsizing coercions and dynamic dispatch.
 
 The derive macro will implement the traits for the type according to the
 following procedure:
@@ -564,7 +564,7 @@ compatibility concerns with `Pin`. We cannot prevent you from using `Pin::new`
 with structs that have malicious `Deref` implementations. However, one possible
 place we can intervene is the coercion from `Pin<SmartPointer<MyStruct>>` to
 `Pin<SmartPointer<dyn MyTrait>>`. If you need to use unsafe before those
-coerceions are possible, then the problem is solved. For example, we might
+coercions are possible, then the problem is solved. For example, we might
 introduce a `StableDeref` trait:
 ```rs
 /// # Safety
@@ -680,7 +680,7 @@ current restrictions are just whatever [`DispatchFromDyn`] requires today, and
 proposals for relaxing them have been seen before (e.g., in the
 [pre-RFC][pre-rfc].)
 
-One example of a restriction that we could lift is the restrction that there is
+One example of a restriction that we could lift is the restriction that there is
 only one non-zero-sized field. This could allow implementations of `Rc` and
 `Arc` that store the value and refcount in two different allocations, like how
 the C++ `shared_ptr` works.

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -521,6 +521,22 @@ This RFC does not propose that solution because:
 
 The authors are not aware of any macros using a `#[pointee]` attribute today.
 
+## Derive macro or not?
+
+Stabilizing this as a derive macro more or less locks us in with the decision
+that the compiler will use traits to specify which types are compatible with
+trait objects. However, one could imagine other mechanisms. For example, stable
+Rust currently has logic saying that any struct where the last field is `?Sized`
+will work with unsizing operations. (E.g., if `Wrapper` is such a struct, then
+you can convert from `Box<Wrapper<[u8; 10]>>` to `Box<Wrapper<[u8]>>`.) That
+mechanism is not specified using a trait.
+
+However, using traits for this functionality seems to be the most flexible. To
+solve the unresolved questions, we most likely need to constrain the
+implementations of these traits for `Pin` with stricter trait bounds than what
+is specified on the struct. That will get much more complicated if we use a
+mechanism other than traits to specify this logic.
+
 # Prior art
 [prior-art]: #prior-art
 

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -723,9 +723,12 @@ proposals for relaxing them have been seen before (e.g., in the
 [pre-RFC][pre-rfc].)
 
 One example of a restriction that we could lift is the restriction that there is
-only one non-zero-sized field. This could allow implementations of `Rc` and
-`Arc` that store the value and refcount in two different allocations, like how
-the C++ `shared_ptr` works.
+only one non-zero-sized field. This would allow smart pointers to use custom
+allocators. (Today, types like `Box` and `Rc` only work with trait objects when
+using the default zero-sized allocator.)
+
+This could also allow implementations of `Rc` and `Arc` that store the value and
+refcount in two different allocations, like how the C++ `shared_ptr` works.
 ```rust
 #[derive(SmartPointer)]
 pub struct Rc<T: ?Sized> {

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -200,7 +200,7 @@ impl<T: ?Sized> Deref for Rc<T> {
 
 impl<T> Rc<T> {
     pub fn new(value: T) -> Self {
-        let inner = Box::new(ArcInner {
+        let inner = Box::new(RcInner {
             refcount: 1,
             value,
         });
@@ -284,8 +284,8 @@ Given the following example code:
 ```rust
 #[derive(SmartPointer)]
 struct MySmartPointer<'a, #[pointee] T: ?Sized, A>{
-    ptr: &'a T
-    phantom: PhantomData<A>
+    ptr: &'a T,
+    phantom: PhantomData<A>,
 }
 ```
 
@@ -296,13 +296,14 @@ we'll get the following expansion:
 impl<'a, T, A, U> ::core::ops::CoerceUnsized<MySmartPointer<'a, U, A>> for MySmartPointer<'a, T, A>
 where
     T: ?Sized + ::core::marker::Unsize<U>,
-    U: ?::core::marker::Sized
+    U: ?::core::marker::Sized,
+{}
 
 #[automatically_derived]
 impl<'a, T, A, U> ::core::ops::DispatchFromDyn<MySmartPointer<'a, U, A>> for MySmartPointer<'a, T, A>
 where
     T: ?Sized + ::core::marker::Unsize<U>,
-    U: ?::core::marker::Sized
+    U: ?::core::marker::Sized,
 {}
 ```
 
@@ -321,7 +322,7 @@ you can use them for dynamic dispatch.
 ## Vtable requirements
 
 As seen in the `Rc` example, the macro needs to be usable even if the pointer
-is `NonNull<ArcInner<T>>` (as opposed to `NonNull<T>`).
+is `NonNull<RcInner<T>>` (as opposed to `NonNull<T>`).
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -469,7 +470,7 @@ progress by reducing the scope and stabilizing a subset.
 
 There have already been [previous attempts to stabilize the underlying
 traits][pre-rfc], and they did not make much progress. Therefore, this RFC
-proposes to reduce ths scope and instead stabilize a derive macro.
+proposes to reduce the scope and instead stabilize a derive macro.
 
 [ast-scope]: https://github.com/rust-lang/rfcs/pull/3519#discussion_r1492385549
 [rpit]: https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -264,6 +264,8 @@ Point 1 and 2 are verified syntactically by the derive macro, whereas 3 and 4
 are verified semantically by the compiler when checking the generated
 [`DispatchFromDyn`] implementation as it does today.
 
+The `#[pointee]` attribute may also be written as `#[smart_pointer::pointee]`.
+
 ## Expansion
 
 The macro will expand to two implementations, one for
@@ -485,6 +487,30 @@ has an additional const generic parameter to allow you to use the same
 refcounted value with multiple lists. People have argued that it would be
 better to change this to a generic type instead of a const generic, so it would
 be useful to keep the option of having multiple generic types on the struct.
+
+### Conflicts with third-party derive macros
+
+The `#[pointee]` attribute could in principle conflict with other derive macros
+that also wish to annotate one of the parameters with an attribute called
+`#[pointee]`. To disambiguate such cases, we also allow the attribute to be
+spelled `#[smart_pointer::pointee]`.
+
+It is an error to specify both `#[pointee]` and `#[smart_pointer::pointee]`, so
+both macros must support this kind of disambiguation.
+
+Another way to avoid conflicts between `#[derive(SmartPointer)]` and third-party
+macros is to always assume that the first generic parameter is the pointee.
+This RFC does not propose that solution because:
+
+* It prevents the pointee from having a default unless it is the only parameter,
+  because parameters with a default must come last.
+* If logic such as "the first parameter" becomes commonplace in macro design,
+  then it does not really solve the issue with conflicts: you could have two
+  macros that both assume that the first parameter is special. And this kind of
+  conflict will be more common than attribute conflicts, because the attribute
+  will only conflict if both macros use an attribute of the same name.
+
+The authors are not aware of any macros using a `#[pointee]` attribute today.
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -255,12 +255,16 @@ The macro sets the following requirements on its input:
    `#[pointee]` derive helper attribute.
 3. The struct must not be `#[repr(packed)]` or `#[repr(C)]`.
 4. Other than one-aligned, zero-sized fields, the struct must have exactly one
-   field and that field’s type must be must implement `DispatchFromDyn<F>`
-   where `F` is the type of `T`’s field type.
+   field.
+5. Assume that `T` is a type that can be unsized to `U`, and let `FT` and `FU`
+   be the type of the struct's field when the pointee is equal to `T` and `U`
+   respectively. If the struct's trait bounds are satisfied for both `T` and
+   `U`, then it must be possible to convert `FT` to `FU` using an unsizing
+   coercion.
 
 (Adapted from the docs for [`DispatchFromDyn`].)
 
-Point 1 and 2 are verified syntactically by the derive macro, whereas 3 and 4
+Point 1 and 2 are verified syntactically by the derive macro, whereas 3, 4 and 5
 are verified semantically by the compiler when checking the generated
 [`DispatchFromDyn`] implementation as it does today.
 

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -346,6 +346,11 @@ is `NonNull<RcInner<T>>` (as opposed to `NonNull<T>`).
   [`Cell`], so hopefully that will be enough incentive to continue work on the
   underlying traits.
 
+- This would be the first example in the standard library of a derive macro that
+  does not implement a trait of the same name as the macro. (However, there are
+  examples of macros that implement multiple traits: `#[derive(PartialEq)]`
+  also implements `StructuralPartialEq`.)
+
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -646,10 +646,16 @@ introduce a `StableDeref` trait:
 unsafe trait StableDeref: Deref { }
 ```
 Then we make it so that you can only coerce pinned pointers when they implement
-`StableDeref`. We can do that by modifying its implementation of
-[`CoerceUnsized`] to this:
+`StableDeref`. We can do that by modifying its trait implementations to this:
 ```rs
 impl<T, U> CoerceUnsized<Pin<U>> for Pin<T>
+where
+    T: CoerceUnsized<U>,
+    T: StableDeref,
+    U: StableDeref,
+{}
+
+impl<T, U> DispatchFromDyn<Pin<U>> for Pin<T>
 where
     T: CoerceUnsized<U>,
     T: StableDeref,

--- a/text/3621-derive-smart-pointer.md
+++ b/text/3621-derive-smart-pointer.md
@@ -752,7 +752,15 @@ feature, though it does so for a different reason than
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-No unresolved questions.
+Bikeshedding over the name remains.
+
+The name `#[derive(SmartPointer)]` leaves some things to be desired, as smart
+pointers would generally want to implement some traits that this macro does
+*not* expand to. Most prominently, any smart pointer should implement `Deref` or
+`Receiver`. Really, the macro just says that this pointer works with unsizing
+and dynamic dispatch.
+
+We will settle on the final name prior to stabilization.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities


### PR DESCRIPTION
Use custom smart pointers with trait objects.

[Rendered](https://github.com/Darksonn/rfcs/blob/derive-smart-pointer/text/3621-derive-smart-pointer.md)

Tracking issue: https://github.com/rust-lang/rust/issues/123430

---

Co-authored by @Darksonn and @Veykril 
Thank you to @compiler-errors for [the original idea](https://rust-lang.zulipchat.com/#narrow/stream/410673-t-lang.2Fmeetings/topic/RfL.20meeting.202024-02-21/near/422701742)