### PR TITLE
`async T` and `gen T` types

### DIFF
--- a/text/3628-async-gen-types.md
+++ b/text/3628-async-gen-types.md
@@ -1,6 +1,6 @@
 - Feature Name: `async_gen_types`
 - Start Date: 2024-05-06
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3628](https://github.com/rust-lang/rfcs/pull/3628)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary


### PR DESCRIPTION
Allow the syntax `async T` and `gen T` as types, equivalent to
`impl Future<Output = T>` and `impl Iterator<Item = T>` respectively. Accept
them anywhere `impl Trait` can appear.

This RFC was inspired by a few different needs.

First, writing large numbers of functions that manipulate iterators or futures.
Having a shorthand for the type makes function signatures much clearer.

And second, providing one part of a general solution that gives people the
benefits of `async fn` in all contexts, and for new constructs like `gen`.

Co-authored-by: Eric Holk


[Rendered](https://github.com/joshtriplett/rfcs/blob/async-gen-types/text/3628-async-gen-types.md)