### PR TITLE
Add `homogeneous_try_blocks` RFC

### DIFF
--- a/text/3721-homogeneous-try-blocks.md
+++ b/text/3721-homogeneous-try-blocks.md
@@ -1,7 +1,7 @@
 - Feature Name: `homogeneous_try_blocks`
 - Start Date: 2024-02-22
 - RFC PR: [rust-lang/rfcs#3721](https://github.com/rust-lang/rfcs/pull/3721)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- Rust Issue: [rust-lang/rust#154391](https://github.com/rust-lang/rust/issues/154391)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3721)*

Tweak the behaviour of `?` inside `try{}` blocks to not depend on context, in order to work better with methods and need type annotations less often.

The stable behaviour of `?` when *not* in a `try{}` block is untouched.

[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/3721-homogeneous-try-blocks.md)