### PR TITLE
Supertrait item shadowing v2

### DIFF
--- a/text/0000-supertrait-item-shadowing-v2.md
+++ b/text/0000-supertrait-item-shadowing-v2.md
@@ -49,7 +49,7 @@ When this happens, the sub-trait method is selected instead of reporting an ambi
 
 Note that this only happens when *both* traits are in scope since this is required for the ambiguity to occur in the first place.
 
-When an ambiguity is resolved in this way, a lint warning is also emitted to warn the user about the potential ambiguity. The aim of this lint is to discourage reliance on this mechanism in normal code usage: it should only be used for backwards-compatibilty and the lint can be silenced by having users change their code. We can always later change this lint to be allowed by default if we consider that there are valid use cases for this feature other than backwards-compatiblity.
+We will provide an allow-by-default lint to let users opt in to being notified when an ambiguity is resolved in this way.
 
 ### Type inference
 
@@ -73,7 +73,7 @@ Today that example will give an ambiguity error because `method` is provided by 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-This behavior can be surprising: adding a method to a sub-trait can change which function is called in unrelated code. This is mitigated by the lint which warns users about the potential ambiguity.
+This behavior might be surprising as adding a method to a subtrait can change which function is called in unrelated code. This is somewhat mitigated by the opt-in lint which, when enabled, warns users about the potential ambiguity.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -144,7 +144,7 @@ RFC 2845 was a previous attempt to address this problem, but it has several draw
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-None
+- Should we have a warn-by-default lint that fires at the definition-site of a subtrait that shadows a supertrait item?
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-supertrait-item-shadowing-v2.md
+++ b/text/0000-supertrait-item-shadowing-v2.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-When name resolution encounters an ambiguity between 2 trait methods, if one trait is a sub-trait of the other then select that method instead of reporting an ambiguity error.
+When name resolution encounters an ambiguity between 2 trait methods when both traits are in scope, if one trait is a sub-trait of the other then select that method instead of reporting an ambiguity error.
 
 # Motivation
 [motivation]: #motivation
@@ -46,6 +46,8 @@ This RFC proposes to change name resolution to resolve the ambiguity in the foll
 - One trait is transitively a sub-trait of all other traits in the candidate list.
 
 When this happens, the sub-trait method is selected instead of reporting an ambiguity error.
+
+Note that this only happens when *both* traits are in scope since this is required for the ambiguity to occur in the first place.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-supertrait-item-shadowing-v2.md
+++ b/text/0000-supertrait-item-shadowing-v2.md
@@ -30,11 +30,11 @@ use itertools::Itertools as _;
 
 fn foo() -> impl Iterator<Item = &'static str> {
     "1,2,3".split(",").intersperse("|")
-    // ^ This is ambiguious: it could refer to Iterator::intersperse or Itertools::intersperse
+    // ^ This is ambiguous: it could refer to Iterator::intersperse or Itertools::intersperse
 }
 ```
 
-This code actually works today because `intersperse` is an unstable API, which works because the compiler already has [logic](https://github.com/rust-lang/rust/pull/48552) to prefer stable methods over unstable methods when an amiguity occurs.
+This code actually works today because `intersperse` is an unstable API, which works because the compiler already has [logic](https://github.com/rust-lang/rust/pull/48552) to prefer stable methods over unstable methods when an ambiguity occurs.
 
 Attempts to stabilize `intersperse` have failed with a large number of regressions [reported by crater](https://github.com/rust-lang/rust/issues/88967) which affect many popular crates. Even if these were to be manually corrected (since ambiguity is considered allowed breakage) we would have to go through this whole process again every time a method from `itertools` is uplifted to the standard library.
 
@@ -73,7 +73,7 @@ Today that example will give an ambiguity error because `method` is provided by 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-This behavior can be surprising: adding a method to a sub-trait can change which function is called in unrelated code. This is mitigated by the which warns users about the potential ambiguity.
+This behavior can be surprising: adding a method to a sub-trait can change which function is called in unrelated code. This is mitigated by the lint which warns users about the potential ambiguity.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -138,7 +138,7 @@ Resolving in favor of `a` is a breaking change; in favor of `b` is not. The only
 ### RFC 2845
 
 RFC 2845 was a previous attempt to address this problem, but it has several drawbacks:
-- It doesn't fully address the problem since it only changes name resolution when trait methods are resolved due to generic bounds. In practice, most of the amiguity from stabilizing `intersperse` comes from non-generic code.
+- It doesn't fully address the problem since it only changes name resolution when trait methods are resolved due to generic bounds. In practice, most of the ambiguity from stabilizing `intersperse` comes from non-generic code.
 - It adds a lot of complexity because name resolution depends on the specific trait bounds that have been brought into scope.
 
 # Unresolved questions

--- a/text/0000-supertrait-item-shadowing-v2.md
+++ b/text/0000-supertrait-item-shadowing-v2.md
@@ -1,0 +1,77 @@
+- Feature Name: `supertrait_item_shadowing`
+- Start Date: 2024-05-04
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+When name resolution encounters an ambiguity between 2 trait methods, if one trait is a sub-trait of the other then select that method instead of reporting an ambiguity error.
+
+# Motivation
+[motivation]: #motivation
+
+
+The libs-api team would like to stabilize `Iterator::intersperse` but has a problem. The `itertools` crate already has:
+
+```rust
+// itertools
+trait Itertools: Iterator {
+    fn intersperse(self, element: Self::Item) -> Intersperse<Self>;
+}
+```
+
+This method is used in crates with code similar to the following:
+
+```rust
+use core::iter::Iterator; // Implicit import from prelude
+
+use itertools::Itertools as _;
+
+fn foo() -> impl Iterator<Item = &'static str> {
+    "1,2,3".split(",").intersperse("|")
+    // ^ This is ambiguious: it could refer to Iterator::intersperse or Itertools::intersperse
+}
+```
+
+This code actually works today because `intersperse` is an unstable API, which works because the compiler already has [logic](https://github.com/rust-lang/rust/pull/48552) to prefer stable methods over unstable methods when an amiguity occurs.
+
+Attempts to stabilize `intersperse` have failed with a large number of regressions [reported by crater](https://github.com/rust-lang/rust/issues/88967) which affect many popular crates. Even if these were to be manually corrected (since ambiguity is considered allowed breakage) we would have to go through this whole process again every time a method from `itertools` is uplifted to the standard library.
+
+# Proposed solution
+[proposed-solution]: #proposed-solution
+
+This RFC proposes to change name resolution to resolve the ambiguity in the following specific circumstances:
+- All method candidates are trait methods. (Inherent methods are already prioritized over trait methods)
+- One trait is transitively a sub-trait of all other traits in the candidate list.
+
+When this happens, the sub-trait method is selected instead of reporting an ambiguity error.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+This behavior can be surprising: adding a method to a sub-trait can change which function is called in unrelated code. A lint could be emitted to warn users about the potential ambiguity.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+If we choose not to accept this RFC then there doesn't seem to be a reasonable path for adding new methods to the `Iterator` trait if such methods are already provided by `itertools` without a lot of ecosystem churn.
+
+# Prior art
+[prior-art]: #prior-art
+
+### RFC 2845
+
+RFC 2845 was a previous attempt to address this problem, but it has several drawbacks:
+- It doesn't fully address the problem since it only changes name resolution when trait methods are resolved due to generic bounds. In practice, most of the amiguity from stabilizing `intersperse` comes from non-generic code.
+- It adds a lot of complexity because name resolution depends on the specific trait bounds that have been brought into scope.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+None
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+None

--- a/text/3624-supertrait-item-shadowing-v2.md
+++ b/text/3624-supertrait-item-shadowing-v2.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-When name resolution encounters an ambiguity between two trait methods when both traits are in scope, if one trait is a subtrait of the other then select that method instead of reporting an ambiguity error.
+When method selection encounters an ambiguity between two trait methods when both traits are in scope, if one trait is a subtrait of the other then select that method instead of reporting an ambiguity error.
 
 # Motivation
 [motivation]: #motivation
@@ -40,7 +40,7 @@ Attempts to stabilize `intersperse` have failed with a large number of regressio
 # Proposed solution
 [proposed-solution]: #proposed-solution
 
-This RFC proposes to change name resolution to resolve the ambiguity in the following specific circumstances:
+This RFC proposes to change method selection to resolve the ambiguity in the following specific circumstances:
 
 - All method candidates are trait methods (inherent methods are already prioritized over trait methods).
 - One trait is transitively a subtrait of all other traits in the candidate list.
@@ -63,9 +63,9 @@ If we choose not to accept this RFC then there doesn't seem to be a reasonable p
 
 ## Only doing this for specific traits
 
-One possible alternative to a general change to the name resolution rules would be to only do so on a case-by-case basis for specific methods in standard library traits. This could be done by using a perma-unstable `#[shadowable]` attribute specifically on methods like `Iterator::intersperse`.
+One possible alternative to a general change to the method selection rules would be to only do so on a case-by-case basis for specific methods in standard library traits. This could be done by using a perma-unstable `#[shadowable]` attribute specifically on methods like `Iterator::intersperse`.
 
-There are both advantages and inconveniences to this approach. While it allows most Rust users to avoid having to think about this issue for most traits, it does make the `Iterator` trait more "magical" in that it doesn't follow the same rules as the rest of the language. Having a consistent rule for how name resolution works is easier to teach people.
+There are both advantages and inconveniences to this approach. While it allows most Rust users to avoid having to think about this issue for most traits, it does make the `Iterator` trait more "magical" in that it doesn't follow the same rules as the rest of the language. Having a consistent rule for how method selection works is easier to teach people.
 
 ## Preferring the supertrait method instead
 
@@ -118,10 +118,7 @@ Resolving in favor of `a` is a breaking change; resolving in favor of `b` is not
 
 ### RFC 2845
 
-RFC 2845 was a previous attempt to address this problem, but it has several drawbacks:
-
-- It doesn't fully address the problem since it only changes name resolution when trait methods are resolved due to generic bounds. In practice, most of the ambiguity from stabilizing `intersperse` comes from non-generic code.
-- It adds a lot of complexity because name resolution depends on the specific trait bounds that have been brought into scope.
+RFC 2845 was a previous attempt, but it did not fully address the problem since it only changes method selection when trait methods are resolved due to generic bounds. In practice, most of the ambiguity from stabilizing `intersperse` comes from non-generic code.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/3624-supertrait-item-shadowing-v2.md
+++ b/text/3624-supertrait-item-shadowing-v2.md
@@ -1,7 +1,7 @@
 - Feature Name: `supertrait_item_shadowing`
 - Start Date: 2024-05-04
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- RFC PR: [rust-lang/rfcs#3624](https://github.com/rust-lang/rfcs/pull/3624)
+- Tracking Issue: [rust-lang/rust#89151](https://github.com/rust-lang/rust/issues/89151)
 
 # Summary
 [summary]: #summary

--- a/text/3624-supertrait-item-shadowing-v2.md
+++ b/text/3624-supertrait-item-shadowing-v2.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-When method selection encounters an ambiguity between two trait methods when both traits are in scope, if one trait is a subtrait of the other then select that method instead of reporting an ambiguity error.
+When method selection encounters an ambiguity between two trait methods when both traits are in scope, if one trait is a subtrait of the other then select the method from the subtrait instead of reporting an ambiguity error.
 
 # Motivation
 [motivation]: #motivation

--- a/text/3624-supertrait-item-shadowing-v2.md
+++ b/text/3624-supertrait-item-shadowing-v2.md
@@ -51,25 +51,6 @@ Note that this only happens when *both* traits are in scope since this is requir
 
 We will provide an allow-by-default lint to let users opt in to being notified when an ambiguity is resolved in this way.
 
-### Type inference
-
-This change happens during name resolution and specifically doesn't interact with type inference. Consider this example:
-
-```rust
-trait Foo { fn method(&self) {} }
-trait Bar: Foo { fn method(&self) {} }
-impl<T> Foo for Vec<T> { }
-impl<T: Copy> Bar for Vec<T> { }
-
-fn main() {
-    let x = vec![];
-    x.method(); // which to call?
-    x.push(Box::new(22)); // oh, looks like `Foo`
-}
-```
-
-Today that example will give an ambiguity error because `method` is provided by multiple traits in scope. With this RFC, it will instead always resolve to the subtrait method and then compilation will fail because `Vec` does not implement the `Copy` trait required by `Bar::method`.
-
 # Drawbacks
 [drawbacks]: #drawbacks
 


### PR DESCRIPTION
This is an alternative to #2845 which aims to resolve the [issues](https://github.com/rust-lang/rust/issues/88967) surrounding the stabilization of `Iterator::intersperse`.

## Summary
[summary]: #summary

When name resolution encounters an ambiguity between 2 trait methods, if one trait is a sub-trait of the other then select that method instead of reporting an ambiguity error.

[Rendered](https://github.com/Amanieu/rfcs/blob/item-shadowing/text/3624-supertrait-item-shadowing-v2.md)