### PR TITLE
Use rustbot config to configure rendered links

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -5,6 +5,9 @@ allow-unauthenticated = [
     "not-rfc",
 ]
 
+[rendered-link]
+trigger-files = ["text/"]
+
 [notify-zulip."T-cargo"]
 zulip_stream = 246057 # t-cargo
 topic = "RFC #{number} - {title}"


### PR DESCRIPTION
This PR adds the new config related to the rendered links.

cc https://github.com/rust-lang/triagebot/pull/1868
cc @ehuss 