### PR TITLE
Fix typos in code example of RFC 3681

### DIFF
--- a/text/3681-default-field-values.md
+++ b/text/3681-default-field-values.md
@@ -492,7 +492,7 @@ provide a default value `field: Type = value`, the given `value` must be a
 Therefore, you cannot write something like (10):
 
 ```rust
-fn launch_missilies() -> Result<(), LaunchFailure> {
+fn launch_missiles() -> Result<(), LaunchFailure> {
     authenticate()?;
     begin_launch_sequence()?;
     ignite()?;
@@ -501,7 +501,7 @@ fn launch_missilies() -> Result<(), LaunchFailure> {
 
 struct BadFoo {
     bad_field: u8 = {
-        launch_missilies().unwrap();
+        launch_missiles().unwrap();
         42
     },
 }


### PR DESCRIPTION
Updating `s/missilies/missiles` in the code example that shows how defaults are `const` contexts.

[Rendered](https://github.com/obi1kenobi/rfcs/blob/patch-1/text/3681-default-field-values.md)