### PR TITLE
RFC: Allow packages to specify a set of supported targets

### DIFF
--- a/text/0000-cargo-supported-targets.md
+++ b/text/0000-cargo-supported-targets.md
@@ -1,0 +1,97 @@
+- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+- Discuss how this impacts the ability to read, understand, and maintain Rust code. Code is read and modified far more often than written; will the proposed feature make code easier to maintain?
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+- If this is a language proposal, could this be done in a library or macro instead? Does the proposed change make Rust code easier or harder to read, understand, and maintain?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the language and project as a whole in a holistic
+way. Try to use this section as a tool to more fully consider all possible
+interactions with the project and language in your proposal.
+Also consider how this all fits into the roadmap for the project
+and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.

--- a/text/0000-cargo-supported-targets.md
+++ b/text/0000-cargo-supported-targets.md
@@ -6,92 +6,168 @@
 # Summary
 [summary]: #summary
 
-One paragraph explanation of the feature.
+The addition of `target-requirements` (name to be discussed) to `Cargo.toml`.
+This field is an array of `target-triple`/`cfg` specification that restrict the set of target which a package
+supports. dependents of packages must meet the `target-requirements` of their dependencies, and
+binaries can only be built for targets that meet their `target-requirements`.
 
 # Motivation
 [motivation]: #motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+Some packages don't support every possible rustc target. Trying to depend on a package that does
+not support one's target often produces cryptic build errors, or fails at runtime. Allowing libraries to
+specify target requirements makes build errors nicer, and then opens the door for more advanced
+cross-compilation control. This is especially relevant to embedded programming, where one usually
+supports only a few specific targets. Wasm projects also benefit. Along with `default-target`, this feature
+has the potential to enhance DX when working in workspaces with packages designed for different targets.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+The `target-requirements` field can be added to `Cargo.toml` in any/all Cargo-target
+tables (`[lib]`, `[[bin]]`, `[[example]]`, `[[test]]`, and `[[bench]]`).
 
-- Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
-- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
-- Discuss how this impacts the ability to read, understand, and maintain Rust code. Code is read and modified far more often than written; will the proposed feature make code easier to maintain?
+This field consists of an array of strings, where each string is an explicit target-triple, or a `cfg` requirement
+like for the `[target.'cfg(**)']` table. The supported `cfg` syntax is the same as the one for
+[platform-specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)
+(i.e., we do not support `cfg(test)`, `cfg(debug_assertions)`, and `cfg(proc_macro)`.
 
-For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+__For example:__
+```toml
+[package]
+name = "hello_cargo"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+target-requirements = [
+    'cfg(target_family = "unix")',
+	"wasm32-unknown-unknown"
+]
+```
+Here we only support targets with `target_family = "unix"` __or__ the `wasm32-unknown-unknown` target.
+
+User experience is enhanced by providing a lint (deny by default) that fails compilation when
+the target requirements of a package or one of its dependencies are not satisfied. If a package
+has `target-requirements` specified, then all of its dependencies' `target-requirements`
+must be a superset of its own (see [[#Reference-level explanation]] for details).
+
+When the field is not specified, any target is accepted. _But_, dependencies are checked for compatibility
+only when building for a specific target. This is best illustrated with an example. Consider our package
+`foo`, which depends on `bar`. `bar` has `target-requirements = ['cfg(target_os = "linux")']`.
+
+If `foo`:
+- does not specify `target-requirements`, and tries to build for a linux target, compilation succeeds.
+- specifies  `target-requirements = ["cfg(all())"]` (this is a tautology, "true for any target"),
+	Then building for a linux target will fail (denied by lint), because `foo`'s requirements are not a subset
+	of `bar`'s requirements.
+
+This feature should not be eagerly used; most packages are not tailored for a specific subset of targets.
+It should be used when packages clearly don't support all targets. For example: `io-uring`
+requires `cfg(target_os = "linux")`, `gloo` requires `cfg(target_family = "wasm")`, and
+`riscv` requires `cfg(target_arch = "riscv32")` or `cfg(target_arch = "riscv64")`.
+This feature should also be used to enhance cargo's knowledge about your package. For example,
+when working in a workspace where some packages compile with `#[no_std]` and `target_os = "none"`, 
+and some other packages are tools that require a desktop OS, using `target-requirements`, makes
+`cargo <command> --workspace` ignore packages which have `target-requirements` that are not
+satisfied.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
+_This is incomplete, semantics are not decided yet_.
 
-- Its interaction with other features is clear.
-- It is reasonably clear how the feature would be implemented.
-- Corner cases are dissected by example.
+Please [[#Unresolved questions]] and [[#Rationale and alternatives]] before this section to
+understand issues discussed.
 
-The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+## Cargo procedure overview
+There will be two new steps that `cargo` will perform.
+
+1. Some moment after `cargo` is done with dependency resolution, if a package contains a
+	 `target-requirements` field, the following is done:
+	For each requirement `R`, and for each dependency `D`, `R` is checked against `D`, making sure that
+	`R` fully satisfies the `target-requirements` of `D`. That is, no target can satisfy the requirement
+	`R` and fail the requirements of `D` (one can see this as a "subset" relationship).
+	If this procedure fails, then a lint is raised. The behavior for checking `cfg` set relationships is
+	defined further below. _Note:_ This step is listed in [[#Rationale and alternatives]] as somewhat
+	optional, we do not _need_ it, but I think it would be nice to validate such things.
+
+2. Some moment after step 1, the build target is checked against the package's `target-requirements`,
+	and also against every dependency for the same thing. If it does not satisfy all dependencies the
+	package itself, a lint is raised.
+
+## Behavior with custom targets
+Since we allow `cfg(..)` requirements, custom targets have well defined behavior. The problem arises
+if we only supported target names and wildcards, because in this case custom targets would "never match".
+## Determining `cfg` set belonging
+If it is decided that a package's `target-requirements` are checked to make sure that they are a
+subset of all dependencies `target-requirements`, then relation between `cfg` settings need to
+be established. For example:
+-  `target_os = "windows"`  ⊆ `target_family = "windows"` (although the inverse is true as well
+	currently).
+- `target_os not in ["wasm", "wasi", "windows", "none", "uefi", "cuda"]` ⊆
+	`target_family = "unix"`.
+
+These are the only two relations that I believe could be made (I have checked them against every
+target available). The full list of configuration options is given
+[here](https://doc.rust-lang.org/reference/conditional-compilation.html),
+and I believe there are not
+any other relations that can naturally be made. Apart from the cases above, `cfg` requirements
+are only satisfied by themselves (e.g., `target_abi = "eabi"` satisfies `target_abi = "eabi"`).
+
+__TODOs:__
+- How this interacts with `[target.'cfg(..)']`.
+- How this interacts with `bindeps`.
+
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Why should we *not* do this?
+- It adds yet another field to `Cargo.toml`.
+- It complicates how `Cargo` works.
+- Perhaps an external tool could achieve similar results? (I personally don't know how).
+- from @epage:
+> Performance: this is a lot of extra calls to rustc. Hopefully these
+> are all compatible with our rustc cache so they won't make things too bad.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
-- If this is a language proposal, could this be done in a library or macro instead? Does the proposed change make Rust code easier or harder to read, understand, and maintain?
+The feature described above is the most comprehensive that I could think of. Other simpler alternatives
+are described here.
+## Alternatives
+- Have something more like `required-targets` (similar to `required-features`) that
+	also supports target glob expressions like `x86_64-*-linux-*`.
+- Do not validate that a package's `target-requirements` satisfy all dependencies'
+	`target-requirements`. Only check that a selected target satisfies the package's and the dependencies'
+	requirements.
+- Maybe we could use the `[target.**]` table instead. Having something like
+	```toml
+	[target.'cfg(..)']
+	allowed = false
+	```
+- Naming alternatives: `supported-targets`, `required-targets`.
+
 
 # Prior art
 [prior-art]: #prior-art
 
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
-
-- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
-
-This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
-If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
-
-Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
-Please also take into consideration that rust sometimes intentionally diverges from common language features.
+Does any one know how other build tools solve this?
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+- What if we want to exclude specific target? We can exclude groups with `cfg(not(..))`, but there
+	is currently no way of excluding specific targets.
+- If the field is not set for a cargo-target, and some dependencies have `target-requirements`, what 
+	should we do?
+- How do we make users bypass the lint?
+- Should we solve for this during version solving? (the current rationale is that we don't want
+	targets to affect package version decisions).
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would
-be and how it would affect the language and project as a whole in a holistic
-way. Try to use this section as a tool to more fully consider all possible
-interactions with the project and language in your proposal.
-Also consider how this all fits into the roadmap for the project
-and of the relevant sub-team.
-
-This is also a good place to "dump ideas", if they are out of scope for the
-RFC you are writing but otherwise related.
-
-If you have tried and cannot think of any future possibilities,
-you may simply state that you cannot think of anything.
-
-Note that having something written down in the future-possibilities section
-is not a reason to accept the current or a future RFC; such notes should be
-in the section on motivation or rationale in this or subsequent RFCs.
-The section merely provides additional information.
+- Make targets have an effect on which vendored dependencies make their way into `Cargo.lock` (I don't
+have experience with this, someone please add corrections/details).
+- Have different entry points for different targets (see [#9208](https://github.com/rust-lang/cargo/issues/9208)).

--- a/text/0000-cargo-supported-targets.md
+++ b/text/0000-cargo-supported-targets.md
@@ -3,34 +3,52 @@
 - RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
-# Summary
-[summary]: #summary
+The word _target_ in `cargo` has two different meanings which are both relevant to this RFC.
+The following terms will be used:
+- "cargo-target": The part of a package that is built (`[lib]`, `[[bin]]`, `[[example]]`, `[[test]]`, or `[[bench]]`).
+- "target": The architecture/platform that `rustc` is compiling for.
 
-The addition of `target-requirements` (name to be discussed) to `Cargo.toml`.
-This field is an array of `target-triple`/`cfg` specification that restrict the set of target which a package
-supports. dependents of packages must meet the `target-requirements` of their dependencies, and
-binaries can only be built for targets that meet their `target-requirements`.
+# Summary
+
+The addition of `supported-targets` to `Cargo.toml`.
+This field is an array of `target-triple`/`cfg` specifications that restricts the set of targets which
+a crate supports. Crates must meet the `supported-targets` of their
+dependencies, and they can only be built for targets that satisfy their `supported-targets`.
 
 # Motivation
-[motivation]: #motivation
 
-Some packages don't support every possible rustc target. Trying to depend on a package that does
-not support one's target often produces cryptic build errors, or fails at runtime. Allowing libraries to
-specify target requirements makes build errors nicer, and then opens the door for more advanced
-cross-compilation control. This is especially relevant to embedded programming, where one usually
-supports only a few specific targets. Wasm projects also benefit. Along with `default-target`, this feature
-has the potential to enhance DX when working in workspaces with packages designed for different targets.
+Some crates do not support every possible `rustc` target. Currently, there is no way to formally
+specify which targets a crate does, or does not support.
+
+### Developer Experience
+
+Trying to depend on a crate that does not support one's target often produces cryptic build errors,
+or worse, fails at runtime. Being able to specify which targets are supported ensure that unsupported
+targets cannot build the crate. This also makes build errors specific. This feature also enhances
+developer experience when working in workspaces or with packages designed for different targets simultaneously.
+
+### Cross Compilation 
+
+Once it is known that a crate will only ever build for a subset of targets, it opens
+the door for more advanced control over dependencies.
+For example, transient dependencies under a `[target.**.dependencies]` table could be
+excluded from `Cargo.lock` if the target restriction is not supported by the crate.
+This is especially relevant to areas such as WebAssembly and embedded programming,
+where one usually supports only a few specific targets. Currently, auditing and vendoring
+is tedious because dependencies in `[target.**.dependencies]` tables always make their way
+in the dependency tree, even though they may not actually be used.
+
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-The `target-requirements` field can be added to `Cargo.toml` in any/all Cargo-target
+The `supported-targets` field can be added to `Cargo.toml` in any/all cargo-target
 tables (`[lib]`, `[[bin]]`, `[[example]]`, `[[test]]`, and `[[bench]]`).
 
-This field consists of an array of strings, where each string is an explicit target-triple, or a `cfg` requirement
-like for the `[target.'cfg(**)']` table. The supported `cfg` syntax is the same as the one for
+This field consists of an array of strings, where each string is an explicit target-triple, or a `cfg` specification
+(as for the `[target.'cfg(**)']` table). The supported `cfg` syntax is the same as the one for
 [platform-specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)
-(i.e., we do not support `cfg(test)`, `cfg(debug_assertions)`, and `cfg(proc_macro)`.
+(i.e., `cfg(test)`, `cfg(debug_assertions)`, and `cfg(proc_macro)` are not supported).
 
 __For example:__
 ```toml
@@ -40,134 +58,279 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-target-requirements = [
+supported-targets = [
     'cfg(target_family = "unix")',
-	"wasm32-unknown-unknown"
+    "wasm32-unknown-unknown"
 ]
 ```
-Here we only support targets with `target_family = "unix"` __or__ the `wasm32-unknown-unknown` target.
+Here, only targets with `target_family = "unix"` __or__ the `wasm32-unknown-unknown` target are allowed
+to build the library.
 
 User experience is enhanced by providing a lint (deny by default) that fails compilation when
-the target requirements of a package or one of its dependencies are not satisfied. If a package
-has `target-requirements` specified, then all of its dependencies' `target-requirements`
-must be a superset of its own (see [[#Reference-level explanation]] for details).
+the supported targets of a cargo-target or one of its dependencies are not satisfied. If a crate
+has `supported-targets` specified, then all of its dependencies' `supported-targets`
+must be a superset of its own, for it to be publishable.
 
-When the field is not specified, any target is accepted. _But_, dependencies are checked for compatibility
-only when building for a specific target. This is best illustrated with an example. Consider our package
-`foo`, which depends on `bar`. `bar` has `target-requirements = ['cfg(target_os = "linux")']`.
+When `supported-targets` is not specified, any target is accepted as long as the target used satisfies
+all dependencies' `supported-targets`.
 
-If `foo`:
-- does not specify `target-requirements`, and tries to build for a linux target, compilation succeeds.
-- specifies  `target-requirements = ["cfg(all())"]` (this is a tautology, "true for any target"),
-	Then building for a linux target will fail (denied by lint), because `foo`'s requirements are not a subset
-	of `bar`'s requirements.
-
-This feature should not be eagerly used; most packages are not tailored for a specific subset of targets.
-It should be used when packages clearly don't support all targets. For example: `io-uring`
+This feature should not be eagerly used; most crates are not tailored for a specific subset of targets.
+It should be used when crates clearly do not support all targets. For example: `io-uring`
 requires `cfg(target_os = "linux")`, `gloo` requires `cfg(target_family = "wasm")`, and
 `riscv` requires `cfg(target_arch = "riscv32")` or `cfg(target_arch = "riscv64")`.
-This feature should also be used to enhance cargo's knowledge about your package. For example,
-when working in a workspace where some packages compile with `#[no_std]` and `target_os = "none"`, 
-and some other packages are tools that require a desktop OS, using `target-requirements`, makes
-`cargo <command> --workspace` ignore packages which have `target-requirements` that are not
+
+This feature should also be used to increase cargo's knowledge of a cargo-target. For example,
+when working in a package where some cargo-targets compile with `#[no_std]` and `target_os = "none"`, 
+and some other cargo-targets are tools that require a desktop OS, using `supported-targets` makes
+`cargo <command>` ignore cargo-targets which have `supported-targets` that are not
 satisfied.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-_This is incomplete, semantics are not decided yet_.
+## Compatibility with the selected target
 
-Please [[#Unresolved questions]] and [[#Rationale and alternatives]] before this section to
-understand issues discussed.
+When `cargo` is run on a cargo-target, it checks that the selected target satisfies the `supported-targets`
+of the cargo-target, and of all dependencies. If it does not, a lint is raised and the build fails.
 
-## Cargo procedure overview
-There will be two new steps that `cargo` will perform.
+## Compatibility with dependencies
 
-1. Some moment after `cargo` is done with dependency resolution, if a package contains a
-	 `target-requirements` field, the following is done:
-	For each requirement `R`, and for each dependency `D`, `R` is checked against `D`, making sure that
-	`R` fully satisfies the `target-requirements` of `D`. That is, no target can satisfy the requirement
-	`R` and fail the requirements of `D` (one can see this as a "subset" relationship).
-	If this procedure fails, then a lint is raised. The behavior for checking `cfg` set relationships is
-	defined further below. _Note:_ This step is listed in [[#Rationale and alternatives]] as somewhat
-	optional, we do not _need_ it, but I think it would be nice to validate such things.
+For each dependency `D` of a crate, the `supported-targets` of `D` must be a superset of
+the `supported-targets` of the crate.
 
-2. Some moment after step 1, the build target is checked against the package's `target-requirements`,
-	and also against every dependency for the same thing. If it does not satisfy all dependencies the
-	package itself, a lint is raised.
+If the crate itself has no `supported-targets` specified, then all dependencies must support all targets.
 
-## Behavior with custom targets
-Since we allow `cfg(..)` requirements, custom targets have well defined behavior. The problem arises
-if we only supported target names and wildcards, because in this case custom targets would "never match".
-## Determining `cfg` set belonging
-If it is decided that a package's `target-requirements` are checked to make sure that they are a
-subset of all dependencies `target-requirements`, then relation between `cfg` settings need to
-be established. For example:
--  `target_os = "windows"`  ⊆ `target_family = "windows"` (although the inverse is true as well
-	currently).
-- `target_os not in ["wasm", "wasi", "windows", "none", "uefi", "cuda"]` ⊆
-	`target_family = "unix"`.
+This is enforced only upon publishing (and thus only for crates). Since `supported-targets` is only useful
+for dependents of a library or binary, enforcing this at build time is not necessary and overly intrusive.
 
-These are the only two relations that I believe could be made (I have checked them against every
-target available). The full list of configuration options is given
-[here](https://doc.rust-lang.org/reference/conditional-compilation.html),
-and I believe there are not
-any other relations that can naturally be made. Apart from the cases above, `cfg` requirements
-are only satisfied by themselves (e.g., `target_abi = "eabi"` satisfies `target_abi = "eabi"`).
+### Subset and superset relations
+[subsets-and-supersets]: #subset-and-superset-relations
 
-__TODOs:__
-- How this interacts with `[target.'cfg(..)']`.
-- How this interacts with `bindeps`.
+When checking if a crate's `supported-targets` are a subset of all dependencies' `supported-targets`,
+the standard mathematical definition of subset is used. That is, `A ⊆ B` if and only if every element
+of `A` is also an element of `B`.
 
+- When comparing a `target-triple` 'A' against another `target-triple` 'B', A ⊆ B if
+    A and B are the same.
+- When comparing a `target-triple` against a `cfg(..)`, the `target-triple` is a subset
+    of the `cfg(..)` if the `target-triple` satisfies the `cfg(..)`.
+- When comparing a `cfg(..)` against a `target-triple`, the `cfg(..)` is never a subset of the `target-triple`.
+- When comparing a `cfg(A)` against another `cfg(B)`, `cfg(A)` ⊆ `cfg(B)` if
+    A and B are the same. (e.g., `target_abi = "eabi"` ⊆ `target_abi = "eabi"`)
+
+To improve usability, two extra relations are defined:
+- `cfg(target_os = "windows")` ⊆ `cfg(target_family = "windows")`.
+- `cfg(target_os = <unix-os>)` ⊆ `cfg(target_family = "unix")`, where `<unix-os>` is any of
+    `["freebsd", "linux", "netbsd", "redox", "illumos", "fuchsia", "emscripten", "android", "ios", "macos", "solaris"]`.
+    This list needs to be updated if a new `unix` OS is supported by `rustc`'s official target list).
+    
+The contrapositive of these relations are also true.
+
+The full list of configuration options is given [here](https://doc.rust-lang.org/reference/conditional-compilation.html).
+
+### Flattening `not`, `any` and `all` in `cfg` specifications
+[flattening-cfg]: #flattening-not-any-and-all-in-cfg-specifications
+
+Since `cfg` specifications can contain `not`, `any`, and `all` operators, these must be handled.
+This is done by flattening the `cfg` specification to a specific form.
+
+The `not` operator is "passed through" `any` and `all` operators using De Morgan's laws, until it
+reaches a single `cfg` specification. For example, `cfg(not(all(target_os = "linux", target_arch = "x86_64")))`
+is equivalent to `cfg(any(not(target_os = "linux"), not(target_arch = "x86_64")))`.
+
+Top level `any` operators are separated into multiple `cfg` specifications. For example,
+```toml
+supported-targets = ['cfg(any(target_os = "linux", target_os = "macos"))']
+```
+is transformed into
+```toml
+supported-targets = ['cfg(target_os = "linux")', 'cfg(target_os = "macos")']
+```
+
+Top level `all` operators are kept as is, as long as they do not contain nested `any`s or `all`s.
+If there is an `any` inside an `all`, the statement is split into multiple `all` statements.
+For example,
+```toml
+supported-targets = ['cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "arm"))']
+```
+is transformed into
+```toml
+supported-targets = [
+    'cfg(all(target_os = "linux", target_arch = "x86_64"))',
+    'cfg(all(target_os = "linux", target_arch = "arm"))'
+]
+```
+If an `all` contains an `all`, the inner `all` is flattened into the outer `all`.
+
+The result of these transformations is always a list of `cfg` specifications that 
+either contains a single specification, or an `all` operator with no nested operators.
+
+This structure can then be used to evaluate subset relations.
+
+## Behavior with unknown entries (and custom targets)
+
+Just as `[target.my-custom-target.dependencies]` is allowed by `cargo`, `supported-targets` can contain
+unknown entries. This is important because users may have different `rustc` versions, and the set of
+official `rustc` targets is unstable; Targets can change name or be removed. Also, developers 
+may want to support their custom target.
+
+To determine if an entry in `supported-targets` is a target name or a `cfg` specification, the
+same mechanism as for `[target.'cfg(..)']` is used (using
+[`cargo-platform`](https://docs.rs/cargo-platform/latest/cargo_platform/index.html)).
+
+## Ignoring builds for unsupported targets
+
+When the target used is not supported by the cargo-target being built, the cargo-target will either be
+skipped or a lint will be raised, depending on how `cargo` was invoked.
+`cargo` behaves identically to when the `required-features` of the cargo-target are not satisfied.
+
+__Note:__ `required-features` is not applicable to `libraries`, while `supported-targets` is. Nevertheless, libraries
+behave the same way as other cargo-targets.
+
+## Detecting unused dependencies
+
+An MVP implementation of this RFC does not _require_ this feature, but it is a natural extension, and a
+major part of the motivation. Hence, it is informally described here.
+
+Dependencies may have `[target.'cfg(..)'.dependencies]` tables, which may never be used because of a
+`supported-targets` restriction.
+
+When resolving dependencies for a package, each cargo-target can have a list of "unused dependencies"
+if the `supported-targets` restriction is mutually exclusive with dependencies behind a `[target.'cfg(..)'.**]`
+table.
+
+For each set of dependencies (normal, build, and dev), the intersection of these unused dependencies
+can be purged from the dependency tree.
+
+This could be implemented either as a separate pass on the `Resolve` graph, or as part of dependency resolution.
+If this is implemented as part of dependency resolution, it may or may not be favorable for
+`supported-targets` to influence the version resolution of dependencies.
+
+When detecting unused dependencies for a cargo-target, _all_ targets specified in `supported-targets` must
+be mutually exclusive with the target from a `[target.'cfg(..)'.dependencies]` table. If an entry in
+`supported-targets` is not mutually exclusive with the target from a `[target.'cfg(..)'.dependencies]`
+table, then the dependency cannot be considered unused.
+
+### Mutually exclusive `cfg` settings
+[mutually-exclusive-cfg]: #mutually-exclusive-cfg-settings
+
+Some `cfg` settings have mutually exclusive elements, while some do not. What is meant here is, for example,
+`target_arch = "x86_64"` and `target_arch = "arm"` are mutually exclusive (a target-triple cannot have both),
+while `target_feature = "avx"` and `target_feature = "rdrand"` are not.
+
+`cfg` options that have mutually exclusive elements:
+- `target_arch`
+- `target_os`
+- `target_env`
+- `target_abi`
+- `target_endian`
+- `target_pointer_width`
+- `target_vendor`
+
+Those that do not:
+- `target_feature`
+- `target_has_atomic`
+
+Special case:
+- `target_family = "windows` and `target_family = "unix"` are mutually exclusive, while all other `target_family`
+    value pairs are not mutually exclusive.
+
+`cfg(not(<option>))` is also mutually exclusive with `cfg(<option>)`.
+
+`supported-targets` are [flattened][flattening-cfg] before checking for mutual exclusivity with `[target.**.dependencies]`
+tables.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- It adds yet another field to `Cargo.toml`.
-- It complicates how `Cargo` works.
-- Perhaps an external tool could achieve similar results? (I personally don't know how).
-- from @epage:
-> Performance: this is a lot of extra calls to rustc. Hopefully these
-> are all compatible with our rustc cache so they won't make things too bad.
+- Performance: this is a lot of extra calls to rustc.
+    Hopefully these are all compatible with the rustc cache, so they won't make things too bad.
+- This feature must be learned by users wanting to publish packages that depend on crates having `supported-targets`
+    specified.
+- The common case of a crate not supporting `no_std` is not elegantly handled by this feature.
+    The closest thing available is `supported-targets = ['cfg(not(target_os = "none"))']`.
+- In its complete form, this feature increases the complexity of dependency resolution.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-The feature described above is the most comprehensive that I could think of. Other simpler alternatives
-are described here.
-## Alternatives
-- Have something more like `required-targets` (similar to `required-features`) that
-	also supports target glob expressions like `x86_64-*-linux-*`.
-- Do not validate that a package's `target-requirements` satisfy all dependencies'
-	`target-requirements`. Only check that a selected target satisfies the package's and the dependencies'
-	requirements.
-- Maybe we could use the `[target.**]` table instead. Having something like
-	```toml
-	[target.'cfg(..)']
-	allowed = false
-	```
-- Naming alternatives: `supported-targets`, `required-targets`.
+## Naming
 
+A few other names for this field can be considered:
+
+- `required-targets`. Although it matches with `required-features`, `required-features` is a list of features
+    that must _all_ be enabled (conjunction), whereas `supported-targets` is a list of targets
+    where _any_ is allowed (disjunction).
+- `target-requirements`. Feels indirect, also implies a conjunction of requirements rather than a disjunction.
+- `targets`. As in "this package _targets_ ...". Ambiguous, and could be confused with the `target` table.
+
+## Not using `cfg`
+
+Using `cfg` complicates the implementation, and may require a substantial amount of calls to `rustc` to check
+target-`cfg` compatibility. Some alternatives are discussed here along with their drawbacks.
+
+### Using wildcards
+
+Instead of using `cfg` specifications, one could use wildcards (e.g., `x86_64-*-linux-*`).
+This is much simpler to implement, target-triples are syntactically checked for a match instead
+of solving set relations for `cfg`. However, this is not as expressive as `cfg`, and does not correctly
+represent the semantics of target triples. For example, supporting `target_family = "unix"` would
+require an annoyingly long list of wildcard patterns. Things like `target_pointer_width = "32"` are
+even harder to represent, and things like `target_feature = "avx"` are basically not representable.
+Also, this is new syntax not currently used by cargo.
+
+### Allowing only target triples
+
+This is an even stricter version of the above. Being even simpler to implement, this alternative
+may not be expressive enough for the common use case. Packages rarely support specific target triples,
+rather they support/require specific target attributes. What would likely happen is that packages
+would copy and paste the target triple list matching their requirements from somewhere or someone else.
+Every time a new target with the same attribute is added, the whole ecosystem would have to be updated.
+
+## Without `cfg` relations
+
+The set relations defined on `cfg` for the [validation of the dependency tree][subsets-and-supersets]
+and for [detecting unused dependencies][mutually-exclusive-cfg] can seem artificial or hard coded.
+These are a bi-product of the "state of the world." It _currently_ does not make sense to have a target-triple
+with `target_os = "windows"` and `target_family = "unix"`, hence why the relation is defined.
+
+These could be removed at a cost to user experience. For example, consider the following situation:
+
+Suppose crate `foo` has `supported-targets = ['cfg(target_os = "linux")']` for its library,
+and crate `bar` has `supported-targets = ['cfg(target_family = "unix")']` in its library.
+`bar` also has some dependency `baz` through `[target.'cfg(target_os = "macos")'.dependencies]`.
+
+If `foo` depends on `bar`, and the previously mentioned relations are removed, then `foo` would
+need to have `supported-targets = ['cfg(all(target_family = "unix", target_os = "linux"))']` to be publishable.
+This is not as user-friendly, but is a possible alternative.
+
+Similarly, if `cfg` set relations are not implemented and `foo` depends on `bar`, then `baz` would
+be included in the dependency tree of `foo`, even though it is never used. To solve this,
+bar would need to have `supported-targets = ['cfg(all(target_family = "unix", target_os = "linux", not(target_os = "macos)))']`
+for `baz` to not be included in the dependency tree. This is also not user-friendly, but again, simpler
+to implement and maintain.
+
+The problem can get substantial if many target specific dependencies are involved.
 
 # Prior art
 [prior-art]: #prior-art
 
-Does any one know how other build tools solve this?
+Does anyone know how other build tools solve this?
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- What if we want to exclude specific target? We can exclude groups with `cfg(not(..))`, but there
+- What if one wants to exclude a single specific target? Groups can be excluded with `cfg(not(..))`, but there
 	is currently no way of excluding specific targets.
-- If the field is not set for a cargo-target, and some dependencies have `target-requirements`, what 
-	should we do?
-- How do we make users bypass the lint?
-- Should we solve for this during version solving? (the current rationale is that we don't want
-	targets to affect package version decisions).
+- How do we make users bypass the lint (probably with some `--ignore-**` flag)?
+- Should we solve for this during dependency version resolution? (the current rationale is that we do not want
+	targets to affect package version resolution). In the future, this could be implemented in
+    `pubgrub` using [constraints](https://github.com/pubgrub-rs/pubgrub/issues/120).
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-- Make targets have an effect on which vendored dependencies make their way into `Cargo.lock` (I don't
-have experience with this, someone please add corrections/details).
 - Have different entry points for different targets (see [#9208](https://github.com/rust-lang/cargo/issues/9208)).
+- Make this process part of `pubgrub`, or whatever resolver `cargo` will be using.
+- Show which targets are supported on `docs.rs`.
+- Have search filters on `crates.io` for crates with specific targets.

--- a/text/0000-cargo-supported-targets.md
+++ b/text/0000-cargo-supported-targets.md
@@ -1,5 +1,6 @@
-- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Feature Name: `supported-targets`
+- Start Date: 2025-01-08
+- Pre-RFC: [Rust internals](https://internals.rust-lang.org/t/pre-rfc-allow-packages-to-specify-a-set-of-supported-targets/21979)
 - RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
@@ -326,21 +327,22 @@ with the target preconditions of the dependency.
 
 The list of strings format was chosen because of its simplicity and expressiveness. Other formats can also be considered:
 
-- Using the `[target]` table, for example:
-    ```toml
-    [target.'cfg(target_os = "linux")']
-    supported = true
-    ```
-    If the list of supported targets is long (should it ever be?), then the `Cargo.toml` file becomes very verbose
-    as well.
-- A `[suppported]` table, with `arch = ["<arch>", ...]`, `os = ["<os>", ...]`, `target = ["<target>", ...]`, etc.
-    This is more verbose, complex to implement, learn, and remember. It is also not obvious how `not` and `all`
-    could be represented in this format. For example:
-    ```toml
-    [supported]
-    os = ["linux", "macos"]
-    arch = ["x86_64"]
-    ```
+Using the `[target]` table, for example:
+```toml
+[target.'cfg(target_os = "linux")']
+supported = true
+```
+If the list of supported targets is long (should it ever be?), then the `Cargo.toml` file becomes very verbose
+as well.
+
+A `[suppported]` table, with `arch = ["<arch>", ...]`, `os = ["<os>", ...]`, `target = ["<target>", ...]`, etc.
+This is more verbose, complex to implement, learn, and remember. It is also not obvious how `not` and `all`
+could be represented in this format. For example:
+```toml
+[supported]
+os = ["linux", "macos"]
+arch = ["x86_64"]
+```
 
 ## Naming
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -283,7 +283,7 @@ believe the crate will not compile or work as expected (e.g. because it uses tar
 and not use it merely for "I haven't personally tested this on other targets".
 
 Even then, it will happen that crates unnecessarily limit their dependents and users, because of 
-over restrictive `supported-targets`. So, users must be able to disable the lint or error.
+over restrictive `supported-targets`. So, users must be able to remove the lint or error.
 To alleviate this, a flag like `--ignore-supported-targets` could be added to `cargo` to ignore the `supported-targets` of a
 package, and a field like
 ```toml
@@ -294,6 +294,12 @@ could be added to ignore the `supported-targets` of a specific dependency. This 
 could otherwise be added to the [`[patch]` table](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section),
 or be added as mutable metadata in package registries
 ([related discussion](https://blog.rust-lang.org/inside-rust/2024/03/26/this-development-cycle-in-cargo-1.78.html#why-is-this-yanked)).
+
+One thing to keep in mind is that disabling the `supported-targets` check for a package or a dependency
+removes the ability to prune the dependency tree of a package. That is because disabling the lint/error
+is equivalent to the package or the dependency supporting all targets. So, either the `--ignore-supported-targets`
+flag has the ability to change lockfile generation (this pattern is advised against), or dependencies are still
+pruned as if the package's `supported-targets` were respected, but the lint/error is ignored.
 
 ### Compatibility of `[dependencies]`
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -85,6 +85,8 @@ and some others are tools that require a desktop OS, using `supported-targets` m
 `cargo <command>` ignore packages which have `supported-targets` that are not satisfied
 by the selected target.
 
+Cargo's documentation should give clear guidance for when to use this field, and should not suggest using it by default. In particular, we should steer users to use this when they have good reason to believe the crate will not compile or work as expected (e.g. because it uses target-specific APIs), and not use it merely for "I haven't personally tested this on other targets".
+
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -467,7 +467,7 @@ increase usability. By extension, `target_family = "windows"` would now be mutua
 _Note:_ More relations could be defined, for example `target_feature = "neon"` ⊆ `target_arch =
 "arm"`. With this however, things start to get complicated.
 
-## Lint against useless target-specific tables
+## Lint against unused target-specific tables
 
 If a package has:
 ```toml
@@ -478,8 +478,6 @@ supported-targets = 'cfg(target_os = "linux")'
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # ...
-```
-A lint could be added to highlight the fact that the `[target]` table is useless.
 
 ## `supported-targets` at the cargo-target level
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -33,16 +33,13 @@ possibilities](#future-possibilities) to deliver an MVP we can then build on.
 
 The error message when a library has platform-specific features, like requiring atomics, is about parts of `std` missing which could be for one of several reasons. Some of these problems won't be found until you've built or tested your project on one of these platforms. Like with #2495, if library authors could provide this information to Cargo, developers can get an improved error message under any circumstance.
 
+### Include fewer packages with `cargo vendor`
+
+`Cargo.lock`, and by extension, `cargo vendor`, must assume that a package may be built on any platform that has or will exist.  This means that if a transitive dependency pulls in Windows-specific dependencies, `cargo vendor` will include them when run on a Linux-only application.  Being able to tell `cargo vendor` what platforms to care about can reduce the space used in a repo and reduce churn.
+
 ### Dependency Management 
 
-Once it is known that a package will only ever build for a subset of targets, it opens the door for
-more advanced control over dependencies. For example, transitive dependencies declared under a
-`[target.**.dependencies]` table could be excluded from `Cargo.lock` if the dependent's
-`supported-targets` are mutually exclusive with the target preconditions under which the
-dependencies are included. This is especially relevant to areas such as WebAssembly and embedded
-programming, where one usually supports only a few specific targets. Currently, auditing and
-vendoring is tedious because dependencies under `[target.**.dependencies]` tables always make their
-way in the dependency tree, even though they may not actually be used.
+Likewise, today users either need to audit dependencies irrelevant for the platforms they target or filter these out somehow.  By providing first-class support for specifying what platform features a package requires, audit tools can consolidate on that for narrowing down the list of what dependencies to audit.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -88,7 +88,7 @@ by the selected target.
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-When `cargo` is run on a package, it checks that the selected target satisfies the `supported-targets`
+When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run on a package, it checks that the selected target satisfies the `supported-targets`
 of the package. If it does not, an error is raised and the build fails. However, `supported-targets`
 is _not_ checked if the cargo command does not require compilation (`cargo doc`, `cargo fmt`, etc.).
 For example, `cargo doc` can be run on a host that the package does not support.

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -299,7 +299,8 @@ One thing to keep in mind is that disabling the `supported-targets` check for a 
 removes the ability to prune the dependency tree of a package. That is because disabling the lint/error
 is equivalent to the package or the dependency supporting all targets. So, either the `--ignore-supported-targets`
 flag has the ability to change lockfile generation (this pattern is advised against), or dependencies are still
-pruned as if the package's `supported-targets` were respected, but the lint/error is ignored.
+pruned as if the package's `supported-targets` were respected, but the lint/error is ignored. The lockfile
+could also store the state which was used to generate it, but this currently is not implemented in `cargo`.
 
 ### Compatibility of `[dependencies]`
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -516,7 +516,7 @@ the `edition` field, which is available at both the package and the cargo-target
 `supported-targets`.
 
 This could also allow for a cargo-target to be swapped out based on the selected target. For example,
-we could specify which binary should be used as `main` based on the selected target
+one could specify which binary should be used as `main` based on the selected target
 [#9208](https://github.com/rust-lang/cargo/issues/9208).
 .
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -250,7 +250,8 @@ responsible for ensuring that the dependencies are compatible with the target.
 Some higher-level languages and build tools have the ability to specify which platforms are compatible.
 - Python has [platform compatibility tags](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#platform-compatibility-tags).
     The reference explains how these are [used](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#use)
-    by installers to determine which build of a package to install.
+    by installers to determine which build of a package to install. PyPI also has [classifiers](https://pypi.org/classifiers/)
+    which allows to add metadata (including which platforms are allowed) to a package.
 - `npm` allows specifying which [`os`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#os) and
     [`cpu`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#cpu) a package supports. These generate an
     error when installing a package that does not support the platform used.

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -22,9 +22,7 @@ set of targets which a package supports. Packages can only be built for targets 
 Some packages do not support every possible `rustc` target. Currently, there is no way to formally
 specify which targets a package does, or does not support.
 
-This feature enhances developer experience when working in workspaces containing packages designed
-for many different targets. Commands run on a workspace ignore packages that don't support the
-selected target.
+When working on a project with packages that only build on certain platforms, users cannot run Cargo commands across the entire workspace (e.g. `cargo test --workspace`) but must individually select packages that only work on the specific platform (e.g. `cargo test --workspace --exclude firmware`).  This extends to CI with people wanting to write matrix jobs but have to hand maintain the list of packages for each platform in the matrix.
 
 ## Long-term Motivations
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -245,9 +245,20 @@ compile_error!("unsupported target cfg");
 is an example of a crate utilizing this method.
 
 In other system level languages, vendoring dependencies is a common practice, and the user would be
-responsible for ensuring that the dependencies are compatible with the target. For interpreted
-languages, this is a non-issue because any platform being able to run the interpreter can run the
-package.
+responsible for ensuring that the dependencies are compatible with the target.
+
+Some higher-level languages and build tools have the ability to specify which platforms are compatible.
+- Python has [platform compatibility tags](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#platform-compatibility-tags).
+    The reference explains how these are [used](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#use)
+    by installers to determine which build of a package to install.
+- `npm` allows specifying which [`os`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#os) and which
+    [`cpu`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#cpu) a package supports. These generate an
+    error when installing a package that does not support the platform used.
+- Swift has [`package.platforms`](https://developer.apple.com/documentation/packagedescription/package/platforms), which
+    allows specifying which platforms and versions a package support (mostly for apple products e.g., `macOS`, `iOS`, `watchOS`, `tvOS`).
+- [Buck](https://buck2.build/docs/rule_authors/configurations/#target-platform-compatibility)
+    and [Bazel](https://bazel.build/reference/be/common-definitions#common.target_compatible_with)
+    both have `target_compatible_with`.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -82,10 +82,10 @@ require a desktop OS, using `supported-targets` makes `cargo <command>` ignore p
 When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run, it checks that the
 selected target satisfies the `supported-targets` of the package being built. If it does not, the
 package is skipped or an error is raised, depending on how [`cargo` was invoked](ignoring-builds).
-However, `supported-targets` are _not_ checked if the cargo command does not require compilation
-(e.g., `cargo fmt`). This field is only for local development, and is removed from `Cargo.toml`
-when publishing a crate. It could be published to give more information to `docs.rs`, `crates.io`,
-and `cargo` itself, but this is left as a [future possibility](#future-possibilities).
+However, `supported-targets` is _only_ checked for commands that take a `--target` option and does not affect other commands (e.g., `cargo fmt`).
+
+As this field is limited to local development, `cargo package` / `cargo publish` will strip it from `Cargo.toml`.
+Including the field in the `.crate` file is left as a [future possibility](#future-possibilities) for now.
 
 ## Ignoring builds for unsupported targets
 [ignoring-builds]: #igonring-builds-for-unsupported-targets

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -280,25 +280,27 @@ using it by default. In particular, we should steer users to use this when they 
 believe the crate will not compile or work as expected (e.g. because it uses target-specific APIs),
 and not use it merely for "I haven't personally tested this on other targets".
 
-Even then, it will happen that crates unnecessarily limit their dependents and users, because of 
-over restrictive `supported-targets`. So, users must be able to remove the lint or error.
-To alleviate this, a flag like `--ignore-supported-targets` could be added to `cargo` to ignore the `supported-targets` of a
-package, and a field like
-```toml
-[dependencies]
-overrestrictive-dep = { version = "0.1.0", ignore-supported-targets = true }
-```
-could be added to ignore the `supported-targets` of a specific dependency. This functionality
-could otherwise be added to the [`[patch]` table](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section),
-or be added as mutable metadata in package registries
-([related discussion](https://blog.rust-lang.org/inside-rust/2024/03/26/this-development-cycle-in-cargo-1.78.html#why-is-this-yanked)).
-
-One thing to keep in mind is that disabling the `supported-targets` check for a package or a dependency
-removes the ability to prune the dependency tree of a package. That is because disabling the lint/error
-is equivalent to the package or the dependency supporting all targets. So, either the `--ignore-supported-targets`
-flag has the ability to change lockfile generation (this pattern is advised against), or dependencies are still
-pruned as if the package's `supported-targets` were respected, but the lint/error is ignored. The lockfile
-could also store the state which was used to generate it, but this currently is not implemented in `cargo`.
+Even then, it will happen that crates unnecessarily limit their dependents and users because of 
+overly restrictive `supported-targets`.
+Some options for handling this include
+- Doing nothing, encouraging people to upstream patches
+- Encourage `[patch]`ing the dependency
+  - Requires managing a fork
+  - Every dependent of the package with a questionable `supported-targets` must do this
+- Encourage unidiff `[patch]`es
+  - Design has unresolved questions ([cargo#4648](https://github.com/rust-lang/cargo/issues/4648))
+  - Every dependent of the package with a questionable `supported-targets` must do this
+- A bespoke manifest override
+  - One-off feature that needs design work
+- A CLI override like `--ignore-rust-version`
+  - This precludes `Cargo.lock` trimming as the lockfile is meant to capture dependencies for every potential state a package may be run in
+  - This affects the entire dependency tree and not just the package with questionable `supported-targets`
+  - Every dependent of the package with a questionable `supported-targets` must do this
+- A lint like proposed for `package.rust-version`
+  - Blocked on [cargo#12235](https://github.com/rust-lang/cargo/issues/12235)
+  - See also CLI override
+- Allow a registry database to override `supported-targets`
+  - Blocked on a lot of design work ([related discussion](https://blog.rust-lang.org/inside-rust/2024/03/26/this-development-cycle-in-cargo-1.78.html#why-is-this-yanked))
 
 ### Compatibility of `[dependencies]`
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -305,7 +305,7 @@ name = "bar"
 baz = "0.1.0"
 ```
 Currently, `baz` is included in the dependency tree of `foo`, even though `foo` is never built for `macos`.
-With the addition of `supported-targets`, `baz` can be purged from the dependency tree of `foo`, since
+With the addition of `supported-targets`, `baz` can be pruned from the dependency tree of `foo`, since
 `target_os = "macos"` is mutually exclusive with `target_os = "linux"`.
 
 Formally, dependencies (and transitive dependencies) under `[target.**.dependencies]` tables are
@@ -394,13 +394,15 @@ require an annoyingly long list of wildcard patterns. Things like `target_pointe
 even harder to represent, and things like `target_feature = "avx"` are basically not representable.
 Also, this is new syntax not currently used by cargo.
 
-### Allowing only target triples
+### Allowing only target-triples
 
-This is an even stricter version of the above. Being even simpler to implement, this alternative
-may not be expressive enough for the common use case. Packages rarely support specific target triples,
-rather they support/require specific target attributes. What would likely happen is that packages
-would copy and paste the target triple list matching their requirements from somewhere or someone else.
-Every time a new target with the same attribute is added, the whole ecosystem would have to be updated.
+This is an even stricter version of the above. Set relations between `supported-targets` lists are exact,
+and the resolver can determine if a platform-specific dependency can be pruned from the dependency tree more easily,
+hence why the original proposal chose this format. Being even simpler to implement, this alternative may not be
+expressive enough for the common use case. Packages rarely support specific target triples, rather they
+support/require specific target attributes. What would likely happen is that packages would copy and paste
+the target triple list matching their requirements from somewhere or someone else. Every time a new target
+with the same attribute is added, the whole ecosystem would have to be updated.
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -190,6 +190,13 @@ Using `cfg` complicates the implementation (and thus maintenance), and may requi
 amount of calls to `rustc` to check target-`cfg` compatibility. Some alternatives are discussed here
 along with their drawbacks.
 
+### Target-triples
+
+The initial proposal allowed both the `cfg` syntax and whitelisting specific target-triples, to follow the behavior of [platform-specific
+dependency tables](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies).
+This was removed as it was deemed better to accept targets based on their _attributes_ than on their
+_name_. Indeed, `rustc` supported target-triples have changed names, and have been added or removed in the past.
+
 ### Using wildcards
 
 Instead of using `cfg` specifications, one could use wildcards (e.g., `x86_64-*-linux-*`). This is

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -19,8 +19,8 @@ set of targets which a package supports. Packages can only be built for targets 
 
 # Motivation
 
-Some packages do not support every possible `rustc` target. Currently, there is no way to formally
-specify which targets a package does, or does not support.
+Some packages rely on features or behavior that is not available on every platform `rustc` can target. Currently, there is no way to formally
+specify platform requirements of a package
 
 When working on a project with packages that only build on certain platforms, users cannot run Cargo commands across the entire workspace (e.g. `cargo test --workspace`) but must individually select packages that only work on the specific platform (e.g. `cargo test --workspace --exclude firmware`).  This extends to CI with people wanting to write matrix jobs but have to hand maintain the list of packages for each platform in the matrix.
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -112,10 +112,7 @@ does not satisfy the `supported-targets` of the package, then an error is raised
 
 ## Format
 
-The list of strings format was chosen because of its simplicity and expressiveness. It can be
-unintuitive to understand however, as the list implies a union of all its elements, which is not
-immediately obvious.
-
+The `cfg` string format was chosen because of its simplicity and expressiveness.
 Other formats can be considered:
 
 Using a list of `cfg` strings, and also accepting explicit target-triples:
@@ -126,6 +123,8 @@ supported-targets = [
     "x86_64-pc-windows-gnu",
 ]
 ```
+This can be unintuitive to understand however, as the list implies a union of all its elements,
+which is not immediately obvious.
 
 Using the `[target]` table, for example:
 ```toml
@@ -158,14 +157,6 @@ Some other names for this field can be considered:
 
 The `supported-targets` field is placed at the package level, and not at the cargo-target level
 (i.e., under, `[lib]`, `[[bin]]`, etc.)
-
-Dependencies are resolved at the package level, so even if one would have cargo-targets with
-different `supported-targets`, the dependencies would still be available to all cargo-targets. So,
-either cargo-targets would have access to dependencies that they cannot use, or all dependencies
-would need to support the union of all `supported-targets` of all cargo-targets.
-
-Examples, tests and benchmarks also have access to the package's library and binaries, so they must
-have the same set of `supported-targets`.
 
 It is possible to allow cargo-targets to further restrict the `supported-targets` of the package,
 but this is left as a [future possibility](#future-possibilities).
@@ -205,14 +196,11 @@ added, the whole ecosystem would have to be updated.
 # Prior art
 [prior-art]: #prior-art
 
-Locally, users can already specify which targets they want to build for by default using the
-`target` field in `cargo`'s `config.toml` file. This setting does not affect packages published on
-`crates.io`. On nightly, the `per-package-target` feature defines the `package.default-target` field
-in `Cargo.toml` to specify the default target for a package. Both of these options can be
-overwritten by the `--target` flag, and only work for a single target-triple.
+Users can already select which packages they want to select in a workspace with the flags
+`--package` and `--exclude`.
 
-The `per-package-target` feature also defines the `force-target` field, which is supposed to force
-the package to build for the specific target-triple. This does not interact well when used in
+The `per-package-target` nightly feature defines the `force-target` field, which is supposed to
+force the package to build for a specific target-triple. This does not interact well when used in
 dependencies, as one would expect a dependency to be built for the same target as the package.
 `supported-targets` supersedes `force-target` because instead of enforcing a single target, it
 enforces a set of targets.
@@ -227,10 +215,10 @@ compile_error!("unsupported target cfg");
 [`getrandom`](https://github.com/rust-random/getrandom/blob/9fb4a9a2481018e4ab58d597ecd167a609033149/src/backends.rs#L156-L160)
 is an example of a crate utilizing this method.
 
-I am not aware of a package manager that solves this issue like in this RFC. In other system level
-languages, vendoring dependencies is a common practice, and the user would be responsible for
-ensuring that the dependencies are compatible with the target. For interpreted languages, this is a
-non-issue because any platform being able to run the interpreter can run the package.
+In other system level languages, vendoring dependencies is a common practice, and the user would be
+responsible for ensuring that the dependencies are compatible with the target. For interpreted
+languages, this is a non-issue because any platform being able to run the interpreter can run the
+package.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
@@ -388,8 +376,7 @@ supported-targets = 'cfg(all(target_os = "linux", any(target_arch = "x86_64", ta
 ```
 is transformed into
 ```toml
-supported-targets =
-    'cfg(any(all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "arm")))'
+supported-targets = 'cfg(any(all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "arm")))'
 ```
 If an `all` contains an `all`, the inner `all` is flattened into the outer `all`.
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -330,7 +330,15 @@ with the target preconditions of the dependency.
 
 ## Format
 
-The list of strings format was chosen because of its simplicity and expressiveness. Other formats can also be considered:
+The list of strings format was chosen because of its simplicity and expressiveness. It can be unintuitive
+to understand however, as the list implies a union of all its elements, which is not immediately obvious.
+
+Other formats can be considered:
+
+Using a single `cfg` string, without explicit target-triples:
+```toml
+supported-targets = 'cfg(any(target_family = "unix", target_family = "wasm"))'
+```
 
 Using the `[target]` table, for example:
 ```toml

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -282,6 +282,15 @@ using it by default. In particular, we should steer users to use this when they 
 believe the crate will not compile or work as expected (e.g. because it uses target-specific APIs),
 and not use it merely for "I haven't personally tested this on other targets".
 
+Even then, crates may find themselves unnecessarily limiting their dependents and users. To alleviate this, 
+a flag like `--ignore-supported-targets` could be added to `cargo` to ignore the `supported-targets`
+of a package, and a field like
+```toml
+[dependencies]
+overrestrictive-dep = { version = "0.1.0", ignore-supported-targets = true }
+```
+could be added to ignore the `supported-targets` of a specific dependency.
+
 ### Compatibility of `[dependencies]`
 
 One could restrict the set of `supported-targets` of a package to be a subset of the

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -85,7 +85,8 @@ require a desktop OS, using `supported-targets` makes `cargo <command>` ignore p
 [reference-level-explanation]: #reference-level-explanation
 
 The `supported-targets` field is an optional key that tells cargo which targets the package can be
-built for.
+built for. However, it does not affect which host can build the package i.e., any host can still build
+the package, but only for certain targets.
 ```toml
 [package]
 # ...
@@ -341,6 +342,7 @@ the package's `supported-targets` needs to be a subset of every `[dev-dependenci
 package's library and binaries, and so it must respect the `supported-targets` of the package.
 
 ### Compatibility of `[build-dependencies]`
+[build-dependencies-compatability]: #compatibility-of-build-dependencies
 
 What makes `[build-dependencies]` unique is that they are built for the host computer, and not the
 selected target. As such, they are not restrained by the `supported-targets` of the package. Hence,
@@ -424,6 +426,9 @@ baz = "0.1.0"
 Currently, `baz` is included in the dependency tree of `foo`, even though `foo` is never built for
 `macos`. `baz` could be pruned from the dependency tree of `foo`, since `target_os = "macos"` is
 mutually exclusive with `target_os = "linux"`.
+
+This only applies to `[dependencies]` and `[dev-dependencies]`, as `[build-dependencies]` are
+[not restrained by `supported-targets`](build-dependencies-compatability), so they are not pruned.
 
 Formally, dependencies (and transitive dependencies) under `[target.**.dependencies]` tables are
 eliminated from the dependency tree of a package if the `supported-targets` of the package is

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -117,7 +117,7 @@ build-target, then `cargo` skips any package that does not support the selected 
 is specified using `--package` or if `cargo` is invoked on a single package, and the selected target
 does not satisfy the `supported-targets` of the package, then an error is raised. The intent is to mimic
 the behavior of `required-features` with package filtering based on targets. Hence, `required-targets`
-is proposed as an [alternative name](#Naming).
+is proposed as an [alternative name](#naming).
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -162,6 +162,7 @@ arch = ["x86_64"]
 ```
 
 ## Naming
+[naming]: #Naming
 
 Some other names for this field can be considered:
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -1,57 +1,65 @@
 - Feature Name: `supported-targets`
 - Start Date: 2025-01-08
-- Pre-RFC: [Rust internals](https://internals.rust-lang.org/t/pre-rfc-allow-packages-to-specify-a-set-of-supported-targets/21979)
+- Pre-RFC: [Rust
+  internals](https://internals.rust-lang.org/t/pre-rfc-allow-packages-to-specify-a-set-of-supported-targets/21979)
 - RFC PR: [rust-lang/rfcs#3759](https://github.com/rust-lang/rfcs/pull/3759)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
-The word _target_ is extensively used in this document.
-The [glossary](https://doc.rust-lang.org/cargo/appendix/glossary.html#target) defines its many meanings.
-Here, _target_ refers to the "Target Architecture" for which a package is built. Otherwise, the terms
-"cargo-target" and "target-triple" are used in accordance with their definitions in the glossary.
+The word _target_ is extensively used in this document. The
+[glossary](https://doc.rust-lang.org/cargo/appendix/glossary.html#target) defines its many meanings.
+Here, _target_ refers to the "Target Architecture" for which a package is built. Otherwise, the
+terms "cargo-target" and "target-triple" are used in accordance with their definitions in the
+glossary.
 
 # Summary
 
-The addition of `supported-targets` to `Cargo.toml`.
-This field is an array of `target-triple`/`cfg` specifications that restricts the set of targets which
-a package supports. Packages must meet the `supported-targets` of their
-dependencies, and they can only be built for targets that satisfy their `supported-targets`.
+The addition of `supported-targets` to `Cargo.toml`. This field is an array of `target-triple`/`cfg`
+specifications that restricts the set of targets which a package supports. Packages can only be
+built for targets that satisfy their `supported-targets`.
 
 # Motivation
 
 Some packages do not support every possible `rustc` target. Currently, there is no way to formally
 specify which targets a package does, or does not support.
 
+This feature enhances developer experience when working in workspaces containing packages designed
+for many different targets. Commands run on a workspace ignore packages that don't support the
+    selected target.
+
+## Long-term Motivations
+
+_These do not motivate the RFC itself, rather they motivate the [future
+possibilities](#future-possibilities) section._
+
 ### Developer Experience
 
 Trying to depend on a crate that does not support one's target often produces cryptic build errors,
-or worse, fails at runtime. Being able to specify which targets are supported ensures that unsupported
-targets cannot build the crate, and also makes build errors specific.
-
-This feature also enhances developer experience when working in workspaces containing packages designed for
-many different targets. Commands run on a workspace ignore packages that don't support the selected target.
+or worse, fails at runtime. Being able to specify which targets are supported ensures that
+unsupported targets cannot build the crate, and also makes build errors specific.
 
 ### Dependency Management 
 
-Once it is known that a package will only ever build for a subset of targets, it opens
-the door for more advanced control over dependencies.
-For example, transitive dependencies declared under a `[target.**.dependencies]` table could be
-excluded from `Cargo.lock` if the dependent's `supported-targets` is mutually exclusive with
-the target preconditions under which the dependencies are included.
-This is especially relevant to areas such as WebAssembly and embedded programming,
-where one usually supports only a few specific targets. Currently, auditing and vendoring
-is tedious because dependencies under `[target.**.dependencies]` tables always make their way
-in the dependency tree, even though they may not actually be used.
+Once it is known that a package will only ever build for a subset of targets, it opens the door for
+more advanced control over dependencies. For example, transitive dependencies declared under a
+`[target.**.dependencies]` table could be excluded from `Cargo.lock` if the dependent's
+`supported-targets` are mutually exclusive with the target preconditions under which the
+dependencies are included. This is especially relevant to areas such as WebAssembly and embedded
+programming, where one usually supports only a few specific targets. Currently, auditing and
+vendoring is tedious because dependencies under `[target.**.dependencies]` tables always make their
+way in the dependency tree, even though they may not actually be used.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
 The `supported-targets` field can be added to `Cargo.toml` under the `[package]` table.
 
-This field consists of an array of strings, where each string is an explicit target-triple or a `cfg` specification
-(as for the `[target.'cfg(**)']` table). The supported `cfg` syntax is the same as the one for
-[platform-specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)
-(i.e., `cfg(test)`, `cfg(debug_assertions)`, and `cfg(proc_macro)` are not supported).
-If a selected target satisfies any entry of the `supported-targets` list, then the package can be built for that target.
+This field consists of an array of strings, where each string is an explicit target-triple or a
+`cfg` specification (as for the `[target.'cfg(**)']` table). The supported `cfg` syntax is the same
+as the one for [platform-specific
+dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)
+(i.e., `cfg(test)`, `cfg(debug_assertions)`, and `cfg(proc_macro)` are not supported). If a selected
+target satisfies any entry of the `supported-targets` list, then the package can be built for that
+target.
 
 __For example:__
 ```toml
@@ -65,79 +73,241 @@ supported-targets = [
     'cfg(target_os = "macos")'
 ]
 ```
-Here, only targets satisfying: the `wasm32-unknown-unknown` target, __or__ the `linux` OS, __or__ the `macos` OS,
-are allowed to build the package. If no `supported-targets` was specified, then any target would be allowed.
+Here, only targets satisfying: the `wasm32-unknown-unknown` target, __or__ the `linux` OS, __or__
+the `macos` OS, are allowed to build the package. User experience is enhanced by raising an error
+that fails compilation when the supported targets of a package are not satisfied by the selected
+target.
 
-User experience is enhanced by raising an error that fails compilation when the supported targets
-of a package are not satisfied by the selected target. A package's `supported-targets` must be a subset
-of its dependencies' `supported-targets`, otherwise the build also fails.
+This feature should be used when a package clearly does not support all targets. For example:
+`io-uring` requires `cfg(target_os = "linux")`, `gloo` requires `cfg(target_family = "wasm")`, and
+`riscv` requires `cfg(any(target_arch = "riscv32", target_arch = "riscv64"))`.
 
-When `supported-targets` is not specified, any target is accepted, so all dependencies must support
-all targets.
-
-This feature should be used when a package clearly does not support all targets. For example: `io-uring`
-requires `cfg(target_os = "linux")`, `gloo` requires `cfg(target_family = "wasm")`, and
-`riscv` requires `cfg(target_arch = "riscv32")` or `cfg(target_arch = "riscv64")`.
-
-This feature should also be used to increase cargo's knowledge of a package. For example,
-when working in a workspace where some packages compile with `#[no_std]` and `target_os = "none"`, 
-and some others are tools that require a desktop OS, using `supported-targets` makes
-`cargo <command>` ignore packages which have `supported-targets` that are not satisfied
-by the selected target.
-
-Cargo's documentation should give clear guidance for when to use this field, and should not suggest using it by default. In particular, we should steer users to use this when they have good reason to believe the crate will not compile or work as expected (e.g. because it uses target-specific APIs), and not use it merely for "I haven't personally tested this on other targets".
+This feature increases cargo's knowledge of a package. For example, when working in a workspace
+where some packages are for a platform with `target_os = "none"`, and some others are tools that
+require a desktop OS, using `supported-targets` makes `cargo <command>` ignore packages which have
+`supported-targets` that are not satisfied by the selected target.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run, it checks that
-the selected target satisfies the `supported-targets` of the package being built. If it does not, the package is
-skipped or an error is raised, depending on how [`cargo` was invoked](ignoring-builds). However, `supported-targets`
-are _not_ checked if the cargo command does not require compilation (e.g., `cargo fmt`).
+When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run, it checks that the
+selected target satisfies the `supported-targets` of the package being built. If it does not, the
+package is skipped or an error is raised, depending on how [`cargo` was invoked](ignoring-builds).
+However, `supported-targets` are _not_ checked if the cargo command does not require compilation
+(e.g., `cargo fmt`).
 
-## Compatibility of `[dependencies]`
+## Behavior with unknown entries (and custom targets)
 
-The set of `supported-targets` of a package must be a subset of the `supported-targets` of its
-`[dependencies]`. If the crate itself has no `supported-targets` specified,
-then all dependencies must support all targets.
+Just as `[target.my-custom-target.dependencies]` is allowed by `cargo`, `supported-targets` can
+contain unknown entries. This is important because users may have different `rustc` versions, and
+the set of official `rustc` targets is unstable; Targets can change name or be removed. Also,
+developers may want to support their custom target.
 
-If a dependency does not respect this requirement (if it is not compatible), an error is raised and the build fails.
+To determine if an entry in `supported-targets` is a target name or a `cfg` specification, the same
+mechanism as for `[target.'cfg(..)']` is used (using
+[`cargo-platform`](https://docs.rs/cargo-platform/latest/cargo_platform/index.html)).
 
-If this was not enforced, a package could support targets that are not supported by its dependencies,
-which does not make sense.
+## Ignoring builds for unsupported targets
+[ignoring-builds]: #igonring-builds-for-unsupported-targets
 
-## Compatibility of `[dev-dependencies]`
+If cargo is invoked in a workspace or virtual workspace without specifying a package as
+build-target, then `cargo` skips any package that does not support the selected target. If a package
+is specified using `--package` or if `cargo` is invoked on a single package, and the selected target
+does not satisfy the `supported-targets` of the package, then an error is raised.
 
-`[dev-dependencies]` are checked the using the same method as regular `[dependencies]`. That is, the package's
-`supported-targets` must be a subset of every `[dev-dependencies]`'s `supported-targets`. The rationale is
-that an example, test, or benchmark has access to the package's library and binaries, and so it must respect the
-`supported-targets` of the package.
+# Drawbacks
+[drawbacks]: #drawbacks
 
-## Compatibility of `[build-dependencies]`
+- Once implemented this does not yet solve the problem of dependency pruning in `Cargo.lock`, which
+  is a common use case for this feature.
+- This is the first step towards a target aware `cargo`, which may increase `cargo`'s complexity,
+  and bring more feature requests along these lines.
 
-What makes `[build-dependencies]` unique is that they are built for the host computer,
-and not the selected target. As such, they are not restrained by the `supported-targets`
-of the package. Hence, all dependencies are allowed in the `[build-dependencies]` table.
-However, a build error is raised if one of the build dependencies does not support
-the _host_'s target-triple at build time.
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
 
-In the future, having all build dependencies support all targets could be enforced to ensure
-that a crate can be built on any host. This is left as a [future possibility](#restrict-build-dependencies).
+## Format
 
-## Platform-specific dependencies
-[platform-specific-dependencies]: #platform-specific-dependencies
+The list of strings format was chosen because of its simplicity and expressiveness. It can be
+unintuitive to understand however, as the list implies a union of all its elements, which is not
+immediately obvious.
 
-Platform-specific dependencies are dependencies under the `[target.**]` table. This includes
-normal dependencies, build-dependencies, and dev-dependencies.
+Other formats can be considered:
 
-When platform-specific dependencies are declared, the conditions under which they are
-declared must be a subset of each dependency's `supported-targets`.
-For example, a dependency declared under `[target.'cfg(target_os = "linux")'.dependencies]`
-must at least support the `linux` OS.
+Using a single `cfg` string, without explicit target-triples:
+```toml
+supported-targets = 'cfg(any(target_family = "unix", target_family = "wasm"))'
+```
 
-For regular dependencies and dev-dependencies, it suffices for a platform-specific dependency to support the
-_intersection_ of the package's supported-targets, and the target conditions it is declared under.
-For example:
+Using the `[target]` table, for example:
+```toml
+[target.'cfg(target_os = "linux")']
+supported = true
+```
+If the list of supported targets is long (should it ever be?), then the `Cargo.toml` file becomes
+very verbose as well.
+
+A `[suppported]` table, with `arch = ["<arch>", ...]`, `os = ["<os>", ...]`, `target = ["<target>",
+...]`, etc. This is more verbose, complex to implement, learn, and remember. It is also not obvious
+how `not` and `all` could be represented in this format. For example:
+```toml
+[supported]
+os = ["linux", "macos"]
+arch = ["x86_64"]
+```
+
+## Naming
+
+Some other names for this field can be considered:
+
+- `required-targets`. Pro: it matches with the naming of `required-features`. Con:
+  `required-features` is a list of features that must _all_ be enabled (conjunction), whereas
+  `supported-targets` is a list of targets where _any_ is allowed (disjunction).
+- `targets`. As in "this package _targets_ ...". Pro: Concise. Con: Ambiguous, and could be confused
+  with the `target` table.
+
+## Package scope vs. cargo-target scope
+
+The `supported-targets` field is placed at the package level, and not at the cargo-target level
+(i.e., under, `[lib]`, `[[bin]]`, etc.)
+
+Dependencies are resolved at the package level, so even if one would have cargo-targets with
+different `supported-targets`, the dependencies would still be available to all cargo-targets. So,
+either cargo-targets would have access to dependencies that they cannot use, or all dependencies
+would need to support the union of all `supported-targets` of all cargo-targets.
+
+Examples, tests and benchmarks also have access to the package's library and binaries, so they must
+have the same set of `supported-targets`.
+
+It is possible to allow cargo-targets to further restrict the `supported-targets` of the package,
+but this is left as a [future possibility](#future-possibilities).
+
+See also: [using a package vs. using a workspace](package-vs-workspace).
+
+[package-vs-workspace]:
+#https://blog.rust-lang.org/inside-rust/2024/02/13/this-development-cycle-in-cargo-1-77.html#when-to-use-packages-or-workspaces
+
+## Not using `cfg`
+
+Using `cfg` complicates the implementation (and thus maintenance), and may require a substantial
+amount of calls to `rustc` to check target-`cfg` compatibility. Some alternatives are discussed here
+along with their drawbacks.
+
+### Using wildcards
+
+Instead of using `cfg` specifications, one could use wildcards (e.g., `x86_64-*-linux-*`). This is
+much simpler to implement, target-triples are syntactically checked for a match instead of solving
+set relations for `cfg`. However, this is not as expressive as `cfg`, and does not correctly
+represent the semantics of target-triples. For example, supporting `target_family = "unix"` would
+require an annoyingly long list of wildcard patterns. Things like `target_pointer_width = "32"` are
+even harder to represent, and things like `target_feature = "avx"` are basically not representable.
+Also, this is new syntax not currently used by cargo.
+
+### Allowing only target-triples
+
+This is an even stricter version of the above. Set relations between `supported-targets` lists are
+exact, and the resolver can determine if a platform-specific dependency can be pruned from the
+dependency tree more easily, hence why the original proposal chose this format. Being even simpler
+to implement, this alternative may not be expressive enough for the common use case. Packages rarely
+support specific target-triples, rather they support/require specific target attributes. What would
+likely happen is that packages would copy and paste the target-triple list matching their
+requirements from somewhere or someone else. Every time a new target with the same attribute is
+added, the whole ecosystem would have to be updated.
+
+# Prior art
+[prior-art]: #prior-art
+
+Locally, users can already specify which targets they want to build for by default using the
+`target` field in `cargo`'s `config.toml` file. This setting does not affect packages published on
+`crates.io`. On nightly, the `per-package-target` feature defines the `package.default-target` field
+in `Cargo.toml` to specify the default target for a package. Both of these options can be
+overwritten by the `--target` flag, and only work for a single target-triple.
+
+The `per-package-target` feature also defines the `force-target` field, which is supposed to force
+the package to build for the specific target-triple. This does not interact well when used in
+dependencies, as one would expect a dependency to be built for the same target as the package.
+`supported-targets` supersedes `force-target` because instead of enforcing a single target, it
+enforces a set of targets.
+
+Published crates have mainly used their documentation to specify which targets they support, or they
+would leave it up to the user to infer it. Some crates also made use of compile time errors to
+ensure that `cfg` requirements are met, for example:
+```rust
+#[cfg(not(any(…)))]
+compile_error!("unsupported target cfg");
+```
+[`getrandom`](https://github.com/rust-random/getrandom/blob/9fb4a9a2481018e4ab58d597ecd167a609033149/src/backends.rs#L156-L160)
+is an example of a crate utilizing this method.
+
+I am not aware of a package manager that solves this issue like in this RFC. In other system level
+languages, vendoring dependencies is a common practice, and the user would be responsible for
+ensuring that the dependencies are compatible with the target. For interpreted languages, this is a
+non-issue because any platform being able to run the interpreter can run the package.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What if one wants to exclude a single target-triple? Groups can be excluded with `cfg(not(..))`,
+  but there is currently no way of excluding specific targets (Would anyone ever require this?).
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+## Ensuring proper use of dependencies
+
+By leveraging compilation errors, it would be possible to ensure that a package only uses
+dependencies that support the package's `supported-targets`. This would be done by comparing the
+`supported-targets` of the package with the `supported-targets` of the dependencies.
+
+Cargo's documentation should give clear guidance for when to use this field, and should not suggest
+using it by default. In particular, we should steer users to use this when they have good reason to
+believe the crate will not compile or work as expected (e.g. because it uses target-specific APIs),
+and not use it merely for "I haven't personally tested this on other targets".
+
+### Compatibility of `[dependencies]`
+
+One could restrict the set of `supported-targets` of a package to be a subset of the
+`supported-targets` of its `[dependencies]`. If the crate itself had no `supported-targets`
+specified, then all dependencies would need to support all targets.
+
+If a dependency does not respect this requirement (if it is not compatible), an error would be
+raised and the build would fail.
+
+Enforcing this means a package cannot support targets that are not supported by its dependencies,
+which is a good thing assuming the dependencies have correctly specified their `supported-targets`.
+
+### Compatibility of `[dev-dependencies]`
+
+`[dev-dependencies]` should be checked using the same method as regular `[dependencies]`. That is,
+the package's `supported-targets` needs to be a subset of every `[dev-dependencies]`'s
+`supported-targets`. The rationale is that an example, test, or benchmark has access to the
+package's library and binaries, and so it must respect the `supported-targets` of the package.
+
+### Compatibility of `[build-dependencies]`
+
+What makes `[build-dependencies]` unique is that they are built for the host computer, and not the
+selected target. As such, they are not restrained by the `supported-targets` of the package. Hence,
+all dependencies are allowed in the `[build-dependencies]` table. However, a build error could be
+raised if one of the build dependencies does not support the _host_'s target-triple at build time.
+
+A problem can arise if a crate's build script depends on a package that does not support `target_os
+= "windows"` for example. It would be possible to only allow dependencies supporting all targets in
+`[build-dependencies]`.
+
+
+### Platform-specific dependencies
+
+Platform-specific dependencies are dependencies under the `[target.**]` table. This includes normal
+dependencies, build-dependencies, and dev-dependencies. Rules could be defined to ensure that
+platform-specific dependencies are declared correctly.
+
+When platform-specific dependencies are declared, the conditions under which they are declared
+should be a subset of each dependency's `supported-targets`. For example, a dependency declared
+under `[target.'cfg(target_os = "linux")'.dependencies]` should at least support the `linux` OS.
+
+For regular dependencies and dev-dependencies, it would suffice for a platform-specific dependency
+to support the _intersection_ of the package's supported-targets, and the target conditions it is
+declared under. For example:
 ```toml
 [package]
 # ...
@@ -146,147 +316,36 @@ supported-targets = ['cfg(target_os = "linux")']
 [target.'cfg(target_pointer_width = "64")'.dependencies]
 foo = "0.1.0"
 ```
-Here, it suffices for `foo` to support `cfg(all(target_os = "linux", target_pointer_width = "64"))`.
+Here, it would suffice for `foo` to support `cfg(all(target_os = "linux", target_pointer_width =
+"64"))`.
 
-## Artifact dependencies
-
-If an artifact dependency has a `target` field, then the dependency is not checked against the
-package's `supported-targets`. However, the selected `target` for the dependency must be compatible with
-the dependency's `supported-targets`, or else an error is raised. If the artifact dependency does not have a
-`target` field, then it is checked against the package's `supported-targets`, like any other dependency.
-
-## Comparing `supported-targets`
-
-When comparing two `supported-targets` lists, it is necessary to know if one is a _subset_ of the other,
-or if both are _mutually exclusive_. To proceed, both lists are flattened to
-the same representation, and they are then compared. This process is done internally, and does not
-affect the `Cargo.toml` file.
-
-### Flattening `not`, `any`, and `all` in `cfg` specifications
-[flattening-cfg]: #flattening-not-any-and-all-in-cfg-specifications
-
-Since `cfg` specifications can contain `not`, `any`, and `all` operators, these must be handled.
-This is done by flattening the `cfg` specification to a specific form. This form is equivalent to
-[disjunctive normal form](https://en.wikipedia.org/wiki/Disjunctive_normal_form).
-
-The `not` operator is "passed through" `any` and `all` operators using
-[De Morgan's laws](https://en.wikipedia.org/wiki/De_Morgan%27s_laws), until it reaches a single `cfg`
-specification. For example, `cfg(not(all(target_os = "linux", target_arch = "x86_64")))`
-is equivalent to `cfg(any(not(target_os = "linux"), not(target_arch = "x86_64")))`.
-
-Top level `any` operators are separated into multiple `cfg` specifications. For example,
+This would ensure that a package properly uses dependencies that are not available on all targets.
+Assuming that the crate `io-uring` has `supported-targets = ['cfg(target_os = "linux")']`, a crate
+could depend on it using:
 ```toml
-supported-targets = ['cfg(any(target_os = "linux", target_os = "macos"))']
+[package]
+# ...
+
+[target.'cfg(target_os = "linux")'.dependencies]
+io-uring = "0.1.0"
 ```
-is transformed into
-```toml
-supported-targets = ['cfg(target_os = "linux")', 'cfg(target_os = "macos")']
-```
+This would not be required if the package itself had `supported-targets = ['cfg(target_os =
+"linux")']`.
 
-Top level `all` operators are kept as is, as long as they do not contain nested `any`s or `all`s.
-If there is an `any` inside an `all`, the statement is split into multiple `all` statements.
-For example,
-```toml
-supported-targets = ['cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "arm"))']
-```
-is transformed into
-```toml
-supported-targets = [
-    'cfg(all(target_os = "linux", target_arch = "x86_64"))',
-    'cfg(all(target_os = "linux", target_arch = "arm"))'
-]
-```
-If an `all` contains an `all`, the inner `all` is flattened into the outer `all`.
+### Artifact dependencies
 
-The result of these transformations on a `cfg` specification is a list of `cfg` specifications that 
-either contains a single specification, or an `all` operator with no nested operators.
+If an artifact dependency has a `target` field, then the dependency would not be checked against the
+package's `supported-targets`. However, the selected `target` for the dependency would need to be
+compatible with the dependency's `supported-targets`, or else an error is raised. If the artifact
+dependency does not have a `target` field, then it would be checked against the package's
+`supported-targets`, like any other dependency.
 
-This procedure is run on all `cfg` elements of a `supported-targets` list. The resulting list
-can then be used to evaluate relations. In the end, the flattened representation can only contain
-explicit target-triples, `cfg(A)` containing a single `A`, or `cfg(all(A, B, ...))` with all
-`A, B, ...` being single elements.
-
-### The subset relation
-
-To determine if a `supported-targets` list "A" is a subset of another such list "B", the standard mathematical
-definition of subset is used. That is, "A" is a subset of "B" if and only if each element of "A" is
-contained in "B".
-
-So each element of "A" is compared against each element of "B" using the following rules:
-- A `target-triple` is a subset of another `target-triple` if they are the same.
-- A `target-triple` is a subset of a `cfg(..)` if the `cfg(..)` is satisfied by the `target-triple`.
-- A `cfg(..)` is not a subset of a `target-triple`.
-- A `cfg(all(A, B, ...))` is a subset of a `cfg(all(C, D ...))`,
-    if the list `C, D, ...` is a subset of the list `A, B, ...`.
-
-_Note_: All possible cases have been covered, since `cfg(A) == cfg(all(A))`.
-
-More rules could be defined, but these are left as a [future possibility](#more-cfg-relations).
-
-### Mutual exclusivity
-
-For a `supported-targets` list "A" to be mutually exclusive with another such list "B", each element of "A" must
-be mutually exclusive with _all_ elements of "B" (The inverse is also true).
-
-So each element of "A" is compared against each element of "B" using the following rules:
-- A `target-triple` is mutually exclusive with another `target-triple` if they are different.
-- A `target-triple` is mutually exclusive with a `cfg(..)` if the `cfg(..)` is not satisfied by
-    the `target-triple`.
-- A `cfg(all(A, B, ...))` is mutually exclusive with a `cfg(all(C, D, ...))` if any element of the list
-    `A, B, ...` is mutually exclusive with any element of the list `C, D, ...`.
-
-_Note_: All possible cases have been covered, since `cfg(A) == cfg(all(A))`.
-
-Two `cfg` singletons are mutually exclusive under the following rules:
-- `cfg(A)` is mutually exclusive with `cfg(not(A))`.
-- `cfg(<option> = "A")` is mutually exclusive with `cfg(<option> = "B")` if `A` and `B` are different,
-    and `<option>` has mutually exclusive elements.
-
-Some `cfg` options have mutually exclusive elements, while some do not. What is meant here is, for example,
-`target_arch = "x86_64"` and `target_arch = "arm"` are mutually exclusive (a target-triple cannot have both),
-while `target_feature = "avx"` and `target_feature = "rdrand"` are not.
-
-`cfg` options that have mutually exclusive elements:
-- `target_arch`
-- `target_os`
-- `target_env`
-- `target_abi`
-- `target_endian`
-- `target_pointer_width`
-- `target_vendor`
-
-Those that do not:
-- `target_feature`
-- `target_has_atomic`
-- `target_family`
-
-`target_family = "windows` and `target_family = "unix"` could also be defined as mutually exclusive to
-enhance usability, but this is left as a [future possibility](#more-cfg-relations).
-
-## Behavior with unknown entries (and custom targets)
-
-Just as `[target.my-custom-target.dependencies]` is allowed by `cargo`, `supported-targets` can contain
-unknown entries. This is important because users may have different `rustc` versions, and the set of
-official `rustc` targets is unstable; Targets can change name or be removed. Also, developers 
-may want to support their custom target.
-
-To determine if an entry in `supported-targets` is a target name or a `cfg` specification, the
-same mechanism as for `[target.'cfg(..)']` is used (using
-[`cargo-platform`](https://docs.rs/cargo-platform/latest/cargo_platform/index.html)).
-
-## Ignoring builds for unsupported targets
-[ignoring-builds]: #igonring-builds-for-unsupported-targets
-
-When the target used is not supported by the package being built, the package will either be
-skipped or an error will be raised, depending on how `cargo` was invoked. If cargo is invoked
-in a workspace or virtual workspace without specifying a specific package, then `cargo` skips the package.
-If a specific package is specified using `--package`, or if `cargo` is invoked on a single package,
-then an error is raised.
 
 ## Eliminating unused dependencies from `Cargo.lock`
 
-A package's dependencies may themselves have `[target.'cfg(..)'.dependencies]` tables, which may never be used because of the
-`supported-targets` restrictions of the package. These can safely be eliminated from the dependency tree of the package.
+A package's dependencies may themselves have `[target.'cfg(..)'.dependencies]` tables, which may
+never be used because of the `supported-targets` restrictions of the package. These can safely be
+eliminated from the dependency tree of the package.
 
 Consider the following example:
 ```toml
@@ -305,162 +364,154 @@ name = "bar"
 [target.'cfg(target_os = "macos")'.dependencies]
 baz = "0.1.0"
 ```
-Currently, `baz` is included in the dependency tree of `foo`, even though `foo` is never built for `macos`.
-With the addition of `supported-targets`, `baz` can be pruned from the dependency tree of `foo`, since
-`target_os = "macos"` is mutually exclusive with `target_os = "linux"`.
+Currently, `baz` is included in the dependency tree of `foo`, even though `foo` is never built for
+`macos`. `baz` could be pruned from the dependency tree of `foo`, since `target_os = "macos"` is
+mutually exclusive with `target_os = "linux"`.
 
 Formally, dependencies (and transitive dependencies) under `[target.**.dependencies]` tables are
-eliminated from the dependency tree of a package if the `supported-targets` of the package is mutually exclusive
-with the target preconditions of the dependency.
+eliminated from the dependency tree of a package if the `supported-targets` of the package is
+mutually exclusive with the target preconditions of the dependency.
 
-# Drawbacks
-[drawbacks]: #drawbacks
+## Comparing `supported-targets`
 
-- The `cfg` syntax is very expressive, but also very complex. As outlined above,
-    detecting subset and mutual exclusivity relations is not trivial.
-- Comparing `supported-targets` lists is an `O(n * m)` operation, with `n` and `m` being the number of elements
-    in the lists. (I doubt this will be a problem, as `n` and `m` are expected to be small).
-- Performance: this is a lot of extra calls to rustc.
-    Hopefully these are all compatible with the rustc cache, so they won't make things too bad.
-- This feature must be learned by those wanting to use dependencies with `supported-targets` specified.
-- This is the first step towards a target aware `cargo`, which may increase `cargo`'s complexity, and bring
-    more feature requests along these lines.
+To prune the dependency tree, and to ensure proper use of dependencies, it becomes necessary to
+compare `supported-targets` lists. When comparing two `supported-targets` lists, it is necessary to
+know if one is a _subset_ of the other, or if both are _mutually exclusive_. To proceed, both lists
+are flattened to the same representation, and they are then compared. This process is done
+internally, and does not affect the `Cargo.toml` file.
 
-# Rationale and alternatives
-[rationale-and-alternatives]: #rationale-and-alternatives
+### Flattening `not`, `any`, and `all` in `cfg` specifications [flattening-cfg]:
+#flattening-not-any-and-all-in-cfg-specifications
 
-## Format
+Since `cfg` specifications can contain `not`, `any`, and `all` operators, these must be handled.
+This is done by flattening the `cfg` specification to a specific form. This form is equivalent to
+[disjunctive normal form](https://en.wikipedia.org/wiki/Disjunctive_normal_form).
 
-The list of strings format was chosen because of its simplicity and expressiveness. It can be unintuitive
-to understand however, as the list implies a union of all its elements, which is not immediately obvious.
+The `not` operator is "passed through" `any` and `all` operators using [De Morgan's
+laws](https://en.wikipedia.org/wiki/De_Morgan%27s_laws), until it reaches a single `cfg`
+specification. For example, `cfg(not(all(target_os = "linux", target_arch = "x86_64")))` is
+equivalent to `cfg(any(not(target_os = "linux"), not(target_arch = "x86_64")))`.
 
-Other formats can be considered:
-
-Using a single `cfg` string, without explicit target-triples:
+Top level `any` operators are separated into multiple `cfg` specifications. For example,
 ```toml
-supported-targets = 'cfg(any(target_family = "unix", target_family = "wasm"))'
+supported-targets = ['cfg(any(target_os = "linux", target_os = "macos"))']
 ```
-
-Using the `[target]` table, for example:
+is transformed into
 ```toml
-[target.'cfg(target_os = "linux")']
-supported = true
+supported-targets = ['cfg(target_os = "linux")', 'cfg(target_os = "macos")']
 ```
-If the list of supported targets is long (should it ever be?), then the `Cargo.toml` file becomes very verbose
-as well.
 
-A `[suppported]` table, with `arch = ["<arch>", ...]`, `os = ["<os>", ...]`, `target = ["<target>", ...]`, etc.
-This is more verbose, complex to implement, learn, and remember. It is also not obvious how `not` and `all`
-could be represented in this format. For example:
+Top level `all` operators are kept as is, as long as they do not contain nested `any`s or `all`s. If
+there is an `any` inside an `all`, the statement is split into multiple `all` statements. For
+example,
 ```toml
-[supported]
-os = ["linux", "macos"]
-arch = ["x86_64"]
+supported-targets = ['cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "arm"))']
 ```
-
-## Naming
-
-Some other names for this field can be considered:
-
-- `required-targets`. Pro: it matches with the naming of `required-features`. Con: `required-features` is a list of features
-    that must _all_ be enabled (conjunction), whereas `supported-targets` is a list of targets
-    where _any_ is allowed (disjunction).
-- `targets`. As in "this package _targets_ ...". Pro: Concise. Con: Ambiguous, and could be confused with the `target` table.
-
-## Package scope vs. cargo-target scope
-
-The `supported-targets` field is placed at the package level, and not at the cargo-target
-level (i.e., under, `[lib]`, `[[bin]]`, etc.)
-
-Dependencies are resolved at the package level, so even if one would have cargo-targets with different
-`supported-targets`, the dependencies would still be available to all cargo-targets. So, either
-cargo-targets would have access to dependencies that they cannot use, or all dependencies would need
-to support the union of all `supported-targets` of all cargo-targets.
-
-Examples, tests and benchmarks also have access to the package's library and binaries, so they must have the
-same set of `supported-targets`.
-
-It is possible to allow cargo-targets to further restrict the `supported-targets` of the package,
-but this is left as a [future possibility](#future-possibilities).
-
-See also: [using a package vs. using a workspace](package-vs-workspace).
-
-[package-vs-workspace]: #https://blog.rust-lang.org/inside-rust/2024/02/13/this-development-cycle-in-cargo-1-77.html#when-to-use-packages-or-workspaces
-
-## Not using `cfg`
-
-Using `cfg` complicates the implementation (and thus maintenance), and may require a substantial
-amount of calls to `rustc` to check target-`cfg` compatibility. Some alternatives are discussed
-here along with their drawbacks.
-
-### Using wildcards
-
-Instead of using `cfg` specifications, one could use wildcards (e.g., `x86_64-*-linux-*`).
-This is much simpler to implement, target-triples are syntactically checked for a match instead
-of solving set relations for `cfg`. However, this is not as expressive as `cfg`, and does not correctly
-represent the semantics of target triples. For example, supporting `target_family = "unix"` would
-require an annoyingly long list of wildcard patterns. Things like `target_pointer_width = "32"` are
-even harder to represent, and things like `target_feature = "avx"` are basically not representable.
-Also, this is new syntax not currently used by cargo.
-
-### Allowing only target-triples
-
-This is an even stricter version of the above. Set relations between `supported-targets` lists are exact,
-and the resolver can determine if a platform-specific dependency can be pruned from the dependency tree more easily,
-hence why the original proposal chose this format. Being even simpler to implement, this alternative may not be
-expressive enough for the common use case. Packages rarely support specific target triples, rather they
-support/require specific target attributes. What would likely happen is that packages would copy and paste
-the target triple list matching their requirements from somewhere or someone else. Every time a new target
-with the same attribute is added, the whole ecosystem would have to be updated.
-
-# Prior art
-[prior-art]: #prior-art
-
-Previously, crates have mainly used their documentation to specify which targets they support, or they would
-leave it up to the user to infer it. Some crates also made use of compile time errors to ensure that
-`cfg` requirements are met, for example:
-```rust
-#[cfg(not(any(…)))]
-compile_error!("unsupported target cfg");
+is transformed into
+```toml
+supported-targets = [
+    'cfg(all(target_os = "linux", target_arch = "x86_64"))',
+    'cfg(all(target_os = "linux", target_arch = "arm"))'
+]
 ```
-[`getrandom`](https://github.com/rust-random/getrandom/blob/9fb4a9a2481018e4ab58d597ecd167a609033149/src/backends.rs#L156-L160)
-is an example of a crate utilizing this method.
+If an `all` contains an `all`, the inner `all` is flattened into the outer `all`.
 
-Locally, users can already specify which targets they want to build for by default using the `target` field in
-`cargo`'s `config.toml` file. This setting is only a local configuration however, and does not affect
-packages published on `crates.io`. On nightly, the `per-package-target` feature defines the `default-target` field
-of the `[package]` table in `Cargo.toml` to specify the default target for a package. Both of these options
-can be overwritten by the `--target` flag, and only work for a single target-triple.
+The result of these transformations on a `cfg` specification is a list of `cfg` specifications that
+either contains a single specification, or an `all` operator with no nested operators.
 
-The `per-package-target` feature also defines the `force-target` field, which is supposed to force the package
-to build for the specific target-triple. This does not interact well when used in dependencies, as one would expect a dependency
-to be built for the same target as the package. `supported-targets` supersedes `force-target` because instead of enforcing
-a single target, it enforces a set of targets.
+This procedure is run on all `cfg` elements of a `supported-targets` list. The resulting list can
+then be used to evaluate relations. In the end, the flattened representation can only contain
+explicit target-triples, `cfg(A)` containing a single `A`, or `cfg(all(A, B, ...))` with all `A, B,
+...` being single elements.
 
-I am not aware of a package manager that solves this issue like in this RFC. In other system level languages,
-vendoring dependencies is a common practice, and the user would be responsible for ensuring that the dependencies
-are compatible with the target. For interpreted languages, this is a non-issue because any platform being able
-to run the interpreter can run the package.
+### The subset relation
 
-# Unresolved questions
-[unresolved-questions]: #unresolved-questions
+To determine if a `supported-targets` list "A" is a subset of another such list "B", the standard
+mathematical definition of subset is used. That is, "A" is a subset of "B" if and only if each
+element of "A" is contained in "B".
 
-- What if one wants to exclude a single target-triple? Groups can be excluded with `cfg(not(..))`, but there
-	is currently no way of excluding specific targets (Would anyone ever require this?).
-- Some crates will inevitably have target requirements that are too strict, how
-    do we make users bypass the error (probably with some `--ignore-**` flag)? Do we want to allow this?
-- Should we solve for this during dependency version resolution? (the current rationale is that we do not want
-	targets to affect package version resolution).
+So each element of "A" is compared against each element of "B" using the following rules:
+- A `target-triple` is a subset of another `target-triple` if they are the same.
+- A `target-triple` is a subset of a `cfg(..)` if the `cfg(..)` is satisfied by the `target-triple`.
+- A `cfg(..)` is not a subset of a `target-triple`.
+- A `cfg(all(A, B, ...))` is a subset of a `cfg(all(C, D ...))`, if the list `C, D, ...` is a subset
+  of the list `A, B, ...`.
 
-# Future possibilities
-[future-possibilities]: #future-possibilities
+_Note_: All possible cases have been covered, since `cfg(A) == cfg(all(A))`.
 
-## Restrict build dependencies
-[restrict-build-dependencies]: #restrict-build-dependencies
+### Mutual exclusivity
 
-Currently, a build script can have any dependency. A problem can arise if a crate's build script depends on
-a package that does not support `target_os = "windows"` for example. With this RFC, it would be
-possible to only allow dependencies supporting all targets in build scripts.
+For a `supported-targets` list "A" to be mutually exclusive with another such list "B", each element
+of "A" must be mutually exclusive with _all_ elements of "B" (The inverse is also true).
+
+So each element of "A" is compared against each element of "B" using the following rules:
+- A `target-triple` is mutually exclusive with another `target-triple` if they are different.
+- A `target-triple` is mutually exclusive with a `cfg(..)` if the `cfg(..)` is not satisfied by the
+  `target-triple`.
+- A `cfg(all(A, B, ...))` is mutually exclusive with a `cfg(all(C, D, ...))` if any element of the
+  list `A, B, ...` is mutually exclusive with any element of the list `C, D, ...`.
+
+_Note_: All possible cases have been covered, since `cfg(A) == cfg(all(A))`.
+
+Two `cfg` singletons are mutually exclusive under the following rules:
+- `cfg(A)` is mutually exclusive with `cfg(not(A))`.
+- `cfg(<option> = "A")` is mutually exclusive with `cfg(<option> = "B")` if `A` and `B` are
+  different, and `<option>` has mutually exclusive elements.
+
+Some `cfg` options have mutually exclusive elements, while some do not. What is meant here is, for
+example, `target_arch = "x86_64"` and `target_arch = "arm"` are mutually exclusive (a target-triple
+cannot have both), while `target_feature = "avx"` and `target_feature = "rdrand"` are not.
+
+`cfg` options that have mutually exclusive elements:
+- `target_arch`
+- `target_os`
+- `target_env`
+- `target_abi`
+- `target_endian`
+- `target_pointer_width`
+- `target_vendor`
+
+Those that do not:
+- `target_feature`
+- `target_has_atomic`
+- `target_family`
+
+### More `cfg` relations
+
+Even more relations could be defined. Consider the following scenario:
+```toml
+[package]
+name = "bar"
+supported-targets = ['cfg(target_family = "unix")']
+# ...
+```
+```toml
+[package]
+name = "foo"
+supported-targets = ['cfg(target_os = "macos")']
+
+[dependencies]
+bar = "0.1.0"
+```
+This could compile if `target_os = "macos"` was a subset of `target_family = "unix"`.
+
+Specifically, two extra relations can be defined:
+- `cfg(target_os = "windows")` ⊆ `cfg(target_family = "windows")`.
+- `cfg(target_os = <unix-os>)` ⊆ `cfg(target_family = "unix")`, where `<unix-os>` is any of
+  `["freebsd", "linux", "netbsd", "redox", "illumos", "fuchsia", "emscripten", "android", "ios",
+  "macos", "solaris"]`. This list needs to be updated if a new `unix` OS is supported by `rustc`'s
+  official target list. This would make the first example compile.
+
+_Note:_ The contrapositive of these relations is also true.
+
+Also, `target_family` is currently defined as not having mutually exclusive elements. This is
+because `target_family = "wasm"` is not mutually exclusive with other target families. But,
+`target_family = "unix"` could be defined as mutually exclusive with `target_family = "windows"` to
+increase usability. By extension, `target_family = "windows"` would now be mutually exclusive with
+`target_os = "linux"`, for example.
+
+_Note:_ More relations could be defined, for example `target_feature = "neon"` ⊆ `target_arch =
+"arm"`. With this however, things start to get complicated.
 
 ## Lint against useless target-specific tables
 
@@ -476,65 +527,18 @@ supported-targets = ['cfg(target_os = "linux")']
 ```
 A lint could be added to highlight the fact that the `[target]` table is useless.
 
-## More `cfg` relations
-[more-cfg-relations]: #more-cfg-relations
-
-Consider the following scenario:
-```toml
-[package]
-name = "bar"
-supported-targets = ['cfg(target_family = "unix")']
-# ...
-```
-```toml
-[package]
-name = "foo"
-supported-targets = ['cfg(target_os = "macos")']
-
-[dependencies]
-bar = "0.1.0"
-```
-With the RFC implemented, a build error would be raised when compiling `foo`, because `cargo`
-does not understand that `target_os = "macos"` is a subset of `target_family = "unix"`.
-
-To go around this issue, `foo` would need to use:
-```toml
-[package]
-name = "foo"
-supported-targets = ['cfg(all(target_family = "unix", target_os = "macos"))']
-
-[dependencies]
-bar = "0.1.0"
-```
-
-To improve usability, two extra relations can be defined:
-- `cfg(target_os = "windows")` ⊆ `cfg(target_family = "windows")`.
-- `cfg(target_os = <unix-os>)` ⊆ `cfg(target_family = "unix")`, where `<unix-os>` is any of
-    `["freebsd", "linux", "netbsd", "redox", "illumos", "fuchsia", "emscripten", "android", "ios", "macos", "solaris"]`.
-    This list needs to be updated if a new `unix` OS is supported by `rustc`'s official target list.
-This would make the first example compile.
-
-_Note:_ The contrapositive of these relations is also true.
-
-Also, `target_family` is currently defined as not having mutually exclusive elements. This is because `target_family = "wasm"`
-is not mutually exclusive with other target families. But, `target_family = "unix"` could be defined as mutually exclusive
-with `target_family = "windows"` to increase usability. By extension, `target_family = "windows"` would now be mutually exclusive
-with `target_os = "linux"`, for example.
-
-_Note:_ More relations could be defined, for example `target_feature = "neon"` ⊆ `target_arch = "arm"`. With this however,
-things start to get complicated.
-
 ## `supported-targets` at the cargo-target level
 
-The `supported-targets` field could also be added at the cargo-target level to have
-more fine-grained control over which targets a cargo-target supports. This would function
-similarly to the `edition` field, which is available at both the package and the cargo-target level.
-The `supported-targets` of a cargo-target would most likely need to be a subset of the package's `supported-targets`.
+The `supported-targets` field could also be added at the cargo-target level to have more
+fine-grained control over which targets a cargo-target supports. This would function similarly to
+the `edition` field, which is available at both the package and the cargo-target level. The
+`supported-targets` of a cargo-target would most likely need to be a subset of the package's
+`supported-targets`.
 
 ## Interaction with crate features
 
-Currently, crate `[features]` and `supported-targets` do not interact. It is possible however that
-a crate feature interacts with the set of `supported-targets`, either by restraining or expanding it.
+Currently, crate `[features]` and `supported-targets` do not interact. It is possible however that a
+crate feature interacts with the set of `supported-targets`, either by restraining or expanding it.
 It could be possible to allow crate features to modify the `supported-targets` of a package.
 
 ## Misc

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -88,10 +88,10 @@ by the selected target.
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run on a package, it checks that the selected target satisfies the `supported-targets`
-of the package. If it does not, an error is raised and the build fails. However, `supported-targets`
-is _not_ checked if the cargo command does not require compilation (`cargo doc`, `cargo fmt`, etc.).
-For example, `cargo doc` can be run on a host that the package does not support.
+When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run on a package, it checks that
+the selected target satisfies the `supported-targets` of the package. If it does not, an error is raised
+and the build fails. However, `supported-targets` is _not_ checked if the cargo command does not require
+compilation (e.g., `cargo fmt`).
 
 ## Compatibility of `[dependencies]`
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -89,7 +89,9 @@ by the selected target.
 [reference-level-explanation]: #reference-level-explanation
 
 When `cargo` is run on a package, it checks that the selected target satisfies the `supported-targets`
-of the package. If it does not, an error is raised and the build fails.
+of the package. If it does not, an error is raised and the build fails. However, `supported-targets`
+is _not_ checked if the cargo command does not require compilation (`cargo doc`, `cargo fmt`, etc.).
+For example, `cargo doc` can be run on a host that the package does not support.
 
 ## Compatibility of `[dependencies]`
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -166,7 +166,8 @@ affect the `Cargo.toml` file.
 [flattening-cfg]: #flattening-not-any-and-all-in-cfg-specifications
 
 Since `cfg` specifications can contain `not`, `any`, and `all` operators, these must be handled.
-This is done by flattening the `cfg` specification to a specific form.
+This is done by flattening the `cfg` specification to a specific form. This form is equivalent to
+[disjunctive normal form](https://en.wikipedia.org/wiki/Disjunctive_normal_form).
 
 The `not` operator is "passed through" `any` and `all` operators using
 [De Morgan's laws](https://en.wikipedia.org/wiki/De_Morgan%27s_laws), until it reaches a single `cfg`

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -358,7 +358,7 @@ Some other names for this field can be considered:
 ## Package scope vs. cargo-target scope
 
 The `supported-targets` field is placed at the package level, and not at the cargo-target
-level (i.e., under, `[lib]`, `[[bin]]`, etc.). A rationale is given for why the cargo-target level is not used.
+level (i.e., under, `[lib]`, `[[bin]]`, etc.)
 
 Dependencies are resolved at the package level, so even if one would have cargo-targets with different
 `supported-targets`, the dependencies would still be available to all cargo-targets. So, either

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -221,7 +221,9 @@ added, the whole ecosystem would have to be updated.
 [prior-art]: #prior-art
 
 Users can already select which packages they want to select in a workspace with the flags
-`--package` and `--exclude`.
+`--package` and `--exclude`. Cargo features can also be used to restrict which cargo-target
+is built using the `required-features` field. However, `required-features` does not allow filtering
+packages at the workspace level, nor does it allow filtering out the library of a package.
 
 The `per-package-target` nightly feature defines the `force-target` field, which is supposed to
 force the package to build for a specific target-triple. This does not interact well when used in

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -282,14 +282,18 @@ using it by default. In particular, we should steer users to use this when they 
 believe the crate will not compile or work as expected (e.g. because it uses target-specific APIs),
 and not use it merely for "I haven't personally tested this on other targets".
 
-Even then, crates may find themselves unnecessarily limiting their dependents and users. To alleviate this, 
-a flag like `--ignore-supported-targets` could be added to `cargo` to ignore the `supported-targets`
-of a package, and a field like
+Even then, it will happen that crates unnecessarily limit their dependents and users, because of 
+over restrictive `supported-targets`. So, users must be able to disable the lint or error.
+To alleviate this, a flag like `--ignore-supported-targets` could be added to `cargo` to ignore the `supported-targets` of a
+package, and a field like
 ```toml
 [dependencies]
 overrestrictive-dep = { version = "0.1.0", ignore-supported-targets = true }
 ```
-could be added to ignore the `supported-targets` of a specific dependency.
+could be added to ignore the `supported-targets` of a specific dependency. This functionality
+could otherwise be added to the [`[patch]` table](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section),
+or be added as mutable metadata in package registries
+([related discussion](https://blog.rust-lang.org/inside-rust/2024/03/26/this-development-cycle-in-cargo-1.78.html#why-is-this-yanked)).
 
 ### Compatibility of `[dependencies]`
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -29,11 +29,9 @@ When working on a project with packages that only build on certain platforms, us
 This RFC unblocks further work to improve platform-specific packages.  While these problems are important, solving them has been left to  [future
 possibilities](#future-possibilities) to deliver an MVP we can then build on.
 
-### Developer Experience
+### More specific error messages
 
-Trying to depend on a crate that does not support one's target often produces cryptic build errors,
-or worse, fails at runtime. Being able to specify which targets are supported ensures that
-unsupported targets cannot build the crate, and also makes build errors specific.
+The error message when a library has platform-specific features, like requiring atomics, is about parts of `std` missing which could be for one of several reasons. Some of these problems won't be found until you've built or tested your project on one of these platforms. Like with #2495, if library authors could provide this information to Cargo, developers can get an improved error message under any circumstance.
 
 ### Dependency Management 
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -478,6 +478,9 @@ supported-targets = 'cfg(target_os = "linux")'
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # ...
+```
+
+A lint could be added to highlight the fact that the `[target]` table is unused.
 
 ## `supported-targets` at the cargo-target level
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -96,7 +96,7 @@ and does __not__ accept `cfg(test)`, `cfg(debug_assertions)`, nor `cfg(proc_macr
 A malformed `supported-targets` field will raise an error.
 
 If the `supported-targets` field is not present, then the package is assumed to support all targets. That is,
-the default value is `'cfg(all())'`.
+the default value is `'cfg(all())'` (understood as `cfg(true)`).
 
 When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run, it checks that the
 selected target satisfies the `supported-targets` of the package being built. If it does not, the

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -1,7 +1,7 @@
 - Feature Name: `supported-targets`
 - Start Date: 2025-01-08
 - Pre-RFC: [Rust internals](https://internals.rust-lang.org/t/pre-rfc-allow-packages-to-specify-a-set-of-supported-targets/21979)
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3759](https://github.com/rust-lang/rfcs/pull/3759)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 The word _target_ is extensively used in this document.

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -115,7 +115,9 @@ This field is subject to [workspace inheritance](https://doc.rust-lang.org/cargo
 If cargo is invoked in a workspace or virtual workspace without specifying a package as
 build-target, then `cargo` skips any package that does not support the selected target. If a package
 is specified using `--package` or if `cargo` is invoked on a single package, and the selected target
-does not satisfy the `supported-targets` of the package, then an error is raised.
+does not satisfy the `supported-targets` of the package, then an error is raised. The intent is to mimic
+the behavior of `required-features` with package filtering based on targets. Hence, `required-targets`
+is proposed as an [alternative name](#Naming).
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -29,10 +29,6 @@ When working on a project with packages that only build on certain platforms, us
 This RFC unblocks further work to improve platform-specific packages.  While these problems are important, solving them has been left to  [future
 possibilities](#future-possibilities) to deliver an MVP we can then build on.
 
-### More specific error messages
-
-The error message when a library has platform-specific features, like requiring atomics, is about parts of `std` missing which could be for one of several reasons. Some of these problems won't be found until you've built or tested your project on one of these platforms. Like with #2495, if library authors could provide this information to Cargo, developers can get an improved error message under any circumstance.
-
 ### Include fewer packages with `cargo vendor`
 
 `Cargo.lock`, and by extension, `cargo vendor`, must assume that a package may be built on any platform that has or will exist.  This means that if a transitive dependency pulls in Windows-specific dependencies, `cargo vendor` will include them when run on a Linux-only application.  Being able to tell `cargo vendor` what platforms to care about can reduce the space used in a repo and reduce churn.
@@ -40,6 +36,10 @@ The error message when a library has platform-specific features, like requiring 
 ### Dependency Management 
 
 Likewise, today users either need to audit dependencies irrelevant for the platforms they target or filter these out somehow.  By providing first-class support for specifying what platform features a package requires, audit tools can consolidate on that for narrowing down the list of what dependencies to audit.
+
+### More specific error messages
+
+The error message when a library has platform-specific features, like requiring atomics, is about parts of `std` missing which could be for one of several reasons. Some of these problems won't be found until you've built or tested your project on one of these platforms. Like with #2495, if library authors could provide this information to Cargo, developers can get an improved error message under any circumstance.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -423,6 +423,8 @@ leave it up to the user to infer it. Some crates also made use of compile time e
 #[cfg(not(any(…)))]
 compile_error!("unsupported target cfg");
 ```
+[`getrandom`](https://github.com/rust-random/getrandom/blob/9fb4a9a2481018e4ab58d597ecd167a609033149/src/backends.rs#L156-L160)
+is an example of a crate utilizing this method.
 
 Locally, users can already specify which targets they want to build for by default using the `target` field in
 `cargo`'s `config.toml` file. This setting is only a local configuration however, and does not affect

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -87,7 +87,9 @@ When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run, it
 selected target satisfies the `supported-targets` of the package being built. If it does not, the
 package is skipped or an error is raised, depending on how [`cargo` was invoked](ignoring-builds).
 However, `supported-targets` are _not_ checked if the cargo command does not require compilation
-(e.g., `cargo fmt`).
+(e.g., `cargo fmt`). This field is only for local development, and is removed from `Cargo.toml`
+when publishing a crate. It could be published to give more information to `docs.rs`, `crates.io`,
+and `cargo` itself, but this is left as a [future possibility](#future-possibilities).
 
 ## Ignoring builds for unsupported targets
 [ignoring-builds]: #igonring-builds-for-unsupported-targets

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -90,10 +90,10 @@ Cargo's documentation should give clear guidance for when to use this field, and
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run on a package, it checks that
-the selected target satisfies the `supported-targets` of the package. If it does not, an error is raised
-and the build fails. However, `supported-targets` is _not_ checked if the cargo command does not require
-compilation (e.g., `cargo fmt`).
+When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run, it checks that
+the selected target satisfies the `supported-targets` of the package being built. If it does not, the package is
+skipped or an error is raised, depending on how [`cargo` was invoked](ignoring-builds). However, `supported-targets`
+are _not_ checked if the cargo command does not require compilation (e.g., `cargo fmt`).
 
 ## Compatibility of `[dependencies]`
 
@@ -274,6 +274,7 @@ same mechanism as for `[target.'cfg(..)']` is used (using
 [`cargo-platform`](https://docs.rs/cargo-platform/latest/cargo_platform/index.html)).
 
 ## Ignoring builds for unsupported targets
+[ignoring-builds]: #igonring-builds-for-unsupported-targets
 
 When the target used is not supported by the package being built, the package will either be
 skipped or an error will be raised, depending on how `cargo` was invoked. If cargo is invoked

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -184,9 +184,9 @@ See also: [using a package vs. using a workspace](package-vs-workspace).
 [package-vs-workspace]:
 #https://blog.rust-lang.org/inside-rust/2024/02/13/this-development-cycle-in-cargo-1-77.html#when-to-use-packages-or-workspaces
 
-## Not using `cfg`
+## Field format 
 
-Using `cfg` complicates the implementation (and thus maintenance), and may require a substantial
+Using the `cfg` syntax complicates the implementation (and thus maintenance), and may require a substantial
 amount of calls to `rustc` to check target-`cfg` compatibility. Some alternatives are discussed here
 along with their drawbacks.
 
@@ -194,8 +194,9 @@ along with their drawbacks.
 
 The initial proposal allowed both the `cfg` syntax and whitelisting specific target-triples, to follow the behavior of [platform-specific
 dependency tables](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies).
-This was removed as it was deemed better to accept targets based on their _attributes_ than on their
+This was removed as it was deemed better to accept targets based on their _attributes_ rather than on their
 _name_. Indeed, `rustc` supported target-triples have changed names, and have been added or removed in the past.
+Target-triple names also do not encapsulate the semantics of the target.
 
 ### Using wildcards
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -26,8 +26,8 @@ When working on a project with packages that only build on certain platforms, us
 
 ## Long-term Motivations
 
-_These do not motivate the RFC itself, rather they motivate the [future
-possibilities](#future-possibilities) section._
+This RFC unblocks further work to improve platform-specific packages.  While these problems are important, solving them has been left to  [future
+possibilities](#future-possibilities) to deliver an MVP we can then build on.
 
 ### Developer Experience
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -120,8 +120,6 @@ does not satisfy the `supported-targets` of the package, then an error is raised
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- Once implemented this does not yet solve the problem of dependency pruning in `Cargo.lock`, which
-  is a common use case for this feature.
 - This is the first step towards a target aware `cargo`, which may increase `cargo`'s complexity,
   and bring more feature requests along these lines.
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -531,6 +531,12 @@ more fine-grained control over which targets a cargo-target supports. This would
 similarly to the `edition` field, which is available at both the package and the cargo-target level.
 The `supported-targets` of a cargo-target would most likely need to be a subset of the package's `supported-targets`.
 
+## Interaction with crate features
+
+Currently, crate `[features]` and `supported-targets` do not interact. It is possible however that
+a crate feature interacts with the set of `supported-targets`, either by restraining or expanding it.
+It could be possible to allow crate features to modify the `supported-targets` of a package.
+
 ## Misc
 
 - Have `cargo add` check the `supported-targets` before adding a dependency.

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -226,7 +226,7 @@ added, the whole ecosystem would have to be updated.
 Users can already select which packages they want to select in a workspace with the flags
 `--package` and `--exclude`. Cargo features can also be used to restrict which cargo-target
 is built using the `required-features` field. However, `required-features` does not allow filtering
-packages at the workspace level, nor does it allow filtering out the library of a package.
+packages in a workspace, nor does it allow filtering out the library of a package.
 
 The `per-package-target` nightly feature defines the `force-target` field, which is supposed to
 force the package to build for a specific target-triple. This does not interact well when used in

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -515,6 +515,14 @@ the `edition` field, which is available at both the package and the cargo-target
 `supported-targets` of a cargo-target would most likely need to be a subset of the package's
 `supported-targets`.
 
+This could also allow for a cargo-target to be swapped out based on the selected target. For example,
+we could specify which binary should be used as `main` based on the selected target
+[#9208](https://github.com/rust-lang/cargo/issues/9208).
+.
+
+This could also help WebAssembly targets, as `wasm` executables need to be built as libraries to then
+be executed by a JavaScript environment [#12260](https://github.com/rust-lang/cargo/issues/12260).
+
 ## Interaction with crate features
 
 Currently, crate `[features]` and `supported-targets` do not interact. It is possible however that a

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -251,14 +251,14 @@ Some higher-level languages and build tools have the ability to specify which pl
 - Python has [platform compatibility tags](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#platform-compatibility-tags).
     The reference explains how these are [used](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#use)
     by installers to determine which build of a package to install.
-- `npm` allows specifying which [`os`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#os) and which
+- `npm` allows specifying which [`os`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#os) and
     [`cpu`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#cpu) a package supports. These generate an
     error when installing a package that does not support the platform used.
 - Swift has [`package.platforms`](https://developer.apple.com/documentation/packagedescription/package/platforms), which
     allows specifying which platforms and versions a package support (mostly for apple products e.g., `macOS`, `iOS`, `watchOS`, `tvOS`).
 - [Buck](https://buck2.build/docs/rule_authors/configurations/#target-platform-compatibility)
     and [Bazel](https://bazel.build/reference/be/common-definitions#common.target_compatible_with)
-    both have `target_compatible_with`.
+    both provide `target_compatible_with`.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -248,10 +248,10 @@ In other system level languages, vendoring dependencies is a common practice, an
 responsible for ensuring that the dependencies are compatible with the target.
 
 Some higher-level languages and build tools have the ability to specify which platforms are compatible.
-- Python has [platform compatibility tags](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#platform-compatibility-tags).
+- Python package has [classifiers](https://pypi.org/classifiers/) as package metadata that includes supported platforms
+- Python wheels (pre-built packages) have [platform compatibility tags](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#platform-compatibility-tags).
     The reference explains how these are [used](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#use)
-    by installers to determine which build of a package to install. PyPI also has [classifiers](https://pypi.org/classifiers/)
-    which allows to add metadata (including which platforms are allowed) to a package.
+    by installers to determine which build of a package to install.
 - `npm` allows specifying which [`os`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#os) and
     [`cpu`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#cpu) a package supports. These generate an
     error when installing a package that does not support the platform used.

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -34,7 +34,7 @@ many different targets. Commands run on a workspace ignore packages that don't s
 
 Once it is known that a package will only ever build for a subset of targets, it opens
 the door for more advanced control over dependencies.
-For example, transient dependencies declared under a `[target.**.dependencies]` table are
+For example, transitive dependencies declared under a `[target.**.dependencies]` table could be
 excluded from `Cargo.lock` if the dependent's `supported-targets` is mutually exclusive with
 the target preconditions under which the dependencies are included.
 This is especially relevant to areas such as WebAssembly and embedded programming,

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -259,6 +259,8 @@ Some higher-level languages and build tools have the ability to specify which pl
 - [Buck](https://buck2.build/docs/rule_authors/configurations/#target-platform-compatibility)
     and [Bazel](https://bazel.build/reference/be/common-definitions#common.target_compatible_with)
     both provide `target_compatible_with`.
+Some accept a string or list of strings representing the platforms, while `Buck` & `Bazel` seem to accept a
+form comparable to `cfg` in Rust.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -84,13 +84,30 @@ require a desktop OS, using `supported-targets` makes `cargo <command>` ignore p
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
+The `supported-targets` field is an optional key that tells cargo which targets the package can be
+built for.
+```toml
+[package]
+# ...
+supported-targets = 'cfg(any(target_os = "linux", target_os = "macos"))'
+```
+The value of this field must respect the [`cfg` syntax](https://doc.rust-lang.org/reference/conditional-compilation.html),
+and does __not__ accept `cfg(test)`, `cfg(debug_assertions)`, nor `cfg(proc_macro)` as configuration options.
+A malformed `supported-targets` field will raise an error.
+
+If the `supported-targets` field is not present, then the package is assumed to support all targets. That is,
+the default value is `'cfg(all())'`.
+
 When a `cargo` build command (e.g. `check`, `build`, `run`, `clippy`) is run, it checks that the
 selected target satisfies the `supported-targets` of the package being built. If it does not, the
 package is skipped or an error is raised, depending on how [`cargo` was invoked](ignoring-builds).
-However, `supported-targets` is _only_ checked for commands that take a `--target` option and does not affect other commands (e.g., `cargo fmt`).
+However, `supported-targets` is _only_ checked for commands that take a `--target` option and does
+not affect other commands (e.g., `cargo fmt`).
 
 As this field is limited to local development, `cargo package` / `cargo publish` will strip it from `Cargo.toml`.
 Including the field in the `.crate` file is left as a [future possibility](#future-possibilities) for now.
+
+This field is subject to [workspace inheritance](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table).
 
 ## Ignoring builds for unsupported targets
 [ignoring-builds]: #igonring-builds-for-unsupported-targets

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -524,7 +524,6 @@ things start to get complicated.
 ## Misc
 
 - Have `cargo add` check the `supported-targets` before adding a dependency.
-- Make this process part of the resolver.
 - Show which targets are supported on `docs.rs`.
 - Have search filters on `crates.io` for crates with support for specific targets.
 - Also add this field at the cargo-target level.

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -568,6 +568,9 @@ supported-targets = 'cfg(target_os = "linux")'
 
 A lint could be added to highlight the fact that the `[target]` table is unused.
 
+Exception should be made for `target.'cfg(any())'`/`target.'cfg(false)` tables, as they are often
+used to lock the version of transitive dependencies, and should not be linted against.
+
 ## `supported-targets` at the cargo-target level
 
 The `supported-targets` field could also be added at the cargo-target level to have more

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -30,7 +30,7 @@ targets cannot build the crate, and also makes build errors specific.
 This feature also enhances developer experience when working in workspaces containing packages designed for
 many different targets. Commands run on a workspace ignore packages that don't support the selected target.
 
-### Cross Compilation 
+### Dependency Management 
 
 Once it is known that a package will only ever build for a subset of targets, it opens
 the door for more advanced control over dependencies.

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -17,6 +17,12 @@ The addition of `supported-targets` to `Cargo.toml`. This field is a `cfg` strin
 set of targets which a package supports. Packages can only be built for targets that satisfy their
 `supported-targets`.
 
+```toml
+[package]
+name = "hello_cargo"
+supported-targets = 'cfg(any(target_os = "linux", target_os = "macos"))'
+```
+
 # Motivation
 
 Some packages rely on features or behavior that is not available on every platform `rustc` can target. Currently, there is no way to formally

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -8,7 +8,7 @@
 The word _target_ is extensively used in this document. The
 [glossary](https://doc.rust-lang.org/cargo/appendix/glossary.html#target) defines its many meanings.
 Here, _target_ refers to the "Target Architecture" for which a package is built. Otherwise, the
-terms "cargo-target" and "target-triple" are used in accordance with their definitions in the
+terms "cargo-target" and "target-tuple" are used in accordance with their definitions in the
 glossary.
 
 # Summary
@@ -133,7 +133,7 @@ is proposed as an [alternative name](#naming).
 The `cfg` string format was chosen because of its simplicity and expressiveness.
 Other formats can be considered:
 
-Using a list of `cfg` strings, and also accepting explicit target-triples:
+Using a list of `cfg` strings, and also accepting explicit target-tuples:
 ```toml
 supported-targets = [
     'cfg(target_family = "unix")',
@@ -191,32 +191,32 @@ Using the `cfg` syntax complicates the implementation (and thus maintenance), an
 amount of calls to `rustc` to check target-`cfg` compatibility. Some alternatives are discussed here
 along with their drawbacks.
 
-### Target-triples
+### Target-tuples
 
-The initial proposal allowed both the `cfg` syntax and whitelisting specific target-triples, to follow the behavior of [platform-specific
+The initial proposal allowed both the `cfg` syntax and whitelisting specific target-tuples, to follow the behavior of [platform-specific
 dependency tables](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies).
 This was removed as it was deemed better to accept targets based on their _attributes_ rather than on their
-_name_. Indeed, `rustc` supported target-triples have changed names, and have been added or removed in the past.
-Target-triple names also do not encapsulate the semantics of the target.
+_name_. Indeed, `rustc` supported target-tuples have changed names, and have been added or removed in the past.
+Target-tuple names also do not encapsulate the semantics of the target.
 
 ### Using wildcards
 
 Instead of using `cfg` specifications, one could use wildcards (e.g., `x86_64-*-linux-*`). This is
-much simpler to implement, target-triples are syntactically checked for a match instead of solving
+much simpler to implement, target-tuples are syntactically checked for a match instead of solving
 set relations for `cfg`. However, this is not as expressive as `cfg`, and does not correctly
-represent the semantics of target-triples. For example, supporting `target_family = "unix"` would
+represent the semantics of target-tuples. For example, supporting `target_family = "unix"` would
 require an annoyingly long list of wildcard patterns. Things like `target_pointer_width = "32"` are
 even harder to represent, and things like `target_feature = "avx"` are basically not representable.
 Also, this is new syntax not currently used by cargo.
 
-### Allowing only target-triples
+### Allowing only target-tuples
 
 This is an even stricter version of the above. Set relations between `supported-targets` lists are
 exact, and the resolver can determine if a platform-specific dependency can be pruned from the
 dependency tree more easily, hence why the original proposal chose this format. Being even simpler
 to implement, this alternative may not be expressive enough for the common use case. Packages rarely
-support specific target-triples, rather they support/require specific target attributes. What would
-likely happen is that packages would copy and paste the target-triple list matching their
+support specific target-tuples, rather they support/require specific target attributes. What would
+likely happen is that packages would copy and paste the target-tuple list matching their
 requirements from somewhere or someone else. Every time a new target with the same attribute is
 added, the whole ecosystem would have to be updated.
 
@@ -229,7 +229,7 @@ is built using the `required-features` field. However, `required-features` does 
 packages in a workspace, nor does it allow filtering out the library of a package.
 
 The `per-package-target` nightly feature defines the `force-target` field, which is supposed to
-force the package to build for a specific target-triple. This does not interact well when used in
+force the package to build for a specific target-tuple. This does not interact well when used in
 dependencies, as one would expect a dependency to be built for the same target as the package.
 `supported-targets` supersedes `force-target` because instead of enforcing a single target, it
 enforces a set of targets.
@@ -331,7 +331,7 @@ package's library and binaries, and so it must respect the `supported-targets` o
 What makes `[build-dependencies]` unique is that they are built for the host computer, and not the
 selected target. As such, they are not restrained by the `supported-targets` of the package. Hence,
 all dependencies are allowed in the `[build-dependencies]` table. However, a build error could be
-raised if one of the build dependencies does not support the _host_'s target-triple at build time.
+raised if one of the build dependencies does not support the _host-tuple_ at build time.
 
 A problem can arise if a crate's build script depends on a package that does not support `target_os
 = "windows"` for example. It would be possible to only allow dependencies supporting all targets in
@@ -480,7 +480,7 @@ Two `cfg` singletons are mutually exclusive under the following rules:
   different, and `<option>` has mutually exclusive elements.
 
 Some `cfg` options have mutually exclusive elements, while some do not. What is meant here is, for
-example, `target_arch = "x86_64"` and `target_arch = "arm"` are mutually exclusive (a target-triple
+example, `target_arch = "x86_64"` and `target_arch = "arm"` are mutually exclusive (a target-tuple
 cannot have both), while `target_feature = "avx"` and `target_feature = "rdrand"` are not.
 
 `cfg` options that have mutually exclusive elements:

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -256,9 +256,26 @@ package.
 
 ## Ensuring proper use of dependencies
 
-By leveraging compilation errors, it would be possible to ensure that a package only uses
-dependencies that support the package's `supported-targets`. This would be done by comparing the
-`supported-targets` of the package with the `supported-targets` of the dependencies.
+Complicated errors caused by packages and dependencies that are incompatible with the selected
+target can be avoided by using the information in the `supported-targets` field. For example, a
+warning or an error could be raised if a package uses a dependency that does not accept the package's
+`supported-targets`:
+```toml
+[package]
+name = "bar"
+supported-targets = 'cfg(target_os = "windows")'
+```
+```toml
+[package]
+name = "foo"
+supported-targets = 'cfg(target_os = "linux")'
+
+[dependencies]
+bar = "0.1.0"
+```
+Here, a compilation error helps by showing which dependency is incompatible with the package's
+`supported-targets`, rather than a cryptic error message about missing parts of `std`, or runtime
+errors.
 
 Cargo's documentation should give clear guidance for when to use this field, and should not suggest
 using it by default. In particular, we should steer users to use this when they have good reason to

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -25,6 +25,8 @@ supported-targets = 'cfg(any(target_os = "linux", target_os = "macos"))'
 
 # Motivation
 
+_For more background, see [rust-lang/cargo#6179](https://github.com/rust-lang/cargo/issues/6179)_
+
 Some packages rely on features or behavior that is not available on every platform `rustc` can target. Currently, there is no way to formally
 specify platform requirements of a package.
 

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -521,9 +521,15 @@ with `target_os = "linux"`, for example.
 _Note:_ More relations could be defined, for example `target_feature = "neon"` ⊆ `target_arch = "arm"`. With this however,
 things start to get complicated.
 
+## `supported-targets` at the cargo-target level
+
+The `supported-targets` field could also be added at the cargo-target level to have
+more fine-grained control over which targets a cargo-target supports. This would function
+similarly to the `edition` field, which is available at both the package and the cargo-target level.
+The `supported-targets` of a cargo-target would most likely need to be a subset of the package's `supported-targets`.
+
 ## Misc
 
 - Have `cargo add` check the `supported-targets` before adding a dependency.
 - Show which targets are supported on `docs.rs`.
 - Have search filters on `crates.io` for crates with support for specific targets.
-- Also add this field at the cargo-target level.

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -373,7 +373,7 @@ Formally, dependencies (and transitive dependencies) under `[target.**.dependenc
 eliminated from the dependency tree of a package if the `supported-targets` of the package is
 mutually exclusive with the target preconditions of the dependency.
 
-## Comparing `supported-targets`
+### Comparing `supported-targets`
 
 To prune the dependency tree, and to ensure proper use of dependencies, it becomes necessary to
 compare `supported-targets`. When comparing two sets of `supported-targets`, it is necessary to
@@ -381,7 +381,7 @@ know if one is a _subset_ of the other, or if both are _mutually exclusive_. To 
 are flattened to the same representation, and they are then compared. This process is done
 internally, and does not affect the `Cargo.toml` file.
 
-### Flattening `not`, `any`, and `all` in `cfg` specifications
+#### Flattening `not`, `any`, and `all` in `cfg` specifications
 
 Since `cfg` specifications can contain `not`, `any`, and `all` operators, these must be handled.
 This is done by flattening the `cfg` specification to a specific form. This form is equivalent to
@@ -409,7 +409,7 @@ If an `all` contains an `all`, the inner `all` is flattened into the outer `all`
 The result of these transformations on a `cfg` specification is a union of `cfg` specifications that
 either contains a single specification, or an `all` operator with no nested operators.
 
-### The subset relation
+#### The subset relation
 
 To determine if the `supported-targets` set "A" is a subset of another such set "B", the standard
 mathematical definition of subset is used. That is, "A" is a subset of "B" if and only if each
@@ -421,7 +421,7 @@ of the list `A, B, ...`.
 
 _Note_: `cfg(A) == cfg(all(A))`.
 
-### Mutual exclusivity
+#### Mutual exclusivity
 
 For the `supported-targets` set "A" to be mutually exclusive with another such set "B", each element
 of "A" must be mutually exclusive with _all_ elements of "B" (The inverse is also true).
@@ -455,7 +455,7 @@ Those that do not:
 - `target_has_atomic`
 - `target_family`
 
-### More `cfg` relations
+#### More `cfg` relations
 
 Even more relations could be defined. Consider the following scenario:
 ```toml

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -6,7 +6,7 @@
 
 The word _target_ is extensively used in this document.
 The [glossary](https://doc.rust-lang.org/cargo/appendix/glossary.html#target) defines its many meanings.
-Here, _target_ refers to the "Target Architeture" for which a package is built. Otherwise, the terms
+Here, _target_ refers to the "Target Architecture" for which a package is built. Otherwise, the terms
 "cargo-target" and "target-triple" are used in accordance with their definitions in the glossary.
 
 # Summary

--- a/text/3759-cargo-supported-targets.md
+++ b/text/3759-cargo-supported-targets.md
@@ -20,7 +20,7 @@ set of targets which a package supports. Packages can only be built for targets 
 # Motivation
 
 Some packages rely on features or behavior that is not available on every platform `rustc` can target. Currently, there is no way to formally
-specify platform requirements of a package
+specify platform requirements of a package.
 
 When working on a project with packages that only build on certain platforms, users cannot run Cargo commands across the entire workspace (e.g. `cargo test --workspace`) but must individually select packages that only work on the specific platform (e.g. `cargo test --workspace --exclude firmware`).  This extends to CI with people wanting to write matrix jobs but have to hand maintain the list of packages for each platform in the matrix.
 
@@ -39,7 +39,7 @@ Likewise, today users either need to audit dependencies irrelevant for the platf
 
 ### More specific error messages
 
-The error message when a library has platform-specific features, like requiring atomics, is about parts of `std` missing which could be for one of several reasons. Some of these problems won't be found until you've built or tested your project on one of these platforms. Like with #2495, if library authors could provide this information to Cargo, developers can get an improved error message under any circumstance.
+The error message when a library has platform-specific features, like requiring atomics, is about parts of `std` missing which could be for one of several reasons. Some of these problems won't be found until you've built or tested your project on one of these platforms. Like with [#2495](https://rust-lang.github.io/rfcs/2495-min-rust-version.html), if library authors could provide this information to Cargo, developers can get an improved error message under any circumstance.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3759)*

# Summary

The addition of `supported-targets` to `Cargo.toml`. This field is an array of `target-triple`/`cfg` specifications that restricts the set of targets which a package supports. Packages must meet the `supported-targets` of their dependencies, and they can only be built for targets that satisfy their `supported-targets`.

[Rendered](https://github.com/carloskiki/rfcs/blob/master/text/3759-cargo-supported-targets.md)
[FCP](https://github.com/rust-lang/rfcs/pull/3759#issuecomment-2580238874)