### PR TITLE
Support triagebot assignment and shortcuts

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -8,6 +8,10 @@ allow-unauthenticated = [
 [rendered-link]
 trigger-files = ["text/"]
 
+[assign]
+
+[shortcut]
+
 [notify-zulip."T-cargo"]
 zulip_stream = 246057 # t-cargo
 topic = "RFC #{number} - {title}"


### PR DESCRIPTION
It's convenient to be able to use triagebot shortcuts such as `@rustbot author` and `@rustbot ready`, and to be able to use the similar shortcuts for assignment, so let's enable those in this repository.

cc @ehuss