### PR TITLE
Fix minor typo in 3681-default-field-values.md

### DIFF
--- a/text/3681-default-field-values.md
+++ b/text/3681-default-field-values.md
@@ -1063,7 +1063,7 @@ However, it has some notable problems:
 + It provides zero improvements to the ergonomics of *specifying* defaults,
   only for using them. Arguably, the most important aspect of this RFC is
   not the syntax `Foo { .. }` but rather the ability to provide default values
-  for field.
+  for fields.
 
 + By extension, the improvement to documentation clarity is lost.
 


### PR DESCRIPTION
Fixing a one-letter typo in RFC 3681.

[Rendered](https://github.com/obi1kenobi/rfcs/blob/patch-2/text/3681-default-field-values.md)