### PR TITLE
Fix 3416's tracking issue link

### DIFF
--- a/text/3416-feature-metadata.md
+++ b/text/3416-feature-metadata.md
@@ -2,7 +2,7 @@
 - Start Date: 2023-04-14
 - RFC PR: [rust-lang/rfcs#3416](https://github.com/rust-lang/rfcs/pull/3416)
 - Rust Issue:
-  [rust-lang/cargo#13576](https://github.com/rust-lang/cargo/issues/13576)
+  [rust-lang/cargo#14157](https://github.com/rust-lang/cargo/issues/14157)
 
 # Summary
 


### PR DESCRIPTION
Copied and pasted from the wrong tab

[Rendered](https://github.com/epage/rfcs/blob/tracking/text/3416-feature-metadata.md)