### PR TITLE
Unsafe derives and attributes

### DIFF
--- a/text/0000-unsafe-derives-and-attrs.md
+++ b/text/0000-unsafe-derives-and-attrs.md
@@ -1,0 +1,87 @@
+- Feature Name: `unsafe_derives_and_attrs`
+- Start Date: 2024-10-22
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Allow declaring proc macro attributes and derive macros as unsafe, and
+requiring `unsafe` to invoke them.
+
+# Motivation
+[motivation]: #motivation
+
+Some traits place requirements on implementations that the Rust compiler cannot
+verify. Those traits can mark themselves as unsafe, requiring `unsafe impl`
+syntax to implement. However, trait `derive` macros cannot currently require
+`unsafe`. This RFC defines a syntax for declaring and using unsafe `derive`
+macros.
+
+This RFC also defines a syntax for declaring proc macro attributes as unsafe.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## Derives
+
+When declaring a proc macro `derive`, you can add the `unsafe` parameter to the
+`proc_macro_derive` attribute to indicate that the derive requires `unsafe`:
+
+```rust
+#[proc_macro_derive(DangerousTrait, unsafe)]
+pub fn derive_helper_attr(_item: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+```
+
+Invoking this derive requires writing either
+`#[unsafe(derive(DangerousTrait))]` or `#[derive(unsafe(DangerousTrait))]`.
+(The latter syntax allows isolating the `unsafe` to a single derive within a
+list of derives.) Invoking an unsafe derive without the unsafe derive syntax
+will produce a compiler error. Using the unsafe derive syntax without an unsafe
+derive will trigger an "unused unsafe" lint.
+
+A `proc_macro_derive` attribute can include both `attributes` for helper
+attributes and `unsafe` to declare the derive unsafe, in any order.
+
+## Attributes
+
+When declaring a proc macro attribute, you can add the `unsafe` parameter to
+the `proc_macro_attribute` attribute to indicate that the attribute requires
+`unsafe`:
+
+```rust
+#[proc_macro_attribute(unsafe)]
+pub fn dangerous(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+```
+
+Invoking an unsafe attribute requires the unsafe attribute syntax:
+`#[unsafe(dangerous)]`.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+Should we support the `#[unsafe(derive(DangerousTrait))]` syntax, or only
+`#[derive(unsafe(DangerousTrait))]`? The former elevates the `unsafe` to be
+more visible, and allows deriving several traits using one `unsafe`. The latter
+isolates the `unsafe` to a specific trait. This RFC proposes supporting both,
+but we could choose to only support the latter instead.
+
+# Prior art
+[prior-art]: #prior-art
+
+RFC 3325 defined unsafe attributes. This RFC provides a natural extension of
+that mechanism to derives.
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+When we add support for `macro_rules!`-based attributes and derives, we should
+provide a means for such attributes and derives to declare themselves unsafe as
+well.
+
+We could provide a syntax to declare specific helper attributes of a derive as
+unsafe, without declaring the entire derive unsafe.

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -62,6 +62,10 @@ struct SomeStruct { ... }
 struct AnotherStruct { ... }
 ```
 
+(Note that current rustfmt will place every derive on a line of its own if any
+have a comment. That could be changed in a future style edition, but this RFC
+is not making or advocating any style proposals.)
+
 ## Attributes
 
 When declaring a proc macro attribute, you can add the `unsafe` parameter to

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -93,16 +93,17 @@ instead, put the `unsafe` on the outside: `#[unsafe(derive(DangerousTrait))]`.
 
 Some rationale for putting it on the inside:
 - This encourages minimizing the scope of the `unsafe`, isolating it to a
-  single trait.
-- This allows writing all traits to derive within a single `#[derive(...)]`, if
-  desired. Putting the `unsafe` on the outside requires separate `derive`s for
-  safe and unsafe derives, and potentially multiple if the derives care about
-  ordering.
-- This makes it easy to attach `SAFETY` comments to each individual trait.
-- One way to think of `derive(Trait)` is `derive` is the mechanism to invoke
-  derive macros, and `Trait` is the actual derive macro. In this sense, when
-  writing `derive(unsafe(UnsafeTrait))`, the `unsafe` is attached to the
-  specific derive macro rather than the `derive` directive.
+  single derive macro.
+- This allows writing all derive macros to invoke within a single
+  `#[derive(...)]`, if desired. Putting the `unsafe` on the outside requires
+  separate `derive`s for safe and unsafe derives, and potentially multiple if
+  the derives care about ordering.
+- This makes it easy to attach `SAFETY` comments to each individual derive
+  macro.
+- One way to think of `derive(Macro)` is that `derive(..)` enters a context in
+  which one or more derive macros can be invoked, and naming `Macro` is how we
+  actually invoke the derive macro. When invoking unsafe derive macros, we have
+  to wrap those with `unsafe(..)` as in `derive(unsafe(DangerousDeriveMacro))`.
 
 We could use a different syntax for invoking unsafe derives, such as
 `derive(unsafe Trait)`. However, that would be inconsistent with unsafe

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -107,6 +107,12 @@ Some rationale for putting it on the inside:
   actually invoke the derive macro. When invoking unsafe derive macros, we have
   to wrap those with `unsafe(..)` as in `derive(unsafe(DangerousDeriveMacro))`.
 
+We could, *if* we used the `unsafe(derive(...))` syntax, additionally restrict
+such derives to only contain a single trait, forcing the developer to only
+invoke a single derive macro per `unsafe(derive(...))`. However, this syntax
+naturally leads people to assume this would work, only to encounter an error
+when they do the natural thing that seems like it should work.
+
 We could use a different syntax for invoking unsafe derives, such as
 `derive(unsafe DangerousDeriveMacro)`. However, that would be inconsistent with
 unsafe attributes (which use parentheses), *and* it has the potential to look

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -1,6 +1,6 @@
 - Feature Name: `unsafe_derives_and_attrs`
 - Start Date: 2024-10-22
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3715](https://github.com/rust-lang/rfcs/pull/3715)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -70,6 +70,11 @@ more visible, and allows deriving several traits using one `unsafe`. The latter
 isolates the `unsafe` to a specific trait. This RFC proposes supporting both,
 but we could choose to only support the latter instead.
 
+We could use a different syntax for invoking unsafe derives, such as
+`derive(unsafe Trait)`. However, that would be inconsistent with unsafe
+attributes (which use parentheses), *and* it has the potential to look like a
+modifier to `Trait` (e.g. an unsafe version of `Trait`).
+
 # Prior art
 [prior-art]: #prior-art
 

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -26,6 +26,17 @@ macro that implements the `unsafe` trait in a fashion that's always safe (or
 that fails if some obligation is not met), or an `unsafe` `derive` macro that
 puts the safety obligation on the invoker of the `derive`.
 
+Some examples of potential unsafe derives for `unsafe trait`s:
+
+- `TrustedLen` and `DerefPure` in the standard library. (Currently unstable,
+  but such a derive would be useful when they're stable, serving the function
+  of an `unsafe impl`.)
+- `pyo3::marker::Ungil` in `pyo3`, in place of the current handling of a
+  blanket impl for any `Send` type.
+- A hypothetical derive for `bytes::Buf` or similar. (For cases where a type
+  has fields or trivial expressions corresponding to the current slice and
+  offset.)
+
 This RFC also defines a syntax for declaring proc macro attributes as unsafe.
 
 # Guide-level explanation

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -29,34 +29,35 @@ When declaring a proc macro `derive`, you can add the `unsafe` parameter to the
 `proc_macro_derive` attribute to indicate that the derive requires `unsafe`:
 
 ```rust
-#[proc_macro_derive(DangerousTrait, unsafe)]
-pub fn derive_helper_attr(_item: TokenStream) -> TokenStream {
+#[proc_macro_derive(DangerousDeriveMacro, unsafe)]
+pub fn derive_dangerous_derive_macro(_item: TokenStream) -> TokenStream {
     TokenStream::new()
 }
 ```
 
-Invoking this derive requires writing `#[derive(unsafe(DangerousTrait))]`.
-Invoking an unsafe derive without the unsafe derive syntax will produce a
-compiler error. Using the unsafe derive syntax without an unsafe derive will
-trigger an "unused unsafe" lint.
+Invoking this derive macro requires writing
+`#[derive(unsafe(DangerousDeriveMacro))]`. Invoking an unsafe derive macro
+without the unsafe derive syntax will produce a compiler error. Using the
+unsafe derive syntax without an unsafe derive macro will trigger an "unused
+unsafe" lint.
 
 A `proc_macro_derive` attribute can include both `attributes` for helper
 attributes and `unsafe` to declare the derive unsafe, in any order.
 
 If writing code that enforces `SAFETY` comments for every use of `unsafe`, you
 can write the `SAFETY` comment either prior to the derive (for a single unsafe
-derive) or prior to the specific `unsafe(DangerousTrait)` in a list of derives:
+derive) or prior to the specific `unsafe(DangerousDeriveMacro)` in a list of derives:
 
 ```rust
 // SAFETY: ...
-#[derive(unsafe(DangerousTrait))]
+#[derive(unsafe(DangerousDeriveMacro))]
 struct SomeStruct { ... }
 
 #[derive(
     // SAFETY: ...
-    unsafe(DangerousTrait),
+    unsafe(DangerousDeriveMacro),
     // SAFETY: ...
-    unsafe(AnotherDangerousTrait),
+    unsafe(AnotherDangerousDeriveMacro),
 )]
 struct AnotherStruct { ... }
 ```
@@ -88,8 +89,9 @@ can write the `SAFETY` comment immediately prior to the attribute:
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-This RFC proposes the synax `#[derive(unsafe(DangerousTrait))]`. We could,
-instead, put the `unsafe` on the outside: `#[unsafe(derive(DangerousTrait))]`.
+This RFC proposes the synax `#[derive(unsafe(DangerousDeriveMacro))]`. We
+could, instead, put the `unsafe` on the outside:
+`#[unsafe(derive(DangerousDeriveMacro))]`.
 
 Some rationale for putting it on the inside:
 - This encourages minimizing the scope of the `unsafe`, isolating it to a
@@ -106,9 +108,11 @@ Some rationale for putting it on the inside:
   to wrap those with `unsafe(..)` as in `derive(unsafe(DangerousDeriveMacro))`.
 
 We could use a different syntax for invoking unsafe derives, such as
-`derive(unsafe Trait)`. However, that would be inconsistent with unsafe
-attributes (which use parentheses), *and* it has the potential to look like a
-modifier to `Trait` (e.g. an unsafe version of `Trait`).
+`derive(unsafe DangerousDeriveMacro)`. However, that would be inconsistent with
+unsafe attributes (which use parentheses), *and* it has the potential to look
+like a modifier to `DangerousDeriveMacro` (e.g. an unsafe version of
+`DangerousDeriveMacro`), particularly in the common case where
+`DangerousDeriveMacro` has the same name as a trait.
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -98,6 +98,24 @@ struct AnotherStruct { ... }
 have a comment. That could be changed in a future style edition, but this RFC
 is not making or advocating any style proposals.)
 
+### Helper attributes
+
+A `derive` macro can have helper attributes. You can use the following syntax
+to declare a helper attribute as `unsafe`:
+
+```rust
+#[proc_macro_derive(MyDeriveMacro(, attributes(unsafe(dangerous_helper_attr))]
+pub fn derive_my_derive_macro(_item: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+```
+
+Invoking this helper attribute requires the unsafe attribute syntax:
+`#[unsafe(dangerous_helper_attr)]`.
+
+Any combination of safe and unsafe attributes are allowed in both safe and
+unsafe derive macros.
+
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
@@ -157,6 +175,3 @@ that mechanism to derives.
 When we add support for `macro_rules!`-based attributes and derives, we should
 provide a means for such attributes and derives to declare themselves unsafe as
 well.
-
-We could provide a syntax to declare specific helper attributes of a derive as
-unsafe, without declaring the entire derive unsafe.

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -129,6 +129,14 @@ We could use a similar syntax for declaring unsafe derives as invoking them:
 precedent of `unsafe(attribute)`, this can be interpreted as being an unsafe
 operation to *define* rather than an unsafe operation to *invoke*.
 
+If we didn't have this feature, a workaround trait authors could use for the
+specific case of a derive macro implementing a trait is to have a separate
+marker trait as a supertrait of the unsafe trait. Then,
+`derive(DangerousTrait)` could require separately doing `unsafe impl
+PrerequisiteForDangerousTrait`. This would achieve the goal of requiring
+`unsafe` to appear somewhere when deriving the trait, but would not tie the two
+together as directly or clearly.
+
 # Prior art
 [prior-art]: #prior-art
 

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -31,6 +31,30 @@ This RFC also defines a syntax for declaring proc macro attributes as unsafe.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
+## Attributes
+
+When declaring a proc macro attribute, you can add the `unsafe` parameter to
+the `proc_macro_attribute` attribute to indicate that the attribute requires
+`unsafe`:
+
+```rust
+#[proc_macro_attribute(unsafe)]
+pub fn dangerous(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+```
+
+Invoking an unsafe attribute requires the unsafe attribute syntax:
+`#[unsafe(dangerous)]`.
+
+When writing a `SAFETY` comment for each `unsafe`, you can place the `SAFETY`
+comment immediately prior to the attribute:
+
+```rust
+// SAFETY: ...
+#[unsafe(dangerous)]
+```
+
 ## Derives
 
 When declaring a proc macro `derive`, you can use the following syntax to
@@ -73,30 +97,6 @@ struct AnotherStruct { ... }
 (Note that current rustfmt will place every derive on a line of its own if any
 have a comment. That could be changed in a future style edition, but this RFC
 is not making or advocating any style proposals.)
-
-## Attributes
-
-When declaring a proc macro attribute, you can add the `unsafe` parameter to
-the `proc_macro_attribute` attribute to indicate that the attribute requires
-`unsafe`:
-
-```rust
-#[proc_macro_attribute(unsafe)]
-pub fn dangerous(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
-}
-```
-
-Invoking an unsafe attribute requires the unsafe attribute syntax:
-`#[unsafe(dangerous)]`.
-
-When writing a `SAFETY` comment for each `unsafe`, you can place the `SAFETY`
-comment immediately prior to the attribute:
-
-```rust
-// SAFETY: ...
-#[unsafe(dangerous)]
-```
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -48,14 +48,14 @@ can write the `SAFETY` comment either prior to the derive (for a single unsafe
 derive) or prior to the specific `unsafe(DangerousTrait)` in a list of derives:
 
 ```rust
-/// SAFETY: ...
+// SAFETY: ...
 #[derive(unsafe(DangerousTrait))]
 struct SomeStruct { ... }
 
 #[derive(
-    /// SAFETY: ...
+    // SAFETY: ...
     unsafe(DangerousTrait),
-    /// SAFETY: ...
+    // SAFETY: ...
     unsafe(AnotherDangerousTrait),
 )]
 struct AnotherStruct { ... }
@@ -81,7 +81,7 @@ If writing code that enforces `SAFETY` comments for every use of `unsafe`, you
 can write the `SAFETY` comment immediately prior to the attribute:
 
 ```rust
-/// SAFETY: ...
+// SAFETY: ...
 #[unsafe(dangerous)]
 ```
 

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -98,8 +98,8 @@ Some rationale for putting it on the inside:
   single derive macro.
 - This allows writing all derive macros to invoke within a single
   `#[derive(...)]`, if desired. Putting the `unsafe` on the outside requires
-  separate `derive`s for safe and unsafe derives, and potentially multiple if
-  the derives care about ordering.
+  separate `derive`s for safe and unsafe derives, and potentially multiple in
+  the (unusual) case where the derives care about ordering.
 - This makes it easy to attach `SAFETY` comments to each individual derive
   macro.
 - One way to think of `derive(Macro)` is that `derive(..)` enters a context in

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -120,6 +120,11 @@ like a modifier to `DangerousDeriveMacro` (e.g. an unsafe version of
 `DangerousDeriveMacro`), particularly in the common case where
 `DangerousDeriveMacro` has the same name as a trait.
 
+We could use a similar syntax for declaring unsafe derives as invoking them:
+`proc_macro_derive(unsafe(DangerousDeriveMacro))`. However, because of the
+precedent of `unsafe(attribute)`, this can be interpreted as being an unsafe
+operation to *define* rather than an unsafe operation to *invoke*.
+
 # Prior art
 [prior-art]: #prior-art
 

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -104,7 +104,7 @@ A `derive` macro can have helper attributes. You can use the following syntax
 to declare a helper attribute as `unsafe`:
 
 ```rust
-#[proc_macro_derive(MyDeriveMacro(, attributes(unsafe(dangerous_helper_attr))]
+#[proc_macro_derive(MyDeriveMacro, attributes(unsafe(dangerous_helper_attr))]
 pub fn derive_my_derive_macro(_item: TokenStream) -> TokenStream {
     TokenStream::new()
 }

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -99,6 +99,10 @@ Some rationale for putting it on the inside:
   safe and unsafe derives, and potentially multiple if the derives care about
   ordering.
 - This makes it easy to attach `SAFETY` comments to each individual trait.
+- One way to think of `derive(Trait)` is `derive` is the mechanism to invoke
+  derive macros, and `Trait` is the actual derive macro. In this sense, when
+  writing `derive(unsafe(UnsafeTrait))`, the `unsafe` is attached to the
+  specific derive macro rather than the `derive` directive.
 
 We could use a different syntax for invoking unsafe derives, such as
 `derive(unsafe Trait)`. However, that would be inconsistent with unsafe

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -81,6 +81,14 @@ modifier to `Trait` (e.g. an unsafe version of `Trait`).
 RFC 3325 defined unsafe attributes. This RFC provides a natural extension of
 that mechanism to derives.
 
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+This RFC proposes accepting both `#[unsafe(derive(MyTrait))]` and
+`#[derive(unsafe(MyTrait))]`, among other reasons to make it easy to write
+`#[derive(SafeTrait, unsafe(MyTrait))]`. Should we allow both, or only allow
+the former?
+
 # Future possibilities
 [future-possibilities]: #future-possibilities
 

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -44,9 +44,9 @@ unsafe" lint.
 A `proc_macro_derive` attribute can include both `attributes` for helper
 attributes and `unsafe` to declare the derive unsafe, in any order.
 
-If writing code that enforces `SAFETY` comments for every use of `unsafe`, you
-can write the `SAFETY` comment either prior to the derive (for a single unsafe
-derive) or prior to the specific `unsafe(DangerousDeriveMacro)` in a list of derives:
+When writing a `SAFETY` comment for each `unsafe`, you can place the `SAFETY`
+comment either prior to the derive (for a single unsafe derive) or prior to the
+specific `unsafe(DangerousDeriveMacro)` in a list of derives:
 
 ```rust
 // SAFETY: ...
@@ -78,8 +78,8 @@ pub fn dangerous(_attr: TokenStream, item: TokenStream) -> TokenStream {
 Invoking an unsafe attribute requires the unsafe attribute syntax:
 `#[unsafe(dangerous)]`.
 
-If writing code that enforces `SAFETY` comments for every use of `unsafe`, you
-can write the `SAFETY` comment immediately prior to the attribute:
+When writing a `SAFETY` comment for each `unsafe`, you can place the `SAFETY`
+comment immediately prior to the attribute:
 
 ```rust
 // SAFETY: ...

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -18,6 +18,14 @@ syntax to implement. However, trait `derive` macros cannot currently require
 `unsafe`. This RFC defines a syntax for declaring and using unsafe `derive`
 macros.
 
+This provides value for any derive of an `unsafe trait`, ranging from standard
+library unsafe traits such as `Send` and `Sync` to more complex unsafe traits
+in the ecosystem. With this mechanism available, an `unsafe trait` has the
+option of providing two different kinds of `derive` macros: a safe `derive`
+macro that implements the `unsafe` trait in a fashion that's always safe (or
+that fails if some obligation is not met), or an `unsafe` `derive` macro that
+puts the safety obligation on the invoker of the `derive`.
+
 This RFC also defines a syntax for declaring proc macro attributes as unsafe.
 
 # Guide-level explanation

--- a/text/3715-unsafe-derives-and-attrs.md
+++ b/text/3715-unsafe-derives-and-attrs.md
@@ -25,11 +25,11 @@ This RFC also defines a syntax for declaring proc macro attributes as unsafe.
 
 ## Derives
 
-When declaring a proc macro `derive`, you can add the `unsafe` parameter to the
-`proc_macro_derive` attribute to indicate that the derive requires `unsafe`:
+When declaring a proc macro `derive`, you can use the following syntax to
+indicate that the derive requires `unsafe`:
 
 ```rust
-#[proc_macro_derive(DangerousDeriveMacro, unsafe)]
+#[proc_macro_derive(unsafe(DangerousDeriveMacro)]
 pub fn derive_dangerous_derive_macro(_item: TokenStream) -> TokenStream {
     TokenStream::new()
 }
@@ -124,10 +124,10 @@ like a modifier to `DangerousDeriveMacro` (e.g. an unsafe version of
 `DangerousDeriveMacro`), particularly in the common case where
 `DangerousDeriveMacro` has the same name as a trait.
 
-We could use a similar syntax for declaring unsafe derives as invoking them:
-`proc_macro_derive(unsafe(DangerousDeriveMacro))`. However, because of the
-precedent of `unsafe(attribute)`, this can be interpreted as being an unsafe
-operation to *define* rather than an unsafe operation to *invoke*.
+We could use a different syntax for declaring unsafe derives, such as
+`proc_macro_derive(DangerousDeriveMacro, unsafe)`. This would have the
+advantage of not looking like the definition incurs an unsafe obligation, but
+the disadvantage of using a different syntax for definition and use.
 
 If we didn't have this feature, a workaround trait authors could use for the
 specific case of a derive macro implementing a trait is to have a separate


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3715)*

Allow declaring proc macro attributes and derive macros as unsafe, and
requiring `unsafe` to invoke them.

[Rendered](https://github.com/joshtriplett/rfcs/blob/unsafe-derives/text/3715-unsafe-derives-and-attrs.md)