### PR TITLE
text: minor typo fix in 2094-NLL

### DIFF
--- a/text/2094-nll.md
+++ b/text/2094-nll.md
@@ -585,7 +585,7 @@ C      v
 ```
 
 We will use a notation like `Block/Index` to refer to a specific
-statement or terminate in the control-flow graph. `A/0` and `B/4`
+statement or terminator in the control-flow graph. `A/0` and `B/4`
 refer to `p = &foo` and `goto C`, respectively.
 
 ### What is a lifetime and how does it interact with the borrow checker


### PR DESCRIPTION
Please see the commit section.

[Rendered](https://github.com/FullyNonlinear/rfcs/blob/master/text/2094-nll.md)