### PR TITLE
Made example coherent with text

### DIFF
--- a/text/0505-api-comment-conventions.md
+++ b/text/0505-api-comment-conventions.md
@@ -33,7 +33,7 @@ standard library. These are called out specifically in the text itself.
 Avoid block comments. Use line comments instead:
 
 ```rust
-// Wait for the main task to return, and set the process error code
+// Waits for the main task to return, and sets the process error code
 // appropriately.
 ```
 
@@ -41,7 +41,7 @@ Instead of:
 
 ```rust
 /*
- * Wait for the main task to return, and set the process error code
+ * Waits for the main task to return, and sets the process error code
  * appropriately.
  */
 ```

--- a/text/1574-more-api-documentation-conventions.md
+++ b/text/1574-more-api-documentation-conventions.md
@@ -332,7 +332,7 @@ to every grammar question, but there is often some kind of formal consensus.
 Avoid block comments. Use line comments instead:
 
 ```rust
-// Wait for the main task to return, and set the process error code
+// Waits for the main task to return, and sets the process error code
 // appropriately.
 ```
 
@@ -340,7 +340,7 @@ Instead of:
 
 ```rust
 /*
- * Wait for the main task to return, and set the process error code
+ * Waits for the main task to return, and sets the process error code
  * appropriately.
  */
 ```


### PR DESCRIPTION
The example in the API conventions (in imperative) contradicts the text (use third person). This PR corrects the example to fit the text description.