### PR TITLE
`rustc_scalable_vector`

### DIFF
--- a/text/3838-scalable-vectors.md
+++ b/text/3838-scalable-vectors.md
@@ -267,8 +267,6 @@ codegen backend:
       element of the same type (but only if that struct is annotated with
       `#[rustc_scalable_vector]`)
 
-- Cannot be used in arrays
-
 - Cannot be the type of a static variable
 
 - Cannot be instantiated into generic functions (see


### PR DESCRIPTION
Supercedes #3268.

Introduces a new attribute, `#[rustc_scalable_vector(N)]`, which can be used to define new scalable vector types, such as those in Arm's Scalable Vector Extension (SVE), or RISC-V's Vector Extension (RVV).

`rustc_scalable_vector(N)` is internal compiler infrastructure that will be used only in the standard library to introduce scalable vector types which can then be stabilised. Only the infrastructure to define these types are introduced in this RFC, not the types or intrinsics that use it.

This RFC has a dependency on #3729 as scalable vectors are necessarily non-const `Sized`.

**There are some large unresolved questions in this RFC, the current purpose of the RFC is to indicate a intended direction for this work to justify an experimental implementation to help resolve those unresolved questions.**

[Rendered](https://github.com/davidtwco/rfcs/blob/repr-scalable/text/3838-scalable-vectors.md)