### PR TITLE
[RFC] Named macro capture groups

### DIFF
--- a/text/3649-macros-named-capture-groups.md
+++ b/text/3649-macros-named-capture-groups.md
@@ -759,7 +759,7 @@ Why should we *not* do this?
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-- Variable definition syntax could be `$ident(/* ... */)` rather than
+- Variable definition syntax could be `$ident:(/* ... */)` rather than
   `$ident(/* ... */)`. Including the `:` is proposed to be more consistent
   with existing fragment specifiers.
 - There is room for macros to become smarter in their expansions without adding

--- a/text/3649-macros-named-capture-groups.md
+++ b/text/3649-macros-named-capture-groups.md
@@ -311,7 +311,7 @@ Why should we *not* do this?
   with existing fragment specifiers.
 - There is room for macros to become smarter in their expansions without adding
   named capture groups. As mentioned elsewhere in this RFC, it seems like
-  adding named groups is a cleaner solution with less cognifitive
+  adding named groups is a cleaner solution with less cognitive overhead.
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/3649-macros-named-capture-groups.md
+++ b/text/3649-macros-named-capture-groups.md
@@ -72,7 +72,7 @@ Named groups can be used to create code that depends on nested repetitions:
 
 ```rust
 macro_rules! make_functions {
-    ( 
+    (
         // Create a function for each name
         names: [ $names($name:ident),+ ],
         // Optionally specify a greeting
@@ -119,7 +119,7 @@ let mut ret = TokenStream::new();
 for NamesCaptures { name } in greetings {
     let mut fn_body = quote! { println!("function {} called", stringify!($name)); };
 
-    // Append the greeting for each 
+    // Append the greeting for each
     for GreetingCaptures { greeting } in greetings {
         fn_body += quote! { println!("{}", #greeting) };
     }
@@ -146,6 +146,10 @@ macro_rules! rename_fn {
     }
 }
 ```
+
+_TODO: as pointed out in the comments, this syntax is ambivuous between `$group
+()` (recreate the group, add `()` after ) and `$group()` (expand the group).
+`$...group` was proposed as an alterantive._
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -225,7 +229,7 @@ macro_rules! count {
         // Error: attempted to repeat an expression containing no syntax variables
         //↓  the compiler does not know which group this refers to (here there
         //   is only one choice, but that is not always the case).
-        0 $( + 1 )* 
+        0 $( + 1 )*
     }};
 }
 ```
@@ -375,13 +379,13 @@ This can be thought of as a tree structure that loosely matches the token
                 |
                 |-- $outer_a[1]
                 |    `oa[...]`
-    $root      -|            
+    $root      -|
 (entire macro)  |                /- $middle[2,0]
                 |-- $outer_a[2] -|   `m[..]`
                 |    `oa[...]`   |
                 |                \- $middle[2,1]
                 |                    `m[..]`
-                |   
+                |
                 |-- $outer_b[0] --- $y[0,0,0,1]
                     `ob[...]`        `y0`
 
@@ -396,7 +400,7 @@ Summary of captures:
 ```
 
 In the above diagram, `$metavar[i_n, ..., i_1, i_0]` shows that this is the
-`i`th 
+`i`th
 
 
 the `i`th
@@ -618,7 +622,7 @@ need to change slightly._
   _captured_.
 - `${len($metavar)}`: Because `count` becomes more flexible, `len` is no longer
   needed and can be removed.
-- `${ignore($metavar)}`: if this RFC is accepted than `$ignore` can be removed.
+- `${ignore($metavar)}`: if this RFC is accepted then `ignore` can be removed.
   It is used to specify which capture group an expansion group belongs to when
   no metavariables are used in the expansion; with named groups, however, this
   is specified by the group name rather than by contained metavariables.
@@ -701,6 +705,11 @@ determines where to start, and then the following rules are applied:
 - If `level($name) < `level(expression)` (less deeply nested):
   - Walk the entire tree and count each `$name`
   - Reject code with an error if `$name` is not an ancestor
+
+_TODO: this was meant to be compatible with the existing metavariable
+expressions, but after talking to Josh, this should probably be split to
+two separate MVEs. Maybe something along the lines of `count_parents` and
+`count_children` could work._
 
 ```rust
 /* looking at descendents */

--- a/text/3649-macros-named-capture-groups.md
+++ b/text/3649-macros-named-capture-groups.md
@@ -336,5 +336,14 @@ as valid, which could conflict with this proposal.
 - Exact interaction with metavariable expressions is out of this RFC's scope. 
   There is a proposal around
   <https://github.com/rust-lang/rust/pull/122808#issuecomment-2124471027>.
+- Directly reemit all tokens captured in a group ([original proposal]):
+  ````rust
+  // macro LHS, capture "exactly once" repetition
+  $my_tokens(a b $var c d)①
+  
+  // macro RHS, reemit the entire capture `a b value_for_var c d`
+  $my_tokens
+  ````
 
+[original proposal]: https://github.com/rust-lang/rfcs/pull/3649#discussion_r1618998153
 [`macro_metavar_expr`]: https://rust-lang.github.io/rfcs/3086-macro-metavar-expr.html

--- a/text/3649-macros-named-capture-groups.md
+++ b/text/3649-macros-named-capture-groups.md
@@ -759,6 +759,8 @@ Why should we *not* do this?
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
+- In macro metavariable syntax, using named capture groups, we could treat `count` and `index` as *fields* rather than *functions*. For instance, we could write `${$group.index}` rather than `${index($group)}`. This would be consistent with the [macro fragment fields](https://github.com/rust-lang/rfcs/pull/3714) proposal.
+- Since we no longer need both `count` and `len`, we could choose to use either name for the remaining function we still provide. We should consider whether `count` or `len` best describes this functionality.
 - Variable definition syntax could be `$ident:(/* ... */)` rather than
   `$ident(/* ... */)`. Including the `:` is proposed to be more consistent
   with existing fragment specifiers.


### PR DESCRIPTION
This RFC proposes optional names for repetition groups in macros:

```rust
macro_rules! foo {
    ( $group1( $a:ident ),+ ) => {
        $group1( println!("{}", $a); )+
    }
}
```

[Rendered](https://github.com/tgross35/rfcs/blob/macros-named-capture-groups/text/3649-macros-named-capture-groups.md)

Small Pre-RFC: <https://internals.rust-lang.org/t/pre-rfc-named-capture-groups-for-macros/20883>