### PR TITLE
Rename RFC and update RFC pull request link

### DIFF
--- a/text/3631-rustdoc-cfgs-handling.md
+++ b/text/3631-rustdoc-cfgs-handling.md
@@ -2,7 +2,7 @@ Rustdoc: stabilization of the `doc(cfg*)` attributes
 
 - Features Name: `doc_cfg`
 - Start Date: 2022-12-07
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3631](https://github.com/rust-lang/rfcs/pull/3631)
 - Rust Issue: [rust-lang/rust#43781](https://github.com/rust-lang/rust/issues/43781)
 
 


### PR DESCRIPTION
Went too quickly in https://github.com/rust-lang/rfcs/pull/3631 and forgot to rename the RFC file...

[Rendered](https://github.com/GuillaumeGomez/rfcs/blob/rustdoc-doc-cfg-rfc/text/3631-rustdoc-cfgs-handling.md)