### PR TITLE
Make trait methods callable in const contexts

### DIFF
--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -745,7 +745,21 @@ do not require const trait impls even if used in const contexts.
 
 An example from libstd today is [the impl block of Vec::new](https://github.com/rust-lang/rust/blob/1ab85fbd7474e8ce84d5283548f21472860de3e2/library/alloc/src/vec/mod.rs#L406) which has an implicit `A: Allocator` bound from [the type definition](https://github.com/rust-lang/rust/blob/1ab85fbd7474e8ce84d5283548f21472860de3e2/library/alloc/src/vec/mod.rs#L397).
 
-A full example how how things would look then
+A full example how how
+
+```rust
+const trait Foo: ~const Bar + Baz {}
+
+impl const Foo for () {}
+
+const fn foo<T: ~const Foo>() -> T {
+    // cannot call `Baz` methods
+    <T as Bar>::bar()
+}
+
+const _: () = foo();
+```
+
 
 ```rust
 const trait Foo: Bar + ?const Baz {}

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -274,8 +274,8 @@ This situation seems no different from other trait bounds, except that types can
 
 The `Destruct` trait is a bound for whether a type has drop glue. This is trivally true for all types.
 
-`~const Destruct` trait bounds are satsifed only if the type has a `const Drop` impl or all of the types of its components
-are `~const Destruct`.
+`~const Destruct` trait bounds are satisfied only if the type's `Drop` impl (if any) is `const` and all of the types of
+its components are `~const Destruct`.
 
 While this means that it's a breaking change to add a type with a non-const `Drop` impl to a type,
 that's already true and nothing new:

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -1,0 +1,726 @@
+- Feature Name: `const_trait_methods`
+- Start Date: 2024-12-13
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#67792](https://github.com/rust-lang/rust/issues/67792)
+
+# Summary
+[summary]: #summary
+
+Make trait methods callable in const contexts. This includes the following parts:
+
+* Allow marking `trait` declarations as const implementable.
+* Allow marking `trait` impls as `const`.
+* Allow marking trait bounds as `const` to make methods of them callable in const contexts.
+
+Fully contained example ([Playground of currently working example](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=2ab8d572c63bcf116b93c632705ddc1b)):
+
+```rust
+const trait Default {
+    fn default() -> Self;
+}
+
+impl const Default for () {
+    fn default() {}
+}
+
+const fn default<T: ~const Default>() -> T {
+    T::default()
+}
+
+fn compile_time_default<T: const Default>() -> T {
+    const { T::default() }
+}
+
+const _: () = Default::default();
+
+fn main() {
+    let () = default();
+    let () = compile_time_default();
+    let () = Default::default();
+}
+```
+
+# Motivation
+[motivation]: #motivation
+
+Const code is currently only able to use a small subset of Rust code, as many standard library APIs and builtin syntax things require calling trait methods to work.
+As an example, in const contexts you cannot use even basic equality on anything but primitives:
+
+```rust
+const fn foo() {
+    let a = [1, 2, 3];
+    let b = [1, 2, 4];
+    if a == b {} // ERROR: cannot call non-const operator in constant functions
+}
+```
+
+## Background
+
+This RFC requires familarity with "const contexts", so you may have to read [the relevant reference section](https://doc.rust-lang.org/reference/const_eval.html#const-context) first.
+
+Calling functions during const eval requires those functions' bodies to only use statements that const eval can handle. While it's possible to just run any code until it hits a statement const eval cannot handle, that would mean the function body is part of its semver guarantees. Something as innocent as a logging statement would make the function uncallable during const eval.
+
+Thus we have a marker (`const`) to add in front of functions that requires the function body to only contain things const eval can handle. This in turn allows a `const` annotated function to be called from const contexts, as you now have a guarantee it will stay callable.
+
+When calling a trait method, this simple scheme (that works great for free functions and inherent methods) does not work.
+
+Throughout this document, we'll be revisiting the example below. Method syntax and `dyn Trait` problems all also exist with static method calls, so we'll stick with the latter to have the simplest examples possible.
+
+```rust
+const fn default<T: Default>() -> T {
+    T::default()
+}
+
+// Could also be `const fn`, but that's an orthogonal change
+fn compile_time_default<T: Default>() -> T {
+    const { T::default() }
+}
+```
+
+Neither of the above should (or do) compile.
+The first, because you could pass any type T whose default impl could
+
+* mutate a global static,
+* read from a file, or
+* just allocate memory,
+
+which are all not possible right now in const code, and some can't be done in Rust in const code at all.
+
+It should be possible to write `default` in a way that allows it to be called in const contexts
+for types whose `Default` impl's `default` method satisfies all rules that `const fn` must satisfy
+(including some annotation that guarantees this won't break by accident).
+It must always be possible to call `default` outside of const contexts with no limitations on the generic parameters that may be passed.
+
+Similarly it should be possible to write `compile_time_default` in a way that also requires calls
+outside of const contexts to only pass generic parameters whose `Default::default` method satisifies
+the usual `const fn` rules. This is necessary in order to allow a const block
+(which can access generic parameters) in the function body to invoke methods on the generic parameter.
+
+So, we need some annotation that differentiates a `T: Default` bound from one that gives us the guarantees we're looking for.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## Nomenclature and new syntax concepts
+
+### Const trait impls
+
+It is now allowed to prefix a trait name in an impl block with `const`, marking that this `impl`'s type is now allowed to
+have methods of this `impl`'s trait to be called in const contexts (if all where bounds hold, like ususal, but more on this later).
+
+An example looks as follows:
+
+```rust
+impl const Trait for Type {}
+```
+
+Such impls require that the trait is a `const trait`.
+
+All method bodies in a const trait impl are [const contexts](https://doc.rust-lang.org/reference/const_eval.html#const-context).
+
+### Const traits
+
+Traits need to opt-in to being allowed to have const trait impls. Thus you need to declare your traits by prefixing the `trait` keyword with `const`:
+
+```rust
+const trait Trait {}
+```
+
+This in turn checks all methods' default bodies as if they were `const fn`, making them callable in const contexts.
+Impls can now rely on the default methods being const, too, and don't need to override them with a const body.
+
+We may add an attribute later to allow you to mark individual trait methods as not-const so that when creating a const trait, one can
+add (defaulted or not) methods that cannot be used in const contexts.
+
+All default method bodies of const trait declarations are [const contexts](https://doc.rust-lang.org/reference/const_eval.html#const-context).
+
+Note that on nightly the syntax is
+
+```rust
+#[const_trait]
+trait Trait {}
+```
+
+and a result of this RFC would be that we would remove the attribute and add the `const trait` syntax.
+
+### Const trait bounds
+
+Any item that can have trait bounds can also have `const Trait` bounds.
+
+Examples:
+
+* `T: const Trait`, requiring any type that `T` is instantiated with to have a const trait impl.
+* `dyn const Trait`, requiring any type that is unsized to this dyn trait to have a const trait impl.
+    * These are not part of this RFC because they require `const fn` function pointers. See [the Future Possibilities section](#future-possibilities).
+* `impl const Trait` (in all positions).
+    * These are not part of this RFC because they require `const fn` function pointers. See [the Future Possibilities section](#future-possibilities).
+* `trait Foo: const Bar {}`, requiring every type that has an impl for `Foo` (even a non-const one), to also have a const trait impl for `Bar`.
+
+Such an impl allows you to use the type that is bound within a const block or any other const context, because we know that the type has a const trait impl and thus
+must be executable at compile time. The following function will invoke the `Default` impl of a type at compile time and store the result in a constant. Then it returns that constant instead of computing the value every time.
+
+```rust
+fn compile_time_default<T: const Default>() -> T {
+    const { T::default() }
+}
+```
+
+### Maybe-const trait bounds
+
+Many generic `const fn` and especially many const trait impls do not actually require a const trait impl for their generic parameters.
+As `const fn` can also be called at runtime, it would be too strict to require it to only be able to call things with const trait impls.
+Picking up the example from [the beginning](#summary):
+
+```rust
+const trait Default {
+    fn default() -> Self;
+}
+
+impl const Default for () {
+    fn default() {}
+}
+
+impl<T: Default> Default for Box<T> {
+    fn default() -> Self { Box::new(T::default()) }
+}
+
+// This function requires a `const` impl for the type passed for T,
+// even if called from a non-const context
+const fn default<T: const Default>() -> T {
+    T::default()
+}
+
+const _: () = default();
+
+fn main() {
+    let _: Box<u32> = default();
+    //~^ ERROR: <Box<u32> as Default>::default cannot be called at compile-time
+}
+```
+
+What we instead want is that, just like `const fn` can be called at runtime and compile time, we want their trait bounds' constness
+to mirror that behaviour. So we're introducing `~const Trait` bounds, which mean "const if called from const context" (slight oversimplifcation, but read on).
+
+The only thing we need to change in our above example is the `default` function, changing the `const Default` bound to a `~const Default` one.
+
+```rust
+const fn default<T: ~const Default>() -> T {
+    T::default()
+}
+```
+
+`~const` is derived from "approximately", meaning "maybe" in this context, or specifically "const impl required if called in const context".
+It is the opposite of `?` (prexisting for `?Sized` bounds), which also means "maybe", but from the other direction: `?const` (not proposed here, see the alternatives section for why it was rejected) would mean "no const impl required, even if called in const context".
+
+### `~const Destruct` trait
+
+The `Destruct` trait enables dropping types within a const context.
+
+```rust
+const fn foo<T>(t: T) {
+    // `t` is dropped here, but we don't know if we can evaluate its `Drop` impl (or that of its fields' types)
+}
+const fn baz<T: Copy>(t: T) {
+    // Fine, `Copy` implies that no `Drop` impl exists
+}
+const fn bar<T: ~const Destruct>(t: T) {
+    // Fine, we can safely invoke the destructor of `T`.
+}
+```
+
+When a value of a generic type goes out of scope, it is dropped and (if it has one) its `Drop` impl gets invoked.
+This situation seems no different from other trait bounds, except that types can be dropped without implementing `Drop`
+(as they can contain types that implement `Drop`). In that case the type's drop glue is invoked.
+
+The `Destruct` trait is a bound for whether a type has drop glue. This is trivally true for all types.
+
+`~const Destruct` trait bounds are satsifed only if the type has a `const Drop` impl or all of the types of its components
+are `~const Destruct`.
+
+## Trivially enabled features
+
+You can use `==` operators on most types from libstd from within const contexts.
+
+```rust
+const _: () = {
+    let a = [1, 2, 3];
+    let b = [4, 5, 6];
+    assert!(a != b);
+};
+const _: () = {
+    let a = Some(42);
+    let b = a;
+    assert!(a == b);
+};
+```
+
+Note that the use of `assert_eq!` is waiting on `Debug` impls becoming `const`, which
+will likely be tracked under a separate feature gate under the purview of T-libs.
+Similarly other traits will be made `const` over time, but doing so will be
+unblocked by this feature.
+
+## Crate authors: Making your own custom types easier to use
+
+You can write const trait impls of many standard library traits for your own types.
+While it was often possible to write the same code in inherent methods, operators were
+covered by traits from `std::ops` and thus not avaiable for const contexts.
+Most of the time it suffices to add `const` before the trait name in the impl block.
+The compiler will guide you and suggest where to also
+add `~const` bounds for trait bounds on generic parameters of methods or the impl.
+
+Similarly you can make your traits available for users of your crate to implement constly.
+Note that this will change your semver guarantees: you are now guaranteeing that any future
+methods you add don't just have a default body, but a `const` default body. The compiler will
+enforce this, so you can't accidentally make a mistake, but it may still limit how you can
+extend your trait without having to do a major version bump.
+Most of the time it suffices to add `const` before the `trait` declaration. The compiler will
+guide you and suggest where to also add `~const` bounds for super trait bounds or trait bounds
+on generic parameters of your trait or your methods.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+## How does this work in the compiler?
+
+These `const` or `~const` trait bounds desugar to normal trait bounds without modifiers, plus an additional constness bound that has no surface level syntax.
+
+A much more detailed explanation can be found in https://hackmd.io/@compiler-errors/r12zoixg1l#What-now
+
+We generate a `ClauseKind::HostEffect` for every `const` or `~const` bound.
+To mirror how some effectful languages represent such effects,
+I'm going to use `<Type as Trait>::k#host` to allow setting whether the `host` effect is "const" (disabled) or "maybe" (generic).
+This is not comparable with other associated bounds like type bounds or const bounds, as the values the associated host effect can
+take do neither have a usual hierarchy nor a concrete single value we can compare due to the following handling of those bounds:
+
+* There is no "always" (enabled), as that is just the lack of a host effect, meaning no `<Type as Trait>::k#host` bound at all.
+* In contrast to other effect systems, we do not track the effect as a true generic parameter in the type system,
+  but instead just ignore all `Maybe` bounds in host environments and treat them as `Const` in const environments.
+
+While this could be modelled with generic parameters in the type system, that:
+
+* Has been attempted and is really complex (fragile) on the impl side and on the reasoning about things side.
+* Appears to permit more behaviours than are desirable (multiple such parameters, math on these parameters, ...), so they need to be prevented, adding more checks.
+* Is not necessary unless we'd allow much more complex kinds of bounds. So it can be kept open as a future possibility, but for now there's no need.
+* Does not quite work in Rust due to the constness then being early bound instead of late bound, cause all kinds of problems around closures and function calls.
+* Technically cause two entirely separate MIR bodies to be generated, one for where the effect is on and one where it is off. On top of that it then theoretically allows you to call the const MIR body from non-const code.
+
+Thus that approach was abandoned after proponents and opponents cooperated in trying to make the generic parameter approach work, resulting in all proponents becoming opponents, too.
+
+### `const` desugaring
+
+```rust
+fn compile_time_default<T: const Default>() -> T {
+    const { T::default() }
+}
+```
+
+desugars to
+
+```rust
+fn compile_time_default<T>() -> T
+where
+    T: Default,
+    <T as Default>::k#host = Const,
+{
+    const { T::default() }
+}
+```
+
+### `~const` desugaring
+
+```rust
+const fn default<T: ~const Default>() -> T {
+    T::default()
+}
+```
+
+desugars to
+
+```rust
+const fn default<T>() -> T
+where
+    T: Default,
+    <T as Default>::k#host = Maybe,
+{
+    T::default()
+}
+```
+
+### Why not both?
+
+
+```rust
+const fn checked_default<T>() -> T
+where
+    T: const Default,
+    T: ~const Default,
+    T: ~const PartialEq,
+{
+    let a = const { T::default() };
+    let b = T::default();
+    if a == b {
+        a
+    } else {
+        panic!()
+    }
+}
+```
+
+Has a redundant bound. `T: const Default` implies `T: ~const Default`, so while the desugaring will include both (but may filter them out if we deem it useful on the impl side),
+there is absolutely no difference (just like specifying `Fn() + FnOnce()` has a redundant `FnOnce()` bound).
+
+## Precedence of `~`
+
+The `~` sigil applies to the `const`, not the `const Trait`, so you can think of it as `(~const) Trait`, not `~(const Trait)`.
+This is both handled this way by the parser, and semantically what is meant here. The constness of the trait bound is affected,
+the trait bound itself exists either way.
+
+## Why do traits need to be marked as "const implementable"?
+
+### Default method bodies
+
+Adding a new method with a default body would become a breaking change unless that method/default body
+would somehow be marked as `const`, too. So by marking the trait, you're opting into the requirement that all default bodies are const checked,
+and thus neither `impl const Trait for Type` items nor `impl Trait for Type` items will be affected if you add a new method with a default body.
+This scheme avoids adding a new kind of breaking change to the Rust language,
+and instead allows everyone managing a public trait in their crate to continue relying on the
+previous rule "adding a new method is not a breaking change if it has a default body".
+
+### `~const Destruct` super trait
+
+Traits that have `self` (by ownership) methods, will almost always drop the `self` in these methods' bodies unless they are simple wrappers that just forward to the generic parameters' bounds.
+
+The following never drops `T`, because it's the job of `<T as Add>` to handle dropping the values.
+
+```rust
+struct NewType<T>(T);
+
+impl<T: ~const Add<Output = T>> const Add for NewType<T> {
+    type Output = Self,
+    fn add(self, other: Self) -> Self::Output {
+        NewType(self.0 + other.0)
+    }
+}
+```
+
+But if any code path could drop a value...
+
+```rust
+struct NewType<T>(T, bool);
+
+struct Error;
+
+impl<T: ~const Add<Output = T>> const Add for NewType<T> {
+    type Output = Result<Self, Error>;
+    fn add(self, other: Self) -> Self::Output {
+        if self.1 {
+            Ok(NewType(self.0 + other.0, other.1))
+        } else {
+            // Drops both `self.0` and `self.1`
+            Err(Error)
+        }
+    }
+}
+```
+
+... then we need to add a `~const Destruct` bound to `T`, to ensure
+`NewType<T>` can be dropped.
+
+This bound in turn will be infectious to all generic users of `NewType` like
+
+```rust
+const fn add<T: ~const Add>(
+    a: NewType<T>,
+    b: NewType<T>,
+) -> Result<NewType<T::Output>, Error> {
+    a + b
+}
+```
+
+which now need a `T: ~const Destruct` bound, too.
+In practice we have noticed that a large portion of APIs will have a `~const Destruct` bound.
+This bound has little value as an explicit bound that appears almost everywhere.
+Especially since it is a fairly straight forward assumption that a type that has const trait impls will also have a `const Drop` impl or only contain `const Destruct` types.
+
+Thus we give all `const trait`s a `~const Destruct` super trait to ensure users don't need to add `~const Destruct` bounds everywhere.
+We may offer an opt out of this behaviour in the future, if there are convincing real world use cases.
+
+### `~const` bounds on `Drop` impls
+
+It is legal to add `~const` to `Drop` impls' bounds, even thought the struct doesn't have them:
+
+```rust
+const trait Bar {
+    fn thing(&mut self);
+}
+
+struct Foo<T: Bar>(T);
+
+impl<T: ~const Bar> const Drop for Foo<T> {
+    fn drop(&mut self) {
+        self.0.thing();
+    }
+}
+```
+
+There is no reason (and no coherent representation) of adding `~const` trait bounds to a type.
+Our usual `Drop` rules enforce that an impl must have the same bounds as the type.
+`~const` modifiers are special here, because they are only needed in const contexts.
+While they cause exactly the divergence that we want to prevent with the `Drop` impl rules:
+a type can be declared, but not dropped, because bounds are unfulfilled, this is:
+
+* Already the case in const contexts, just for all types that aren't trivially free of `Drop` types.
+* Exactly the behaviour we want.
+
+Extraneous `~const Trait` bounds where `Trait` isn't a bound on the type at all are still rejected:
+
+```rust
+impl<T: ~const Bar + ~const Baz> const Drop for Foo<T> {
+    fn drop(&mut self) {
+        self.0.thing();
+    }
+}
+```
+
+errors with
+
+```
+error[E0367]: `Drop` impl requires `T: Baz` but the struct it is implemented for does not
+  --> src/lib.rs:13:22
+   |
+13 | impl<T: ~const Bar + ~const Baz> const Drop for Foo<T> {
+   |                      ^^^^^^^^^^
+   |
+note: the implementor must specify the same requirement
+  --> src/lib.rs:8:1
+   |
+8  | struct Foo<T: Bar>(T);
+   | ^^^^^^^^^^^^^^^^^^
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+## Adding any feature at all around constness
+
+I think we've reached the point where all critics have agreed that this one kind of effect system is unavoidable since we want to be able to write maintainable code for compile time evaluation.
+
+So the main drawback is that it creates interest in extending the system or add more effect systems, as we have now opened the door with an effect system that supports traits.
+Even though I personally am interested in adding an effect for panic-freedom, I do not think that adding this const effect system should have any bearing on whether we'll add
+a panic-freedom effect system or other effect systems in the future. This feature stands entirely on its own, and even if we came up with a general system for many effects that is (e.g. syntactically) better in the
+presence of many effects, we'll want the syntax from this RFC as sugar for the very common and simple case.
+
+## It's hard to make constness optional with `#[cfg]`
+
+One cannot `#[cfg]` just the `const` keyword in `const Trait`, and even if we made it possible by sticking with `#[const_trait]` attributes, and also adding the equivalent for impls and functions,
+`~const Trait` bounds cannot be made conditional with `#[cfg]`. The only real useful reason to have this is to support newer Rust versions with a cfg, and allow older Rust versions to compile
+the traits, just without const support. This is surmountable with proc macros that either generate two versions or just generate a different version depending on the Rust version.
+Since it's only necessary for a transition period while a crate wants to support both pre-const-trait Rust and
+newer Rust versions, this doesn't seem too bad. With a MSRV bump the proc macro usage can be removed again.
+
+## Can't have const methods and nonconst methods on the same trait
+
+If a trait has methods that don't make sense for const contexts, but some that do, then right now it is required to split that
+trait into a nonconst trait and a const trait and "merge" them by making one of them be a super trait of the other:
+
+```rust
+const trait Foo {
+    fn foo(&self);
+}
+trait Bar: Foo {
+    fn bar(&self);
+}
+
+impl const Foo for () {
+    fn foo(&self) {}
+}
+impl Bar for () {
+    fn bar(&self) {
+        println!("writing to terminal is not possible in const eval");
+    }
+}
+```
+
+Such a split is not possible without a breaking change, so splitting may not be feasible in some cases.
+Especially since we may later offer the ability to have const and nonconst methods on the same trait, then allowing
+the traits to be merged again. That's churn we'd like to avoid.
+
+Note that it may frequently be that such a trait should have been split even without constness being part of the picture.
+
+# Alternatives
+[alternatives]: #alternatives
+
+## use `const Trait` bounds for maybe-const, invent new syntax for always-const
+
+It may seem tempting to use `const fn foo<T: const Trait>` to mean what in this RFC is `~const Trait`, and then add new syntax for bounds that allow using trait methods in const blocks.
+
+## use `Trait<const>` or `Trait<bikeshed#effect: const>` instead of `const Trait`
+
+To avoid new syntax before paths referring to traits, we could treat the constness as a generic parameter or an associated type.
+While an associated type is very close to how the implementation works, neither `effect = const` nor `effect: const` are representing the logic correctly,
+as `const` implies `~const`, but `~const` is nothing concrete, it's more like a generic parameter referring to the constness of the function.
+Fully expanded one can think of
+
+```rust
+const fn foo<T: ~const Trait + const OtherTrait>(t: T) { ... }
+```
+
+to be like
+
+```rust
+const<const C: bool> fn foo<T>(t: T)
+where
+    T: Trait + OtherTrait,
+    <T as Trait>::bikeshed#effect = const<C>,
+    <T as OtherTrait>::bikeshed#effect = const<true>,
+{
+    ...
+}
+```
+
+Note that `const<true>` implies `const<false>` and thus also `for<C> const<C>`, just like `const Trait` implies `~const Trait`.
+
+We do not know of any cases where such an explicit syntax would be useful (only makes sense if you can do math on the bool),
+so a more reduced version could be
+
+```rust
+const fn foo<T>(t: T)
+where
+    T: Trait + OtherTrait,
+    <T as Trait>::bikeshed#effect = ~const,
+    <T as OtherTrait>::bikeshed#effect = const,
+{
+    ...
+}
+```
+
+or
+
+```rust
+const fn foo<T: Trait<bikeshed#effect = ~const> + OtherTrait<bikeshed#effect = const>>(t: T) { ... }
+```
+
+## Make all `const fn` arguments `~const Trait` by default and require an opt out `?const Trait`
+
+We could default to making all `T: Trait` bounds be const if the function is called from a const context, and require a `T: ?const Trait` opt out
+for when a trait bound is only used for its associated types and consts.
+
+This requires a new `~const fn` syntax (sigils or syntax bikesheddable), as the existing `const fn` already has trait bounds that
+do not require const trait impls even if used in const contexts.
+
+A full example how how things would look then
+
+```rust
+const trait Foo: Bar + ?const Baz {}
+
+impl const Foo for () {}
+
+const fn foo<T: Foo>() -> T {
+    // cannot call `Baz` methods
+    <T as Bar>::bar()
+}
+
+const _: () = foo();
+```
+
+This can be achieved across an edition by having some intermediate syntax like prepending `#[next_const]` attributes to all const fn that are using the new syntax, and having a migration lint that suggests adding it to every `const fn` that has trait bounds.
+
+Then in the following edition, we can forbid the `#[next_const]` attribute and just make it the default.
+
+The disadvantage of this is that by default, it creates stricter bounds than desired.
+
+```rust
+const fn foo<T: Foo>() {
+    T::ASSOC_CONST
+}
+```
+
+compiles today, and allows all types that implement `Foo`, irrespective of the constness of the impl.
+With the opt-out scheme that would still compile, but suddenly require callers to provide a const impl.
+
+The safe default (and the one folks are used to for a few years now), is that trait bounds just work, you just
+can't call methods on them. To get more capabilities, you add more syntax. Thus the opt-out approach was not taken.
+
+# Prior art
+[prior-art]: #prior-art
+
+* I tried to get this accepted before under https://github.com/rust-lang/rfcs/pull/2632.
+    * While that moved to [FCP](https://github.com/rust-lang/rfcs/pull/2632#issuecomment-481395097), it had concerns raised.
+    * [T-lang discussed this](https://github.com/rust-lang/rfcs/pull/2632#issuecomment-567699174) and had the following open concerns:
+        * This design has far-reaching implications and we probably aren't going to be able to work them all out in advance. We probably need to start working through the implementation.
+        * This seems like a great fit for the "const eval" project group, and we should schedule a dedicated meeting to talk over the scope of such a group in more detail.
+        * Similarly, it would be worth scheduling a meeting to talk out this RFC in more detail and make sure the lang team is understanding it well.
+        * We feel comfortable going forward with experimentation on nightly even in advance of this RFC being accepted, as long as that experimentation is gated.
+    * All of the above have happened in some form, so I believe it's time to have the T-lang meeting again.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+    * Whether to pick an alternative syntax (and which one in that case).
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+    * We've already handled this since the last RFC, there are no more implementation concerns.
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+    * This RFC's syntax is entirely unrelated to discussions on `async Trait`.
+        * `async Trait` can be written entirely in user code by creating a new trait `AsyncTrait`; there is no workaround for `const`.
+    * This RFC's syntax is entirely unrelated to discussions on effect syntax.
+        * If we get an effect system, it may be desirable to allow expressing const traits with the effect syntax, this design is forward compatible with that.
+        * If we get an effect system, we will still want this shorthand, just like we allow you to write:
+            * `T: Iterator<Item = U>` and don't require `where T: Iterator, <T as Iterator>::Item = U`.
+            * `T: Iterator<Item: Debug>` and don't require `where T: Iterator, <T as Iterator>::Item: Debug`.
+    * RTN for per-method bounds: `T: Trait<some_fn(..): ~const Fn(A, B) -> C>` could supplement this feature in the future.
+        * Very verbose (need to specify arguments and return type).
+        * Want short hand sugar anyway to make it trivial to change a normal function to a const function by just adding some minor annotations.
+        * Significantly would delay const trait stabilization.
+        * Usually requires editing the trait anyway, so there's no "can constify impls without trait author opt in" silver bullet.
+    * New RTN-like per-method bounds: `T: Trait<some_fn(_): ~const>`.
+        * Unclear if soundly possible.
+        * Unclear if possible without incurring significant performance issues for all code (may need tracking new information for all functions out there).
+        * Still requires editing traits.
+        * Still want the `~const Trait` sugar anyway.
+
+## Should we start out by allowing only const trait declarations and const trait impls
+
+We do not need to immediately allow using methods on generic parameters of const fn, as a lot of const code is nongeneric.
+
+The following example could be made to work with just const traits and const trait impls.
+
+```rust
+const fn foo() {
+    let a = [1, 2, 3];
+    let b = [1, 2, 4];
+    if a == b {}
+}
+```
+
+Things like `Option::map` could not be made const without const trait bounds, as they need to actually call the generic `FnOnce` argument.
+
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+## Migrate to `~const fn`
+
+`const fn` and `const` items have slightly different meanings for `const`:
+
+`const fn` can also be called at runtime just fine, while the others are always const
+contexts and need to be evaluated by the const evaluator.
+
+Additionally `const Trait` bounds have a third meaning (the same as `const Trait` in `impl const Trait for Type`):
+
+They can be invoked at compile time, but also in `const fn`.
+
+While all these meanings are subtly different, making their differences more obvious will not make them easier to understand.
+All that changing to `~const fn` would achieve is that folk will add the sigil when told by the compiler, and complain about
+having to type a sigil, when there is no meaning for `const fn` without a sigil.
+
+While I see the allure from a language nerd perspective to give every meaning its own syntax, I believe it is much more practical to
+just call all of these `const` and only separate the `~const Trait` bounds from `const Trait` bounds.
+
+## `const fn()` pointers
+
+Just like `const fn foo(x: impl ~const Trait) { x.method() }` and `const fn foo(x: &dyn ~const Trait) { x.method() }` we want to allow
+`const fn foo(f: const fn()) { f() }`.
+
+There is nothing design-wise blocking function pointers and calling them, they mainly require implementation work and extending the
+compiler's internal type system representation of a function signature to include constness.

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -106,7 +106,7 @@ So, we need some annotation that differentiates a `T: Default` bound from one th
 ### Const trait impls
 
 It is now allowed to prefix a trait name in an impl block with `const`, marking that this `impl`'s type is now allowed to
-have methods of this `impl`'s trait to be called in const contexts (if all where bounds hold, like ususal, but more on this later).
+have methods of this `impl`'s trait to be called in const contexts (if all where bounds hold, like usual, but more on this later).
 
 An example looks as follows:
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -20,7 +20,7 @@ const trait Default {
 }
 
 impl const Default for () {
-    const fn default() {}
+    (const) fn default() {}
 }
 
 struct Thing<T>(T);
@@ -180,11 +180,11 @@ Free functions are unaffected and will stay as `const fn`.
 
 ### Impls for conditionally const methods
 
-Methods that are declared as `(const)` on a trait can now be made `const` in an impl, if that impl is marked as `impl cosnt Trait`:
+Methods that are declared as `(const)` on a trait can now also be made `(const)` in an impl, if that impl is marked as `impl const Trait`:
 
 ```rust
 impl const Trait for Type {
-    const fn thing() {}
+    (const) fn thing() {}
 }
 ```
 
@@ -202,7 +202,7 @@ const trait Foo {
 }
 
 impl const Foo for () {
-    const fn foo(&self) {}
+    (const) fn foo(&self) {}
     fn bar(&self) {
         println!("writing to terminal is not possible in const eval");
     }
@@ -221,11 +221,11 @@ const trait Default {
 }
 
 impl const Default for () {
-    const fn default() {}
+    (const) fn default() {}
 }
 
 impl<T: Default> const Default for Box<T> {
-    fn default() -> Self { Box::new(T::default()) }
+    (const) fn default() -> Self { Box::new(T::default()) }
 }
 
 // This function requires a `const` impl for the type passed for T,
@@ -304,7 +304,7 @@ struct MyStruct<T>(T);
 
 impl<T: (const) Add<Output = T>> const Add for MyStruct<T> {
     type Output = MyStruct<T>;
-    const fn add(self, other: MyStruct<T>) -> MyStruct<T> {
+    (const) fn add(self, other: MyStruct<T>) -> MyStruct<T> {
         MyStruct(self.0 + other.0)
     }
 }
@@ -314,7 +314,7 @@ where
     for<'a> &'a T: (const) Add<Output = T>,
 {
     type Output = MyStruct<T>;
-    const fn add(self, other: &MyStruct<T>) -> MyStruct<T> {
+    (const) fn add(self, other: &MyStruct<T>) -> MyStruct<T> {
         MyStruct(&self.0 + &other.0)
     }
 }
@@ -605,7 +605,7 @@ struct NewType<T>(T);
 
 impl<T: (const) Add<Output = T>> const Add for NewType<T> {
     type Output = Self;
-    fn add(self, other: Self) -> Self::Output {
+    (const) fn add(self, other: Self) -> Self::Output {
         NewType(self.0 + other.0)
     }
 }
@@ -620,7 +620,7 @@ struct Error;
 
 impl<T: (const) Add<Output = T>> const Add for NewType<T> {
     type Output = Result<Self, Error>;
-    fn add(self, other: Self) -> Self::Output {
+    (const) fn add(self, other: Self) -> Self::Output {
         if self.1 {
             Ok(NewType(self.0 + other.0, other.1))
         } else {
@@ -670,7 +670,7 @@ const trait Bar {
 struct Foo<T: Bar>(T);
 
 impl<T: (const) Bar> const Drop for Foo<T> {
-    const fn drop(&mut self) {
+    (const) fn drop(&mut self) {
         self.0.thing();
     }
 }
@@ -689,7 +689,7 @@ Extraneous `(const) Trait` bounds where `Trait` isn't a bound on the type at all
 
 ```rust
 impl<T: (const) Bar + (const) Baz> const Drop for Foo<T> {
-    const fn drop(&mut self) {
+    (const) fn drop(&mut self) {
         self.0.thing();
     }
 }

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -836,3 +836,13 @@ Just like `const fn foo(x: impl ~const Trait) { x.method() }` and `const fn foo(
 
 There is nothing design-wise blocking function pointers and calling them, they mainly require implementation work and extending the
 compiler's internal type system representation of a function signature to include constness.
+
+## `const` closures
+
+Closures need explicit opt-in to be callable in const contexts.
+You can already use closures in const contexts today to e.g. declare consts of function pointer type.
+So what we additionally need is some syntax like `const || {}` to declare a closure that implements
+`const Fn()`. See also [this tracking issue](https://github.com/rust-lang/project-const-traits/issues/10)
+While it may seem tempting to just automatically implement `const Fn()` (or `~const Fn()`) where applicable,
+it's not clear that this can be done, and there are definite situations where it can't be done.
+As further experimentation is needed here, const closures are not part of this RFC.

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -252,7 +252,7 @@ const fn default<T: (const) Default>() -> T {
 ```
 
 `(const)` means "conditionally" in this context, or specifically "const impl required if called in const context".
-It is the opposite of `?` (prexisting for `?Sized` bounds), which also means "conditionally", but from the other direction: `?const`
+It is the opposite of `?` (preexisting for `?Sized` bounds), which also means "conditionally", but from the other direction: `?const`
 (not proposed here, see  [this alternatives section](#make-all-const-fn-arguments-const-trait-by-default-and-require-an-opt-out-const-trait) for why it was rejected)
 would mean "no const impl required, even if called in const context".
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -1043,3 +1043,7 @@ impl RngCore for CountingRng {
 
 and use it in non-generic code.
 It is not clear this is doable soundly for generic methods.
+
+## Macro matcher
+
+In the future, we may want to provide a macro matcher for this optional component of a function declaration or trait declaration, similar to `:vis` for an optional visibility. This would allow macros to match it conveniently, and may encourage forwards compatibility with future things in the same category. However, we should not add such a matcher right away, until we have a clearer picture of what else we may add to the same category.

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -873,7 +873,7 @@ This can be achieved across an edition by having some intermediate syntax like p
 
 Then in the following edition, we can forbid the `#[next_const]` attribute and just make it the default.
 
-The disadvantage of this is that by default, it creates stricter bounds than desired.
+The disadvantage of this is that sometimes, it creates stricter bounds than desired.
 
 ```rust
 const fn foo<T: Foo>() {
@@ -884,15 +884,13 @@ const fn foo<T: Foo>() {
 compiles today, and allows all types that implement `Foo`, irrespective of the constness of the impl.
 With the opt-out scheme that would still compile, but suddenly require callers to provide a const impl.
 
-The safe default (and the one folks are used to for a few years now on stable), is that trait bounds just work, you just
-can't call methods on them.
-This is both useful in
+The alternative proposed above (and the one folks are used to for a few years now on stable), is that trait bounds mean the same on all functions, you just can't call methods on them in `const fn`.
 
 * nudging function authors to using the minimal necessary bounds to get their function
 body to compile and thus requiring as little as possible from their callers,
 * ensuring our implementation is correct by default.
 
-The implementation correctness argument is partially due to our history with `?const` (see https://github.com/rust-lang/rust/issues/83452 for where we got it wrong and thus decided to stop using opt-out), and partially with our history with `?` bounds not being great either (https://github.com/rust-lang/rust/issues/135229, https://github.com/rust-lang/rust/pull/132209). An opt-in is much easier to make sound and keep sound.
+The implementation correctness argument is partially due to our history with `cosnt fn` trait bounds (see https://github.com/rust-lang/rust/issues/83452 for where we got "reject all trait bounds" wrong and thus decided to stop using opt-out), and partially with our history with `?` bounds not being great either (https://github.com/rust-lang/rust/issues/135229, https://github.com/rust-lang/rust/pull/132209). An opt-in is much easier to make sound and keep sound.
 
 To get more capabilities, you add more syntax. Thus the opt-out approach was not taken.
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -518,6 +518,7 @@ Everywhere where non-const trait bounds can be written, but only for traits that
     * super trait bounds
     * where bounds
     * associated type bounds
+* return position impl trait
 
 ### `const` desugaring
 
@@ -653,8 +654,9 @@ In the future we will also want to support `dyn (const) Trait` bounds, which inv
 While that can in generic contexts always be handled by adding more `(const) Destruct` bounds, it would be more similar to how normal `dyn` safety
 works if there were implicit `(const) Destruct` bounds for (most?) `(const) Trait` bounds.
 
-Thus we require that all `trait`s with `(const)` methods also have a `(const) Destruct` super trait bound to ensure users don't need to add `(const) Destruct` bounds everywhere.
-We may relax this requirement in the future or make it implied.
+Thus we lint all `const trait`s with `(const)` methods that take `self` by value to also have a `(const) Destruct` super trait bound to ensure users don't need to add `(const) Destruct` bounds everywhere.
+Other traits may want to add them, and some traits with `self` by value methods may not want to add them. Since it is not backwards compatible to require or relax that super trait bound later,
+we aren't requiring users to choose either, but are suggesting good defaults via lints.
 
 ## `(const)` bounds on `Drop` impls
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -165,7 +165,7 @@ fn compile_time_default<T: const Default>() -> T {
 }
 ```
 
-### Maybe-const trait bounds
+### Conditionally-const trait bounds
 
 Many generic `const fn` and especially many const trait impls do not actually require a const trait impl for their generic parameters.
 As `const fn` can also be called at runtime, it would be too strict to require it to only be able to call things with const trait impls.
@@ -209,8 +209,8 @@ const fn default<T: ~const Default>() -> T {
 }
 ```
 
-`~const` is derived from "approximately", meaning "maybe" in this context, or specifically "const impl required if called in const context".
-It is the opposite of `?` (prexisting for `?Sized` bounds), which also means "maybe", but from the other direction: `?const` (not proposed here, see the alternatives section for why it was rejected) would mean "no const impl required, even if called in const context".
+`~const` is derived from "approximately", meaning "conditionally" in this context, or specifically "const impl required if called in const context".
+It is the opposite of `?` (prexisting for `?Sized` bounds), which also means "conditionally", but from the other direction: `?const` (not proposed here, see the alternatives section for why it was rejected) would mean "no const impl required, even if called in const context".
 
 ### `~const Destruct` trait
 
@@ -288,13 +288,13 @@ A much more detailed explanation can be found in https://hackmd.io/@compiler-err
 
 We generate a `ClauseKind::HostEffect` for every `const` or `~const` bound.
 To mirror how some effectful languages represent such effects,
-I'm going to use `<Type as Trait>::k#host` to allow setting whether the `host` effect is "const" (disabled) or "maybe" (generic).
+I'm going to use `<Type as Trait>::k#host` to allow setting whether the `host` effect is "const" (disabled) or "conditionally" (generic).
 This is not comparable with other associated bounds like type bounds or const bounds, as the values the associated host effect can
 take do neither have a usual hierarchy nor a concrete single value we can compare due to the following handling of those bounds:
 
 * There is no "always" (enabled), as that is just the lack of a host effect, meaning no `<Type as Trait>::k#host` bound at all.
 * In contrast to other effect systems, we do not track the effect as a true generic parameter in the type system,
-  but instead just ignore all `Maybe` bounds in host environments and treat them as `Const` in const environments.
+  but instead just ignore all `Conditionally` bounds in host environments and treat them as `Const` in const environments.
 
 While this could be modelled with generic parameters in the type system, that:
 
@@ -340,7 +340,7 @@ desugars to
 const fn default<T>() -> T
 where
     T: Default,
-    <T as Default>::k#host = Maybe,
+    <T as Default>::k#host = Conditionally,
 {
     T::default()
 }
@@ -550,7 +550,7 @@ Note that it may frequently be that such a trait should have been split even wit
 # Alternatives
 [alternatives]: #alternatives
 
-## use `const Trait` bounds for maybe-const, invent new syntax for always-const
+## use `const Trait` bounds for conditionally-const, invent new syntax for always-const
 
 It may seem tempting to use `const fn foo<T: const Trait>` to mean what in this RFC is `~const Trait`, and then add new syntax for bounds that allow using trait methods in const blocks.
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -658,7 +658,7 @@ We may relax this requirement in the future or make it implied.
 
 ## `(const)` bounds on `Drop` impls
 
-It is legal to add `(const)` to `Drop` impls' bounds, even thought the struct doesn't have them:
+It is legal to add `(const)` to `Drop` impls' bounds, even though the struct doesn't have them:
 
 ```rust
 const trait Bar {
@@ -714,7 +714,7 @@ note: the implementor must specify the same requirement
 
 ## Adding any feature at all around constness
 
-I think we've reached the point where all critics have agreed that this one kind of effect system is unavoidable since we want to be able to write maintainable code for compile time evaluation.
+I think we've reached the point where all critics have agreed that this one kind of effect system is unavoidable since we want to be able to write maintainable generic code for compile time evaluation.
 
 So the main drawback is that it creates interest in extending the system or add more effect systems, as we have now opened the door with an effect system that supports traits.
 Even though I personally am interested in adding an effect for panic-freedom, I do not think that adding this const effect system should have any bearing on whether we'll add

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -545,6 +545,10 @@ In practice we have noticed that a large portion of APIs will have a `~const Des
 This bound has little value as an explicit bound that appears almost everywhere.
 Especially since it is a fairly straight forward assumption that a type that has const trait impls will also have a `const Drop` impl or only contain `const Destruct` types.
 
+In the future we will also want to support `dyn ~const Trait` bounds, which invariably will require the type to implement `~const Destruct` in order to fill in the function pointer for the `drop` slot in the vtable.
+While that can in generic contexts always be handled by adding more `~const Destruct` bounds, it would be more similar to how normal `dyn` safety
+works if there were implicit `~const Destruct` bounds for (most?) `~const Trait` bounds.
+
 Thus we give all `const trait`s a `~const Destruct` super trait to ensure users don't need to add `~const Destruct` bounds everywhere.
 We may offer an opt out of this behaviour in the future, if there are convincing real world use cases.
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -440,7 +440,7 @@ on generic parameters of your trait or your methods.
 
 These `const` or `[const]` trait bounds desugar to normal trait bounds without modifiers, plus an additional constness bound that has no surface level syntax.
 
-A much more detailed explanation can be found in https://hackmd.io/@compiler-errors/r12zoixg1l#What-now
+A much more detailed explanation can be found in https://rustc-dev-guide.rust-lang.org/effects.html
 
 In contrast to other keywords like `unsafe` or `async` (that give you raw pointer derefs or `await` calls respectively),
 the `const` keyword on functions or blocks restricts what you can do within those functions or blocks.

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -404,7 +404,7 @@ parameters, too:
 
 
 ```rust
-const fn foo<T: [const] Debug, F: (const) Fn(T)>(f: F, arg: T) {
+const fn foo<T: [const] Debug, F: [const] Fn(T)>(f: F, arg: T) {
     f(arg)
 }
 
@@ -612,7 +612,7 @@ In the future we will also want to support `dyn [const] Trait` bounds, which inv
 While that can in generic contexts always be handled by adding more `[const] Destruct` bounds, it would be more similar to how normal `dyn` safety
 works if there were implicit `[const] Destruct` bounds for (most?) `[const] Trait` bounds.
 
-Thus we lint all `const trait`s with methods that take `self` by value to also have a `(const) Destruct` super trait bound to ensure users don't need to add `[const] Destruct` bounds everywhere.
+Thus we lint all `const trait`s with methods that take `self` by value to also have a `[const] Destruct` super trait bound to ensure users don't need to add `[const] Destruct` bounds everywhere.
 Other traits may want to add them, and some traits with `self` by value methods may not want to add them. Since it is not backwards compatible to require or relax that super trait bound later,
 we aren't requiring users to choose either, but are suggesting good defaults via lints.
 
@@ -784,7 +784,7 @@ where
 }
 ```
 
-Note that `const<true>` implies `const<false>` and thus also `for<C> const<C>`, just like `const Trait` implies `(const) Trait`.
+Note that `const<true>` implies `const<false>` and thus also `for<C> const<C>`, just like `const Trait` implies `[const] Trait`.
 
 We do not know of any cases where such an explicit syntax would be useful (only makes sense if you can do math on the bool),
 so a more reduced version could be
@@ -793,7 +793,7 @@ so a more reduced version could be
 const fn foo<T>(t: T)
 where
     T: Trait + OtherTrait,
-    <T as Trait>::bikeshed#effect = (const),
+    <T as Trait>::bikeshed#effect = [const],
     <T as OtherTrait>::bikeshed#effect = const,
 {
     ...
@@ -803,7 +803,7 @@ where
 or
 
 ```rust
-const fn foo<T: Trait<bikeshed#effect = (const)> + OtherTrait<bikeshed#effect = const>>(t: T) { ... }
+const fn foo<T: Trait<bikeshed#effect = [const]> + OtherTrait<bikeshed#effect = const>>(t: T) { ... }
 ```
 
 ## Make all `const fn` arguments `[const] Trait` by default and require an opt out `?const Trait`
@@ -970,8 +970,8 @@ just call all of these `const` and only separate the `[const] Trait` bounds from
 
 ## `const fn()` pointers
 
-Just like `const fn foo(x: impl (const) Trait) { x.method() }` and `const fn foo(x: &dyn (const) Trait) { x.method() }` we want to allow
-`const fn foo(f: (const) fn()) { f() }`.
+Just like `const fn foo(x: impl [const] Trait) { x.method() }` and `const fn foo(x: &dyn [const] Trait) { x.method() }` we want to allow
+`const fn foo(f: [const] fn()) { f() }`.
 
 These require changing the type system, making the constness of a function pointer part of the type.
 This in turn implies that a `const fn()` function pointer, a `[const] fn()` function pointer and a `fn()` function pointer could have

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -128,7 +128,7 @@ Impls can now rely on the default methods being const, too, and don't need to ov
 
 ### `const` methods and non-`const` methods on the same trait
 
-If the trait is marked as `const trait Trait`, then all methods under an `const impl Foo for Trait` are assumed
+If the trait is marked as `const trait Trait`, then all methods under an `const impl Trait for Foo` are assumed
 to be callable in const contexts. Thus the only way to implement a `const trait` using non-const operations
 would be to use a non-const `impl`: `impl Foo for Trait`. There is no opt-out from const per-method because it's a
 niche use case that can be trivially worked around.
@@ -147,7 +147,7 @@ Examples:
 * `trait Foo: const Bar {}`, requiring every type that has an impl for `Foo` (even a non-const one), to also have a trait impl with `const` methods for `Bar`.
 * `trait Foo { type Bar: const Trait; }`, requiring all the impls to provide a type for `Bar` that has a trait impl with `const` methods for `Trait`
 
-Such an bound allows you to use the trait methods of those types within a const block or any other const context, because we know that the type has a trait impl with `const` methods and thus
+Such a bound allows you to use the trait methods of those types within a const block or any other const context, because we know that the type has a trait impl with `const` methods and thus
 must be executable at compile time. The following function will invoke the `Default` impl of a type at compile time and store the result in a constant. Then it returns that constant instead of computing the value every time.
 
 ```rust
@@ -192,7 +192,7 @@ fn main() {
 ```
 
 What we instead want is that, just like `const fn` can be called at runtime and compile time, we want their trait bounds' constness
-to mirror that behaviour. So we're introducing `[const] Trait` bounds, which mean "const if called from const context" (slight oversimplifcation, but read on).
+to mirror that behaviour. So we're introducing `[const] Trait` bounds, which mean "const if called from const context" (slight oversimplification, but read on).
 
 The only thing we need to change in our above example is the `default` function, changing the `const Default` bound to a `[const] Default` one.
 
@@ -331,7 +331,7 @@ const _: () = {
 
 Note that the use of `assert_eq!` is waiting on `Debug` impls becoming `const`, which
 will likely be tracked under a separate feature gate under the purview of T-libs.
-Similarly other traits will be made `const` over time, but doing so will be
+Similiarly other traits will be made `const` over time, but doing so will be
 unblocked by this feature.
 
 ### `const Fn*` traits
@@ -379,7 +379,7 @@ Most of the time it suffices to add `const` after the `impl`.
 The compiler will then guide you and suggest where to also
 add `[const]` bounds for trait bounds on generic parameters of methods or the impl.
 
-Similarly you can make your traits available for users of your crate to implement constly using `[const]`.
+Similiarly you can make your traits available for users of your crate to implement constly using `[const]`.
 Note that this will make all methods callable from const contexts, thus imposing stricter requirements on default
 method bodies currently and in the future.
 The compiler will guide you and suggest where to also add `[const]` bounds for super trait bounds or trait bounds
@@ -432,7 +432,7 @@ Everywhere where non-const trait bounds can be written.
     * super trait bounds
     * where bounds
     * associated type bounds
-* return position impl trait
+* return position impl trait and dyn traits are not covered by this RFC
 
 ### `const` desugaring
 
@@ -917,6 +917,20 @@ impl Trait for Type {
 ```
 
 This does not enable the use cases that `const trait`s would enable, because changing an existing method to `const fn` under a trait would be a breaking change, while changing a trait to `const trait` would not.
+
+### Const inherent impls
+
+Another natural extension of this RFC is to allow inherent impls to be const as well:
+
+```rust
+const impl<T: [const] Trait> Foo<T> {
+    pub fn my_method() {
+        // ...
+    }
+}
+```
+
+Doing so allows the `impl` to have `[const]` bounds and would imply all of its associated functions are `const`.
 
 ### Derives
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -19,13 +19,13 @@ const trait Default {
     fn default() -> Self;
 }
 
-impl const Default for () {
+const impl Default for () {
     fn default() {}
 }
 
 struct Thing<T>(T);
 
-impl<T: [const] Default> const Default for Thing<T> {
+impl<T: [const] Default> Default for Thing<T> {
     fn default() -> Self { Self(T::default()) }
 }
 
@@ -167,7 +167,7 @@ Free functions are unaffected and will stay as `const fn`.
 
 ### `const` methods and non-`const` methods on the same trait
 
-If the trait is marked as `const trait Trait`, then all methods under an `impl const Foo for Trait` are assumed
+If the trait is marked as `const trait Trait`, then all methods under an `const impl Foo for Trait` are assumed
 to be callable in const contexts. Thus the only way to implement a `const trait` using non-const operations
 would be to use a non-const `impl`: `impl Foo for Trait`. There is no opt-out from const per-method because it's a
 niche use case that can be trivially worked around.
@@ -183,7 +183,7 @@ const trait Default {
     fn default() -> Self;
 }
 
-impl const Default for () {
+const impl Default for () {
     fn default() {}
 }
 
@@ -261,7 +261,7 @@ which we definitely do not support and have historically rejected over and over 
 ### Impls with const methods for conditionally const trait methods
 
 `const trait` impls for generic types work similarly to generic `const fn`.
-Any `impl const Trait for Type` is allowed to have `[const]` trait bounds:
+Any `const impl Trait for Type` is allowed to have `[const]` trait bounds:
 
 ```rust
 use std::ops::Add;
@@ -301,13 +301,13 @@ struct MyStruct<T>(T);
 generates
 
 ```rust
-impl<T: [const] PartialEq> const PartialEq for MyStruct<T> {
+const impl<T: [const] PartialEq> PartialEq for MyStruct<T> {
     fn eq(&self, other: &Rhs) -> bool {
         self.0 == other.0
     }
 }
 
-impl<T: [const] Eq> const Eq for MyStruct<T> {}
+const impl<T: [const] Eq> Eq for MyStruct<T> {}
 ```
 
 For this RFC, we stick with `derive_const`, because it interacts with other ongoing bits of design work (e.g., RFC 3715)
@@ -467,7 +467,7 @@ Everywhere where non-const trait bounds can be written.
 ### Sites where `[const] Trait` bounds can be used
 
 * `const fn`
-* `impl const Trait` blocks
+* `const impl Trait` blocks
 * NOT in inherent impls, the individual `const fn` need to be annotated instead
 * `const trait` declarations
     * super trait bounds
@@ -554,7 +554,7 @@ The following never drops `T`, because it's the job of `<T as Add>` to handle dr
 ```rust
 struct NewType<T>(T);
 
-impl<T: [const] Add<Output = T>> const Add for NewType<T> {
+const impl<T: [const] Add<Output = T>> Add for NewType<T> {
     type Output = Self;
     fn add(self, other: Self) -> Self::Output {
         NewType(self.0 + other.0)
@@ -569,7 +569,7 @@ struct NewType<T>(T, bool);
 
 struct Error;
 
-impl<T: [const] Add<Output = T>> const Add for NewType<T> {
+const impl<T: [const] Add<Output = T>> Add for NewType<T> {
     type Output = Result<Self, Error>;
     fn add(self, other: Self) -> Self::Output {
         if self.1 {
@@ -620,7 +620,7 @@ const trait Bar {
 
 struct Foo<T: Bar>(T);
 
-impl<T: [const] Bar> const Drop for Foo<T> {
+const impl<T: [const] Bar> Drop for Foo<T> {
     fn drop(&mut self) {
         self.0.thing();
     }
@@ -639,7 +639,7 @@ a type can be declared, but not dropped, because bounds are unfulfilled, this is
 Extraneous `[const] Trait` bounds where `Trait` isn't a bound on the type at all are still rejected:
 
 ```rust
-impl<T: [const] Bar + [const] Baz> const Drop for Foo<T> {
+const impl<T: [const] Bar + [const] Baz> Drop for Foo<T> {
     fn drop(&mut self) {
         self.0.thing();
     }
@@ -650,15 +650,15 @@ errors with
 
 ```
 error[E0367]: `Drop` impl requires `T: Baz` but the struct it is implemented for does not
-  --> src/lib.rs:13:22
+  --> src/lib.rs:11:29
    |
-13 | impl<T: [const] Bar + [const] Baz> const Drop for Foo<T> {
-   |                       ^^^^^^^^^^^
+11 | const impl<T: [const] Bar + [const] Baz> Drop for Foo<T> {
+   |                             ^^^^^^^^^^^
    |
 note: the implementor must specify the same requirement
-  --> src/lib.rs:8:1
+  --> src/lib.rs:3:1
    |
-8  | struct Foo<T: Bar>(T);
+ 3 | struct Foo<T: Bar>(T);
    | ^^^^^^^^^^^^^^^^^^
 ```
 
@@ -816,7 +816,7 @@ trait Foo: [const] Bar + Baz {
     fn baz();
 }
 
-impl const Foo for () {
+const impl Foo for () {
     fn baz() {}
 }
 
@@ -835,7 +835,7 @@ trait Foo: Bar + ?const Baz {
     fn baz();
 }
 
-impl const Foo for () {
+const impl Foo for () {
     fn baz() {}
 }
 
@@ -950,7 +950,7 @@ so that the ecosystem slowly migrates, maybe with an actual deprecation warning 
 `const fn` can also be called at runtime just fine, while the others are always const
 contexts and need to be evaluated by the const evaluator.
 
-Additionally `const Trait` bounds have a third meaning (the same as `const Trait` in `impl const Trait for Type`):
+Additionally `const Trait` bounds have a third meaning (the same as `const Trait` in `const impl Trait for Type`):
 
 They can be invoked at compile time, but also in `const fn`.
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -84,7 +84,7 @@ fn compile_time_default<T: Default>() -> T {
 ```
 
 Neither of the above should (or do) compile.
-The first, because you could pass any type T whose default impl could
+This is because you could pass any type `T` whose `impl` could
 
 * mutate a global static,
 * read from a file, or
@@ -111,7 +111,7 @@ So, we need some annotation that differentiates a `T: Default` bound from one th
 
 ### Const methods
 
-Traits can declare methods as `const`. Changing an existing non-`const` method to a `const` one is a breaking change, as all impls are now required to provide the method as `const`, which existing impls can't.
+Traits can declare methods as `const`. Changing an existing non-`const` method to a `const` one is a breaking change, as all impls are now required to provide the method as `const`, which existing impls can't. However, adding a new `const` method with a default body is not a breaking change.
 
 ```rust
 trait Trait {
@@ -141,7 +141,7 @@ Examples:
 * `trait Foo: const Bar {}`, requiring every type that has an impl for `Foo` (even a non-const one), to also have a trait impl with `const` methods for `Bar`.
 * `trait Foo { type Bar: const Trait; }`, requiring all the impls to provide a type for `Bar` that has a trait impl with `const` methods for `Trait`
 
-Such an impl allows you to use the type that is bound within a const block or any other const context, because we know that the type has a trait impl with `const` methods and thus
+Such an bound allows you to use the trait methods of those types within a const block or any other const context, because we know that the type has a trait impl with `const` methods and thus
 must be executable at compile time. The following function will invoke the `Default` impl of a type at compile time and store the result in a constant. Then it returns that constant instead of computing the value every time.
 
 ```rust
@@ -160,10 +160,10 @@ const trait Trait {
 }
 ```
 
+A trait needs to be `const` to use `const Trait` bounds and have `const impl`s on them.
+
 A method's (optional) default body must satisfy everything a `const fn` body must, making them callable in const contexts.
 Impls can now rely on the default methods being const, too, and don't need to override them with a const body.
-
-Free functions are unaffected and will stay as `const fn`.
 
 ### `const` methods and non-`const` methods on the same trait
 
@@ -199,10 +199,11 @@ const fn default<T: const Default>() -> T {
 }
 
 const _: () = default();
+// Ok! Since `(): const Default`
 
 fn main() {
-    let _: Box<u32> = default();
-    //~^ ERROR: <Box<u32> as Default>::default cannot be called at compile-time
+    let _: Box<()> = default();
+    //~^ ERROR: the trait bound `Box<()>: const Default` is not satisfied
 }
 ```
 
@@ -289,32 +290,6 @@ where
 
 See [this playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=11f9dd9ebcb2e618910a3e295da9f889) for an example that works on nightly today.
 
-### Derives
-
-Most of the time you don't want to write out your impls by hand, but instead derive them as the implementation is obvious from your data structure.
-
-```rust
-#[derive_const(PartialEq, Eq)]
-struct MyStruct<T>(T);
-```
-
-generates
-
-```rust
-const impl<T: [const] PartialEq> PartialEq for MyStruct<T> {
-    fn eq(&self, other: &Rhs) -> bool {
-        self.0 == other.0
-    }
-}
-
-const impl<T: [const] Eq> Eq for MyStruct<T> {}
-```
-
-For this RFC, we stick with `derive_const`, because it interacts with other ongoing bits of design work (e.g., RFC 3715)
-and we don't want to have to resolve all design questions at once to do anything.
-We encourage another RFC to integrate const/unsafe and potentially other modifiers into the derive syntax in a better way.
-If this lands prior to stabilization, we should implement the const portion of it, otherwise we'll deprecate `derive_const`.
-
 ### `[const] Destruct` trait
 
 The `Destruct` trait enables dropping types within a const context.
@@ -332,8 +307,8 @@ const fn bar<T: [const] Destruct>(t: T) {
 ```
 
 When a value of a generic type goes out of scope, it is dropped and (if it has one) its `Drop` impl gets invoked.
-This situation seems no different from other trait bounds, except that types can be dropped without implementing `Drop`
-(as they can contain types that implement `Drop`). In that case the type's drop glue is invoked.
+This situation seems no different from other trait bounds, except that types can have non-trivial destructors without implementing `Drop`
+(as they can contain types that implement `Drop`). In that case the type's drop glue needs to be invoked.
 
 The `Destruct` trait is a bound for whether a type has drop glue. This is trivally true for all types.
 
@@ -937,11 +912,35 @@ as they need to actually call the generic `FnOnce` argument or nested `PartialEq
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-## Better derive syntax than `#[derive_const(Trait)]`
 
-Once `unsafe` derives have been finalized, we can separately design const derives and
-deprecate `derive_const` at that time (mostly by just removing it from any documents explaining it,
-so that the ecosystem slowly migrates, maybe with an actual deprecation warning later).
+### Derives
+
+Most of the time you don't want to write out your impls by hand, but instead derive them as the implementation is obvious from your data structure.
+
+Therefore, it would be nice to have something like the following:
+
+```rust
+#[derive_const(PartialEq, Eq)]
+struct MyStruct<T>(T);
+```
+
+Which should generate
+
+```rust
+const impl<T: [const] PartialEq> PartialEq for MyStruct<T> {
+    fn eq(&self, other: &Rhs) -> bool {
+        self.0 == other.0
+    }
+}
+
+const impl<T: [const] Eq> Eq for MyStruct<T> {}
+```
+
+However, while this is easy to implement for built-in derive macros, it is unclear how to integrate this with custom derives. This interacts with other
+ongoing bits of design work (e.g., RFC 3715) and we don't want to have to resolve all design questions at once to do anything.
+
+Having derives for `const trait`s would be very useful, but this RFC intentionally avoids dealing with its complexities. The design question of how
+derives interact with `const trait`s can be answered in a different RFC, at the same time as e.g. perfect derives and `unsafe` derives.
 
 ## Migrate to `[const] fn`
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -60,9 +60,11 @@ const fn foo() {
 }
 ```
 
+Enabling const traits will allow these builtin language constructs to be used in const code, including but not limited to: `for` loops, `?` operator, and user-defined binary operators such as `==`. Furthermore, it will make it possible to call methods on generic types in const code, making them much more expressive.
+
 ## Background
 
-This RFC requires familarity with "const contexts", so you may have to read [the relevant reference section](https://doc.rust-lang.org/reference/const_eval.html#const-context) first.
+This RFC requires familiarity with "const contexts", so you may have to read [the relevant reference section](https://doc.rust-lang.org/reference/const_eval.html#const-context) first.
 
 Calling functions during const eval requires those functions' bodies to only use statements that const eval can handle. While it's possible to just run any code until it hits a statement const eval cannot handle, that would mean the function body is part of its semver guarantees. Something as innocent as a logging statement would make the function uncallable during const eval.
 
@@ -97,8 +99,8 @@ for types whose `Default` impl's `default` method satisfies all rules that `cons
 (including some annotation that guarantees this won't break by accident).
 It must always be possible to call `default` outside of const contexts with no limitations on the generic parameters that may be passed.
 
-Similarly it should be possible to write `compile_time_default` in a way that also requires calls
-outside of const contexts to only pass generic parameters whose `Default::default` method satisifies
+Similarly, it should be possible to write `compile_time_default` in a way that also requires calls
+outside of const contexts to only pass generic parameters whose `Default::default` method satisfies
 the usual `const fn` rules. This is necessary in order to allow a const block
 (which can access generic parameters) in the function body to invoke methods on the generic parameter.
 
@@ -109,23 +111,27 @@ So, we need some annotation that differentiates a `T: Default` bound from one th
 
 ## Nomenclature and new syntax concepts
 
-### Const methods
+### Const traits and their methods
 
-Traits can declare methods as `const`. Changing an existing non-`const` method to a `const` one is a breaking change, as all impls are now required to provide the method as `const`, which existing impls can't. However, adding a new `const` method with a default body is not a breaking change.
+Traits need to opt-in to allowing their impls to have const methods. Thus you need to mark the trait as `const` and all the methods will become const callable.
 
 ```rust
-trait Trait {
-    const fn method();
+const trait Trait {
+    fn thing();
 }
 ```
 
-These methods need to be implemented as `const`:
+A trait needs to be `const` to use `const Trait` bounds and have `const impl`s on them.
 
-```rust
-impl Trait for Type {
-    const fn method() {}
-}
-```
+A method's (optional) default body must satisfy everything a `const fn` body must, making them callable in const contexts.
+Impls can now rely on the default methods being const, too, and don't need to override them with a const body.
+
+### `const` methods and non-`const` methods on the same trait
+
+If the trait is marked as `const trait Trait`, then all methods under an `const impl Foo for Trait` are assumed
+to be callable in const contexts. Thus the only way to implement a `const trait` using non-const operations
+would be to use a non-const `impl`: `impl Foo for Trait`. There is no opt-out from const per-method because it's a
+niche use case that can be trivially worked around.
 
 ### Const trait bounds
 
@@ -149,28 +155,6 @@ fn compile_time_default<T: const Default>() -> T {
     const { T::default() }
 }
 ```
-
-### Const traits and their methods
-
-Traits need to opt-in to allowing their impls to have const methods. Thus you need to mark the trait as `const` and all the methods will become const callable.
-
-```rust
-const trait Trait {
-    fn thing();
-}
-```
-
-A trait needs to be `const` to use `const Trait` bounds and have `const impl`s on them.
-
-A method's (optional) default body must satisfy everything a `const fn` body must, making them callable in const contexts.
-Impls can now rely on the default methods being const, too, and don't need to override them with a const body.
-
-### `const` methods and non-`const` methods on the same trait
-
-If the trait is marked as `const trait Trait`, then all methods under an `const impl Foo for Trait` are assumed
-to be callable in const contexts. Thus the only way to implement a `const trait` using non-const operations
-would be to use a non-const `impl`: `impl Foo for Trait`. There is no opt-out from const per-method because it's a
-niche use case that can be trivially worked around.
 
 ### Conditionally-const trait bounds
 
@@ -912,6 +896,27 @@ as they need to actually call the generic `FnOnce` argument or nested `PartialEq
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
+### Const methods
+
+It seems natural to want, in addition to allowing `const impl`s for `const trait`s, individual methods to require `const` in all implementations.
+
+As the described feature appears to be orthogonal with the rest of const traits, proposing the following should be quite possible:
+
+```rust
+trait Trait {
+    const fn method();
+}
+```
+
+These methods need to be implemented as `const`, no matter whether they are `const impl`s:
+
+```rust
+impl Trait for Type {
+    const fn method() {}
+}
+```
+
+This does not enable the use cases that `const trait`s would enable, because changing an existing method to `const fn` under a trait would be a breaking change, while changing a trait to `const trait` would not.
 
 ### Derives
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -1,7 +1,7 @@
 - Feature Name: `const_trait_methods`
 - Start Date: 2024-12-13
 - RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
-- Rust Issue: [rust-lang/rust#67792](https://github.com/rust-lang/rust/issues/67792)
+- Rust Issue: [rust-lang/rust#143874](https://github.com/rust-lang/rust/issues/143874)
 
 # Summary
 [summary]: #summary

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -12,7 +12,7 @@ Make trait methods callable in const contexts. This includes the following parts
 * Allow marking `trait` impls as `const`.
 * Allow marking trait bounds as `const` to make methods of them callable in const contexts.
 
-Fully contained example ([Playground of currently working example](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=2ab8d572c63bcf116b93c632705ddc1b)):
+Fully contained example ([Playground of currently working example](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=802ebb58d88a4f85a8f2d6ed82cbb139)):
 
 ```rust
 const trait Default {
@@ -163,16 +163,6 @@ const trait Trait {
 A method's (optional) default body must satisfy everything a `const fn` body must, making them callable in const contexts.
 Impls can now rely on the default methods being const, too, and don't need to override them with a const body.
 
-Note that on nightly the syntax is
-
-```rust
-#[const_trait]
-trait Trait {
-    fn thing();
-}
-```
-
-and a result of this RFC would be to turn `#[const_trait]` into `const trait` syntax for trait declarations.
 Free functions are unaffected and will stay as `const fn`.
 
 ### `const` methods and non-`const` methods on the same trait
@@ -274,27 +264,30 @@ which we definitely do not support and have historically rejected over and over 
 Any `impl const Trait for Type` is allowed to have `[const]` trait bounds:
 
 ```rust
+use std::ops::Add;
+
 struct MyStruct<T>(T);
 
-impl<T: [const] Add<Output = T>> const Add for MyStruct<T> {
+const impl<T: [const] Add<Output = T>> Add for MyStruct<T> {
     type Output = MyStruct<T>;
     fn add(self, other: MyStruct<T>) -> MyStruct<T> {
         MyStruct(self.0 + other.0)
     }
 }
 
-impl<T> const Add for &MyStruct<T>
+const impl<T> Add for &MyStruct<T>
 where
-    for<'a> &'a T: [const] Add<Output = T>,
+    for<'a> &'a T: ~const Add<Output = T>,
 {
     type Output = MyStruct<T>;
     fn add(self, other: &MyStruct<T>) -> MyStruct<T> {
         MyStruct(&self.0 + &other.0)
     }
 }
+
 ```
 
-See [this playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=313a38ef5c36b2ddf489f74167c1ac8a) for an example that works on nightly today.
+See [this playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=11f9dd9ebcb2e618910a3e295da9f889) for an example that works on nightly today.
 
 ### Derives
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -404,7 +404,7 @@ parameters, too:
 
 
 ```rust
-const fn foo<T: [const] Debug, F: [const] Fn(T)>(f: F, arg: T) {
+const fn foo<T, F: [const] Fn(T)>(f: F, arg: T) {
     f(arg)
 }
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -109,7 +109,7 @@ So, we need some annotation that differentiates a `T: Default` bound from one th
 
 ## Nomenclature and new syntax concepts
 
-### Const trait methods
+### Const methods
 
 Traits can declare methods as `const`. Changing an existing non-`const` method to a `const` one is a breaking change, as all impls are now required to provide the method as `const`, which existing impls can't.
 
@@ -150,7 +150,7 @@ fn compile_time_default<T: const Default>() -> T {
 }
 ```
 
-### Conditionally const traits methods
+### Const traits and their methods
 
 Traits need to opt-in to allowing their impls to have const methods. Thus you need to mark the trait as `const` and all the methods will become const callable.
 
@@ -301,7 +301,7 @@ See [this playground](https://play.rust-lang.org/?version=nightly&mode=debug&edi
 Most of the time you don't want to write out your impls by hand, but instead derive them as the implementation is obvious from your data structure.
 
 ```rust
-#[const_derive(PartialEq, Eq)]
+#[derive_const(PartialEq, Eq)]
 struct MyStruct<T>(T);
 ```
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -15,7 +15,7 @@ Make trait methods callable in const contexts. This includes the following parts
 Fully contained example ([Playground of currently working example](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=2ab8d572c63bcf116b93c632705ddc1b)):
 
 ```rust
-[const] trait Default {
+const trait Default {
     fn default() -> Self;
 }
 
@@ -152,10 +152,10 @@ fn compile_time_default<T: const Default>() -> T {
 
 ### Conditionally const traits methods
 
-Traits need to opt-in to allowing their impls to have const methods. Thus you need to mark the trait as `[const]` and all the methods will become const callable.
+Traits need to opt-in to allowing their impls to have const methods. Thus you need to mark the trait as `const` and all the methods will become const callable.
 
 ```rust
-[const] trait Trait {
+const trait Trait {
     fn thing();
 }
 ```
@@ -172,24 +172,24 @@ trait Trait {
 }
 ```
 
-and a result of this RFC would be to turn `#[const_trait]` into `[const] trait` syntax for trait declarations.
+and a result of this RFC would be to turn `#[const_trait]` into `const trait` syntax for trait declarations.
 Free functions are unaffected and will stay as `const fn`.
 
 ### `const` methods and non-`const` methods on the same trait
 
-If the trait is marked as `[const] trait Trait`, then all methods under an `impl const Foo for Trait` are assumed
-to be callable in const contexts. Thus the only way to implement a `[const] trait` using non-const operations
+If the trait is marked as `const trait Trait`, then all methods under an `impl const Foo for Trait` are assumed
+to be callable in const contexts. Thus the only way to implement a `const trait` using non-const operations
 would be to use a non-const `impl`: `impl Foo for Trait`. There is no opt-out from const per-method because it's a
 niche use case that can be trivially worked around.
 
 ### Conditionally-const trait bounds
 
-Many generic `const fn` and especially many `[const] trait`s do not actually require a const methods in the trait impl for their generic parameters.
+Many generic `const fn` and especially many `const trait`s do not actually require a const methods in the trait impl for their generic parameters.
 As `const fn` can also be called at runtime, it would be too strict to require it to only be able to call things with const methods in the trait impls.
 Picking up the example from [the beginning](#summary):
 
 ```rust
-[const] trait Default {
+const trait Default {
     fn default() -> Self;
 }
 
@@ -471,12 +471,12 @@ Thus that approach was abandoned after proponents and opponents cooperated in tr
 
 Everywhere where non-const trait bounds can be written.
 
-### Sites where `(const) Trait` bounds can be used
+### Sites where `[const] Trait` bounds can be used
 
 * `const fn`
 * `impl const Trait` blocks
 * NOT in inherent impls, the individual `const fn` need to be annotated instead
-* `[const] trait` declarations
+* `const trait` declarations
     * super trait bounds
     * where bounds
     * associated type bounds
@@ -612,7 +612,7 @@ In the future we will also want to support `dyn [const] Trait` bounds, which inv
 While that can in generic contexts always be handled by adding more `[const] Destruct` bounds, it would be more similar to how normal `dyn` safety
 works if there were implicit `[const] Destruct` bounds for (most?) `[const] Trait` bounds.
 
-Thus we lint all `[const] trait`s with methods that take `self` by value to also have a `(const) Destruct` super trait bound to ensure users don't need to add `[const] Destruct` bounds everywhere.
+Thus we lint all `const trait`s with methods that take `self` by value to also have a `(const) Destruct` super trait bound to ensure users don't need to add `[const] Destruct` bounds everywhere.
 Other traits may want to add them, and some traits with `self` by value methods may not want to add them. Since it is not backwards compatible to require or relax that super trait bound later,
 we aren't requiring users to choose either, but are suggesting good defaults via lints.
 
@@ -621,7 +621,7 @@ we aren't requiring users to choose either, but are suggesting good defaults via
 It is legal to add `[const]` to `Drop` impls' bounds, even though the struct doesn't have them:
 
 ```rust
-[const] trait Bar {
+const trait Bar {
     fn thing(&mut self);
 }
 

--- a/text/0000-const-trait-impls.md
+++ b/text/0000-const-trait-impls.md
@@ -111,8 +111,7 @@ So, we need some annotation that differentiates a `T: Default` bound from one th
 
 ### Const trait methods
 
-Traits can declare methods as `const`. Doing so is a breaking change, as all impls are now required to provide a `const` method,
-which existing impls can't.
+Traits can declare methods as `const`. Changing an existing non-`const` method to a `const` one is a breaking change, as all impls are now required to provide the method as `const`, which existing impls can't.
 
 ```rust
 trait Trait {


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3762)*

Please remember to create inline comments for discussions to keep this RFC manageable and discussion trees resolveable.

[Rendered](https://github.com/oli-obk/rfcs/blob/const-trait-impl/text/0000-const-trait-impls.md)

Related:

- https://github.com/rust-lang/rust/issues/67792