### PR TITLE
Add PR template encouraging inline comments over normal comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!-- Thank you for trying to improve Rust through the RFC process! -->
+<!-- Please add a short summary of your RFC below and add the link to the markdown file to the "Rendered" link below -->
+<!-- It will likely be https://github.com/<your-username>/rfcs/blob/<your-branch>/text/<file-name> -->
+
+[Rendered](LINK-TO-MARKDOWN-FILE)
+
+> [!IMPORTANT]  
+> When responding to RFCs, try to use inline review comments instead of direct comments for normal comments
+> and keep normal comments for procedural matters like starting FCPs.
+>
+> This keeps the discussion more organized.


### PR DESCRIPTION
RFC threads are known for turning into huge messes once many comments arrive. One among many reasons for this is that the comments are entirely disorganized, which makes it very hard to keep track.

I propose adding a warning the PR template that will strongly encourage people to leave inline review comments. These are significantly easier to keep track of (and can be resolved, hiding them!).

One question: who can/will approve this change? I'm just gonna go off vibes here, telling a bunch of teams about it and hoping that enough people like it that we can just ship it in and improve everyone's life!

Example (do feel free to comment normally here :D):

> [!IMPORTANT]  
> When responding to RFCs, try to use inline review comments instead of direct comments for normal comments
> and keep normal comments for procedural matters like starting FCPs.
>
> This keeps the discussion more organized.