### PR TITLE
RFC: Safety Tags

### DIFF
--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -21,7 +21,6 @@ and provide first-class IDE support.
 #![feature(custom_inner_attributes)]
 #![clippy::safety(invariant::ValidPtr)] // 💡
 
-
 pub mod invariant {
     #[clippy::safety::tag]
     pub fn ValidPtr() {}
@@ -239,14 +238,16 @@ Safety-tag analysis requirements:
 
 * Harvest every item marked `#[clippy::safety::tag]`, including those pulled in from dependencies.  
 * Offer path completion for `#![clippy::safety { ... }]`.  
-* Offer tag-name completion for `#[clippy::safety]` on unsafe functions, let-statements, or expressions.  
-* Validate all tags inside `#[clippy::safety]`, and support “go-to-definition” plus inline documentation hover.
+* Offer tag-name completion for `#[clippy::safety]` on unsafe functions, let-statements, or
+  expressions.  
+* Validate all tags inside `#[clippy::safety]`, and support “go-to-definition” plus inline
+  documentation hover.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
 Even though safety tags are machine-readable, their correctness still hinges on human review:
-developers can silence Clippy by discharging tags without verifying the underlying obligations.
+developers can silence Clippy by discharging tags without verifying underlying safety requirements.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -318,7 +319,7 @@ Currently, there are efforts on introducing contracts and formal verification in
 * [verify-rust-std] pursues applying formal verification tools to libstd. Also see Rust Foundation
   [announcement][vrs#ann], project goals during [2024h2] and [2025h1].
 
-While safety tags are less formally verified, intended to be a check list on safety requirements.
+While safety tags are less formally verified and intended to be a check list on safety requirements.
 
 [verify-rust-std]: https://github.com/model-checking/verify-rust-std
 [vrs#ann]: https://foundation.rust-lang.org/news/rust-foundation-collaborates-with-aws-initiative-to-verify-rust-standard-libraries/
@@ -336,7 +337,7 @@ Crates with heavy unsafe-trait usage will likely need. We’d welcome more minds
 
 ## Tagging on Datastructures
 
-We believe safety obligations are almost always imposed by unsafe functions, so tagging a struct,
+We believe safety requirements are almost always imposed by unsafe functions, so tagging a struct,
 enum, or union is neither needed nor permitted.
 
 ## Tagging on Unsafe Fields

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -355,7 +355,7 @@ their call sites. To enable experimentation, a nightly-only library feature
 
 Procedure:
 
-1. Validate `#[safety::requires]` only appears on unsafe functions if the attribute exists.
+1. Validate `#[safety::requires]` only appears on functions with the `unsafe` qualifier.
    - Merge tags in multiple `requires` on the same function. Emit error if tag name duplicates.
 2. Validate `#[safety::checked]` on HIR nodes whose `ExprKind` is one of
    - **direct unsafe nodes**: `Call`, `MethodCall` that invoke an unsafe function/method, or
@@ -448,7 +448,7 @@ We therefore seek approvals from the following teams:
 2. **Clippy team** – to integrate tag checking into the linter.
 3. **Rust-Analyzer team** – to add IDE support for tags.
 3. **Rustdoc team** – to render tags to docs.
-4. **Compiler team** – to reserve the `safety` namespace and gate the feature via
+4. **Language team** – to reserve the `safety` namespace and gate the feature via
    `#![feature(safety_tags)]` for the namespace and tag APIs in standard libraries.
 
 [safety-tool]: https://github.com/Artisan-Lab/tag-std/blob/main/safety-tool

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -239,7 +239,7 @@ unsafe fn delegation<T>(ptr: *const T) -> T {
 
     #[safety::checked(
       aligned = "alignment of ptr has be adjusted",
-      validPtr, initialized = "delegated to the caller"
+      valid_ptr, initialized = "delegated to the caller"
     )]
     unsafe { read(ptr) }
 }
@@ -247,11 +247,11 @@ unsafe fn delegation<T>(ptr: *const T) -> T {
 
 `valid_ptr` and `initialized` are grouped together to share "delegated to the caller". We do not
 introduce new syntax for grouping tags but instead suggest visually grouping them for clarity. When
-`rustfmt` automatically formats `ValidPtr` to its own line, the only workaround is to set
+`rustfmt` automatically formats `valid_ptr` to its own line, the only workaround is to set
 `attr_fn_like_width = 0` in the `rustfmt.toml` configuration file. For further discussion on this
 tag styling, see this [link](https://github.com/rust-lang/rfcs/pull/3842#discussion_r2296076785).
 
-In this delegation case, you're able to declare a new meaningful tag for ValidPtr and Initialized
+In this delegation case, you're able to declare a new meaningful tag for valid_ptr and initialized
 invariants, and define the new tag on `delegation` function. This practice extends to partial unsafe
 delegation of multiple tag discharges:
 
@@ -402,15 +402,15 @@ Treat `#[safety::requires]` tool attributes on unsafe functions as `#[doc]` attr
 tag names and definitions to render as item list:
 
 ```rust
-#[safety::requires(tag1 = "definition1")]
-#[safety::requires(tag2 = "definition2")]
+#[safety::requires(first_tag = "definition1")]
+#[safety::requires(second_tag = "definition2")]
 ```
 
 will be rendered if in markdown syntax
 
 ```md
-* `Tag1`: definition1
-* `Tag2`: definition2
+* First tag: definition1
+* Second tag: definition2
 ```
 
 It'd be good if tag names have a special css class like background color to be attractive. Tag

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -140,6 +140,16 @@ LLL | unsafe { ptr::read(ptr) }
 
 The process of verifying whether a tag is absent is referred to as tag discharge.
 
+Note that it's allowed to discharge tags of unsafe callees onto the unsafe caller for unsafe
+encapsulation:
+
+```rust
+#[clippy::safety { ValidPtr, Aligned, Initialized }] // ✅
+unsafe fn constructor<T>() -> T {
+    unsafe { read(...) }
+}
+```
+
 ## Safety Tags as Ordinary Items
 
 Before tagging a function, we must declare them as ordinary items with `#[clippy::safety::tag]` such
@@ -209,7 +219,7 @@ Currently, safety tags requires the following unstable features
 Since the safety-tag mechanism is implemented primarily in Clippy and rust-analyzer, no additional
 support is required from rustc.
 
-But We ask the libs team to adopt safety tags for all public `unsafe` APIs in libstd, along with
+But we ask the libs team to adopt safety tags for all public `unsafe` APIs in libstd, along with
 their call sites. To enable experimentation, a nightly-only library feature
 `#![feature(safety_tags)]` should be introduced and remain unstable until the design is finalized.
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -138,10 +138,10 @@ LLL | unsafe { ptr::read(ptr) }
     = NOTE: See core::ptr::invariants::Initialized
 ```
 
-The process of verifying whether a tag is absent is referred to as tag discharge.
+The process of verifying whether a tag is present is referred to as tag discharge.
 
 Note that it's allowed to discharge tags of unsafe callees onto the unsafe caller for unsafe
-encapsulation:
+delegation or propogation:
 
 ```rust
 #[clippy::safety { ValidPtr, Aligned, Initialized }] // ✅

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -449,13 +449,12 @@ to implement them.
 
 We therefore seek approvals from the following teams:
 
-1. **Library team** – to allow the tagging of unsafe operations and to expose tag items as public
-   APIs.
+1. **Library team** – to allow tagging unsafe public functions and unsafe calls.
 2. **Clippy team** – to integrate tag checking into the linter.
 3. **Rust-Analyzer team** – to add IDE support for tags.
 3. **Rustdoc team** – to render tags to docs.
 4. **Language team** – to reserve the `safety` namespace and gate the feature via
-   `#![feature(safety_tags)]` for the namespace and tag APIs in standard libraries.
+   `#![feature(safety_tags)]` for the namespace and tagged APIs in standard libraries.
 
 [safety-tool]: https://github.com/Artisan-Lab/tag-std/blob/main/safety-tool
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -265,13 +265,15 @@ Note that discharing a tag that is not defined will raise a hard error.
 
 Tags constitute a public API; therefore, any alteration to their definition must be evaluated
 against [Semantic Versioning][semver].
-* Adding a tag definition is a **minor** change.
-* Removing a tag definition is a **major** change. Renaming a tag definition is a two-step
-  operation of removal and addition, bringing a major change due to removal. 
+* Adding a tag definition is a **major** change, because new tag is missing. 
+* Removing a tag definition is a **major** change, because the tag doesn't exist.
+* Renaming a tag definition is a **major** change, because it's the result of removal and addition.
+* Marking or cancelling `@deprecated` in tag definition description is a *minor* change, because
+  the tag is still able to be checked.
 
 [semver]: https://doc.rust-lang.org/cargo/reference/semver.html
 
-To give dependent crates time to migrate an outdated tag definition, use `@deprecated` in tag
+To grant dependent crates time to migrate an outdated tag definition, use `@deprecated` in tag
 description. Clippy will emit a deprecation warning whenever the tag is used in `safety::checked`.
 
 ```rust
@@ -321,7 +323,8 @@ Procedure:
       otherwise emit a diagnostic. *(We intentionally stop at this simple rule; splitting complex
       unsafe expressions into separate annotated nodes is considered good style.)*
    4. Make sure tags in `#[safety::checked]` correspond to their definitions.
-   5. Diagnostics are emitted at the current Clippy lint level (warning or error).
+   5. If tags marked `@deprecated` in definitions are successfully checked, emit diagnostics. 
+   6. Diagnostics are emitted at the current Clippy lint level (warning or error).
 
 [HIR ExprKind]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/enum.ExprKind.html
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -287,8 +287,10 @@ against [Semantic Versioning][semver].
 
 NOTE:
 * `requires` or `checked` can be specified multiple times, and they will be merged together.
-  * Duplicate tags in `requires` will trigger errors.
-  * Duplicate tags in `checked` will trigger warning-by-default diagnostics.
+  * Duplicate tags in `requires` will trigger errors, due to no description merge in definitions.
+  * Duplicate tags in `checked` will trigger warnings by default, as `checked` is lenient in
+    diagnostics. This leniency also applies when a defined tag is omitted or a non-existent tag is
+    added. However, Clippy lint levels can be configured to treat such checks as hard errors.
 * the scope of a tag is limited to the defining unsafe function, so identical tag name on different
   unsafe functions won't affect each other.
 
@@ -602,6 +604,11 @@ struct, enum, or union is neither needed nor permitted.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
+
+## Upgrade tag checking in `cargo check` 
+
+If safety tags become standard practice or are widely accepted, tag checks could be integrated into
+rustc, allowing `cargo check` to perform these checks.
 
 ## Discharge One Tag from `any = { Option1, Option2 }`
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -1,0 +1,469 @@
+- Feature Name: safety_tag
+- Start Date: 2025-07-29
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+This RFC introduces a concise safety-comment convention for unsafe code in libstd-adjacent crates:
+tag every unsafe function and call with `#[safety { SP1, SP2 }]`.
+
+Safety tags refine today’s safety-comment habits: a featherweight syntax that condenses every
+requirement into a single, check-off reminder.
+
+The following snippet [compiles] today, but we expect Clippy and rust-analyzer to enforce tag checks
+and provide first-class IDE support.
+
+[compiles]: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=056cbe626a7cc92a317e38e9f54cb1fb
+
+```rust
+#![feature(custom_inner_attributes)]
+#![clippy::safety(invariant::ValidPtr)] // 💡
+
+
+pub mod invariant {
+    #[clippy::safety::tag]
+    pub fn ValidPtr() {}
+}
+
+#[clippy::safety { ValidPtr }] // 💡
+pub unsafe fn read<T>(ptr: *const T) {}
+
+fn main() {
+    #[clippy::safety { ValidPtr }] // 💡
+    unsafe { read(&()) };
+}
+```
+
+# Motivation
+[motivation]: #motivation
+
+To avoid the misuse of unsafe code, Rust developers are encouraged to provide clear safety comments
+for unsafe APIs. While these comments are generally human-readable, they can be ambiguous and
+laborious to write. Even the current best practices in the Rust standard library are somewhat ad hoc
+and informal. Moreover, safety comments are often repetitive and may be perceived as less important
+than the code itself, which makes them error-prone and increases the risk that reviewers may
+overlook inaccuracies or missing safety requirements.
+
+For instance, a severe problem may arise if the safety requirements of an API change over time:
+downstream users may be unaware of such changes and thus be exposed to security risks. Therefore, we
+propose to improve the current practice of writing safety comments by making them checkable through
+a system of safety tags. These tags are designed to be:
+
+* Compatible with existing safety documentation: Safety tags should be expressive enough to
+  represent current safety comments, especially as rendered in today's rustdoc HTML pages.
+* Usable by compiler tools for safety checking: If no safety tags are provided for an unsafe API,
+  lints should be emitted to remind developers to provide safety requirements. If a safety tag is
+  declared for an unsafe API but not discharged at a callsite, lints should be emitted to alert
+  developers about potentially overlooked safety requirements.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## Syntax of Safety Tags
+
+Syntax of a safety tag is defined as follows:
+
+```text
+SafetyTag -> `#` `[` `clippy::safety` `{` Tags `}` `]`
+
+Tags -> Tag (`;` Tag)*
+
+Tag -> ID (`,` ID)* (`:` LiteralString)?
+
+ID -> SingleIdent | SimplePath
+```
+
+Here are some tag examples:
+
+```rust
+#[clippy::safety { SP }]
+#[clippy::safety { SP1, SP2 }]
+
+#[clippy::safety { SP1: "reason" }]
+#[clippy::safety { SP1: "reason"; SP2: "reason" }]
+
+#[clippy::safety { SP1, SP2: "shared reason for the two SPs" }]
+#[clippy::safety { SP1, SP2: "shared reason for the two SPs"; SP3 }]
+#[clippy::safety { SP3; SP1, SP2: "shared reason for the two SPs" }]
+```
+
+`#[clippy::safety]` is a [tool attribute] that you attach to an unsafe function (or to an expression
+that performs unsafe calls). Take [`ptr::read`]: its safety comment lists three requirements, so we
+create three corresponding tags on the function declaration and mark each one off at the call site.
+
+```rust
+#[clippy::safety { ValidPtr, Aligned, Initialized }] // defsite
+pub unsafe fn read<T>(ptr: *const T) -> T { ... }
+
+#[clippy::safety { ValidPtr, Aligned, Initialized }] // callsite
+unsafe { read(ptr) };
+```
+
+We can also attach comments for a tag or a group of tags to clarify how safety requirements are met:
+
+```rust
+#[clippy::safety {
+  InBounded, ValidNum: "`n` won't exceed isize::MAX here, so `p.add(n)` is fine";
+  ValidPtr, Aligned, Initialized: "addr range p..p+n is property initialized"
+}]
+for _ in 0..n {
+    unsafe {
+        p = p.add(1);
+        c ^= p.read();
+    }
+}
+```
+
+[tool attribute]: https://doc.rust-lang.org/reference/attributes.html#tool-attributes
+[`ptr::read`]: https://doc.rust-lang.org/std/ptr/fn.read.html
+
+Every safety tag declared on a function must appear in `#[clippy::safety { ... }]` together with an
+optional reason; any omission triggers a warning-by-default diagnostic that lists the missing tags
+and explains each one:
+
+```rust
+unsafe { ptr::read(ptr) }
+```
+
+```rust
+warning: `ValidPtr`, `Aligned`, `Initialized` tags are missing. Add them to `#[clippy::safety { }]`.
+   --> file.rs:xxx:xxx
+    |
+LLL | unsafe { ptr::read(ptr) }
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^ This unsafe call requires these safety tags.
+    |
+    = NOTE: See core::ptr::invariants::ValidPtr
+    = NOTE: See core::ptr::invariants::Aligned
+    = NOTE: See core::ptr::invariants::Initialized
+```
+
+The process of verifying whether a tag is absent is referred to as tag discharge.
+
+## Safety Tags as Ordinary Items
+
+Before tagging a function, we must declare them as ordinary items with `#[clippy::safety::tag]` such
+as [uninhabited] types or plain functions:
+
+```rust
+#[clippy::safety::tag]
+enum ValidPtr {}
+
+#[clippy::safety::tag]
+fn Aligned() {}
+```
+
+Tags live in their own [type namespace] carry item-level [scopes] and obey [visibility] rules,
+keeping the system modular and collision-free. Since they are never referenced directly as real
+items inside the safety-macro, importing them uses a dedicated syntax:
+
+```rust
+#![clippy::safety { UseTree })]
+```
+
+[`UseTree`] follows the exact grammar of the `use` declaration. Some examples:
+
+```rust
+// at the top of module:
+#![clippy::safety { core::ptr::invariants::* }]
+#![clippy::safety { core::ptr::invariants::ValidPtr }]
+#![clippy::safety { core::ptr::invariants::{ValidPtr, Aligned} }]
+```
+
+That's to say:
+* Tags declared or re-exported in the current module are automatically in scope: no import required.
+* Tags from other modules must be brought in with the inner-tool attribute shown above.
+* Tags are visible and available to downstream crates whenever their declaration paths are public.
+* Attempting to import a tag from a private module is a **hard error**.
+* Referencing a tag that has never been declared is also a **hard error**.
+
+[uninhabited]: https://doc.rust-lang.org/reference/glossary.html#uninhabited
+[type namespace]: https://doc.rust-lang.org/reference/names/namespaces.html
+[item scopes]: https://doc.rust-lang.org/reference/names/scopes.html#item-scopes
+[visibility]: https://doc.rust-lang.org/reference/visibility-and-privacy.html
+[`UseTree`]: https://doc.rust-lang.org/reference/items/use-declarations.html
+
+Tags are treated as items so rustdoc can render their documentation and hyperlink tag references.
+And rust-analyzer can offer **full IDE support**: completion, go-to-definition/declaration, and
+doc-hover.
+
+Tags constitute a public API; therefore, any alteration to their declaration or definition must be
+evaluated against [Semantic Versioning][semver].
+* Adding a tag is a **minor** change.
+* Removing a tag is a **major** change.
+
+To give dependent crates time to migrate, mark obsolete tag items with `#[deprecated]`. Clippy will
+surface the deprecation warning whenever the tag is used.
+
+[semver]: https://doc.rust-lang.org/cargo/reference/semver.html
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+## Unstable Features
+
+Currently, safety tags requires the following unstable features
+* `#![feature(proc_macro_hygiene, stmt_expr_attributes)]` for tagging statements or expressions.
+* `#![feature(custom_inner_attributes)]` for `#![clippy::safety {}]` imports
+
+Since the safety-tag mechanism is implemented primarily in Clippy and rust-analyzer, no additional
+support is required from rustc.
+
+But We ask the libs team to adopt safety tags for all public `unsafe` APIs in libstd, along with
+their call sites. To enable experimentation, a nightly-only library feature
+`#![feature(safety_tags)]` should be introduced and remain unstable until the design is finalized.
+
+## Implementation in Clippy
+
+Procedure:
+
+1. Scan the crate for every item marked `#[clippy::safety::tag]`; cache the compiled tag metadata of
+   upstream dependencies under `target/` for later queries.
+2. Validate every `#![clippy::safety { ... }]` import by a reachability analysis that ensures every
+   referenced tag is defined and accessible.
+3. Verify that every unsafe call carries the required safety tags:
+   * Resolve the callee, collect its declared tags, then walk outward from the call site until the
+     function’s own signature confirms these tags are listed in its `#![clippy::safety { ... }]`
+     attribute.
+   * Tags are only discharged inside or onto an `unsafe fn`; it's an error to tag a safe function.
+   * If an unsafe call lacks any required tag, emit a diagnostic whose severity (warning or error)
+     is governed by the configured Clippy lint level.
+
+Libraries in `rust-lang/rust` must enforce tag checking as a hard error, guaranteeing that every tag
+definition and discharge is strictly valid.
+
+## Implementation in Rust Analyzer
+
+Safety-tag analysis requirements:
+
+* Harvest every item marked `#[clippy::safety::tag]`, including those pulled in from dependencies.  
+* Offer path completion for `#![clippy::safety { ... }]`.  
+* Offer tag-name completion for `#[clippy::safety]` on unsafe functions, let-statements, or expressions.  
+* Validate all tags inside `#[clippy::safety]`, and support “go-to-definition” plus inline documentation hover.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Even though safety tags are machine-readable, their correctness still hinges on human review:
+developers can silence Clippy by discharging tags without verifying the underlying obligations.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+## Alternatives from IRLO
+
+There are alternative discussion or Pre-RFCs on IRLO:
+
+* 2023-10: [Ability to call unsafe functions without curly brackets](https://internals.rust-lang.org/t/ability-to-call-unsafe-functions-without-curly-brackets/19635/22)
+  * This is a discussion about make single unsafe call simpler, so the idea evolved into tczajka's Pre-RFC.
+  * But the idea and syntax from Scottmcm's comments are very enlightening to our RFC.
+* 2024-10: [Detect and Fix Overscope unsafe Block](https://internals.rust-lang.org/t/detect-and-fix-overscope-unsafe-block/21660/19) 
+  * The OP is about safe code scope in big unsafe block, which is not discussed in our RFC.
+  * But scottmcm's comments are good inspiration for our RFC.
+* 2024-12: [Pre-RFC: Unsafe reasons](https://internals.rust-lang.org/t/pre-rfc-unsafe-reasons/22093) proposed by chrefr
+  * This is a good improvement on abstracting safety comments into a single, machine-readable and
+    checkable identifier. However, it doesn't specify arguments and lacks more fine-grained string
+    interpolation for detailing unsafe reasons.
+  * It also requests big changes on language and compiler change, while safety tags in our RFC is lightweight
+* 2025-02: [Pre-RFC: Single function call `unsafe`](https://internals.rust-lang.org/t/pre-rfc-single-function-call-unsafe/22343) proposed by tczajka
+  * The practice of using a single unsafe call is good, but the postfix `.unsafe` requires more
+    compiler support and does not offer suggestions for improving safe comments.
+  * Our RFC, however, supports annotating safety tags on any expression, including single calls.
+* 2025-05: [Pre-RFC: Granular Unsafe Blocks - A more explicit and auditable approach](https://internals.rust-lang.org/t/pre-rfc-granular-unsafe-blocks-a-more-explicit-and-auditable-approach/23022) proposed by Redlintles
+  * The safety categories suggested are overly broad. In contrast, the safety properties outlined in
+    our RFC are more granular and semantics-specific.
+* 2025-07: [Unsafe assertion invariants](https://internals.rust-lang.org/t/unsafe-assertion-invariants/23206)
+  * It’s a good idea to embed safety requirements into doc comments, which aligns with one of the
+    goals in our RFC.
+* 2025-07: [Pre-RFC: Safety Property System](https://internals.rust-lang.org/t/pre-rfc-safety-property-system/23252) proposed by vague
+  * It's a draft of our current proposal, but more focused on custom linter's design.
+  * The critical parts have already been refined from Clippy’s perspective.
+
+## Alternatives from Rust for Linux
+
+More importantly, our proposal is a big improvement to these proposals, which Rust for Linux care
+more about:
+* 2024-09: [Rust Safety Standard: Increasing the Correctness of unsafe Code][Rust Safety Standard]
+  proposed by Benno Lossin
+  * These slides outline the motivations and objectives of safety-documentation standardization —
+    exactly what our proposal aims to deliver.  
+  * They omit implementation details; nevertheless, Predrag (see next line) and we remain faithful
+    to their intent.
+* 2024-10: [Automated checking of unsafe code requirements](https://hackmd.io/@predrag/ByVBjIWlyx)
+  proposed by Predrag
+  * Predrag’s proposal focuses on structured safety comments, entity references, requirement
+    discharges, and the careful handling of soundness hazards when safety rules evolve. Most are
+    compatible with our proposal.
+  * The principal divergence is syntactic: Predrag embeds the rules in doc- and line-comments, which
+    remain highly readable for both humans and tools, yet are discarded early by the compiler. This
+    makes retrieving a rule for a specific expression far harder than with 
+    [`stmt_expr_attributes`](https://github.com/rust-lang/rust/issues/15701).
+
+Originally, we only focus on libstd's common safety propeties ([paper]), but noticed the RustWeek
+[meeting note] in zulipchat. Thus [tag-std#3](https://github.com/Artisan-Lab/tag-std/issues/3) is
+opened to support Rust for Linux on safety standard.
+
+[meeting note]: https://hackmd.io/@qnR1-HVLRx-dekU5dvtvkw/SyUuR6SZgx
+[Rust Safety Standard]: https://kangrejos.com/2024/Rust%20Safety%20Standard.pdf
+[paper]: https://arxiv.org/abs/2504.21312
+
+# Prior art
+[prior-art]: #prior-art
+
+Currently, there are efforts on introducing contracts and formal verification into Rust:
+* [contracts](https://rust-lang.github.io/rust-project-goals/2024h2/Contracts-and-invariants.html):
+  the lang experiment has been implemented since
+  [rust#128044](https://github.com/rust-lang/rust/issues/128044).
+* [verify-rust-std] pursues applying formal verification tools to libstd. Also see Rust Foundation
+  [announcement][vrs#ann], project goals during [2024h2] and [2025h1].
+
+While safety tags are less formally verified, intended to be a check list on safety requirements.
+
+[verify-rust-std]: https://github.com/model-checking/verify-rust-std
+[vrs#ann]: https://foundation.rust-lang.org/news/rust-foundation-collaborates-with-aws-initiative-to-verify-rust-standard-libraries/
+[2024h2]: https://rust-lang.github.io/rust-project-goals/2024h2/std-verification.html
+[2025h1]: https://rust-lang.github.io/rust-project-goals/2025h1/std-contracts.html
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+## Tagging on Unsafe Traits and Impls
+
+We can extend safety definitions to unsafe traits and require discharges in unsafe trait impls.
+
+Crates with heavy unsafe-trait usage will likely need. We’d welcome more minds on this.
+
+## Tagging on Datastructures
+
+We believe safety obligations are almost always imposed by unsafe functions, so tagging a struct,
+enum, or union is neither needed nor permitted.
+
+## Tagging on Unsafe Fields
+
+Unsafe fields are already declared and accessed with the `unsafe` keyword, often accompanied by
+safety comments. We could extend safety tags to cover unsafe fields as well, both in their
+definitions and at every access point they are discharged.
+
+[unsafe field]: https://github.com/rust-lang/rfcs/pull/3458
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+## Generate Safety Docs from Tags
+
+We can take structured safety comments one step further by turning the explanatory prose into
+explicit tag reasons.
+
+For `ptr::read`, the existing comments are replaced with safety tags:
+
+```rust
+/// * `src` must be [valid] for reads.
+/// * `src` must be properly aligned. Use [`read_unaligned`] if this is not the case.
+/// * `src` must point to a properly initialized value of type `T`.
+pub const unsafe fn read<T>(src: *const T) -> T { ... }
+```
+
+```rust
+#[safety {
+    ValidPtr: "`src` must be [valid] for reads";
+    Aligned: "`src` must be properly aligned. Use [`read_unaligned`] if this is not the case";
+    Initialized: "`src` must point to a properly initialized value of type `T`"
+}]
+pub const unsafe fn read<T>(src: *const T) -> T { ... }
+```
+
+`#[safety]` becomes a procedural macro that expands to both `#[doc]` attributes and the
+`#[clippy::safety]` attribute.
+
+```rust
+/// # Safety
+/// 
+/// - ValidPtr: `src` must be [valid] for reads
+/// - Aligned: `src` must be properly aligned. Use [`read_unaligned`] if this is not the case
+/// - Initialized: `src` must point to a properly initialized value of type `T`
+#[clippy::safety { ValidPtr, Aligned, Initialized }]
+pub const unsafe fn read<T>(src: *const T) -> T { ... }
+```
+
+## `any { Option1, Option2 }` Tags
+
+Sometimes it’s useful to declare a set of safety tags on an unsafe function while discharging only
+one of them.
+
+For instance, `ptr::read` could expose the group `any { DropCheck, CopyType }` and then discharge
+either `DropCheck` or `CopyType` at the call site, depending on the concrete type `T`.
+
+Another instance is `<*const T>::as_ref`, whose safety doc states that the caller must guarantee
+“the pointer is either null or safely convertible to a reference.” This can be expressed as
+`#[clippy::safety { any { Null, ValidPtr2Ref } }]`, allowing the caller to discharge whichever tag
+applies.
+
+## Entity References and Code Review Enhancement
+
+To cut boilerplate or link related code locations, we introduce `#[clippy::safety::ref(...)]`, which
+establishes a two-way reference:
+
+An example of this is [IntoIter::try_fold][vec_deque] of VecDeque, using `#[ref]` for short:
+
+[vec_deque]: https://github.com/rust-lang/rust/blob/ebd8557637b33cc09b6ee8273f3154d5d3af6a15/library/alloc/src/collections/vec_deque/into_iter.rs#L104
+
+```rust
+fn try_fold<B, F, R>(&mut self, mut init: B, mut f: F) -> R
+    impl<'a, T, A: Allocator> Drop for Guard<'a, T, A> {
+        #[ref(try_fold)] // 💡 ptr::read below relies on this drop impl
+        fn drop(&mut self) { ... }
+    }
+    ...
+
+    init = head.iter().map(|elem| {
+        guard.consumed += 1;
+
+        #[ref(try_fold)] // 💡
+        #[safety {
+            ValidPtr, Aligned, Initialized,
+            DropCheck: "Because we incremented `guard.consumed`, the deque \
+              effectively forgot the element, so we can take ownership."
+        }]
+        unsafe { ptr::read(elem) }
+    })
+    .try_fold(init, &mut f)?;
+
+    tail.iter().map(|elem| {
+        guard.consumed += 1;
+
+        #[ref(try_fold)] // 💡 No longer to write SAFETY: Same as above.
+        unsafe { ptr::read(elem) }
+    })
+    .try_fold(init, &mut f)
+}
+
+fn try_rfold<B, F, R>(&mut self, mut init: B, mut f: F) -> R {
+    impl<'a, T, A: Allocator> Drop for Guard<'a, T, A> {
+        #[ref(try_fold)] // 💡
+        fn drop(&mut self) { ... }
+    }
+    ...
+
+    init = tail.iter().map(|elem| {
+            guard.consumed += 1;
+
+            #[ref(try_fold)] // 💡 No longer to write SAFETY: See `try_fold`'s safety comment.
+            unsafe { ptr::read(elem) }
+        })
+        .try_rfold(init, &mut f)?;
+
+    head.iter().map(|elem| {
+            guard.consumed += 1;
+
+            #[ref(try_fold)] // 💡 No longer to write SAFETY: Same as above.
+            unsafe { ptr::read(elem) }
+        })
+        .try_rfold(init, &mut f)
+}
+```
+
+These `#[ref]` annotations act as cross-references that nudge developers to inspect every linked
+site. When either end or the code around it changes, reviewers are instantly aware of all affected
+locations and can verify that every referenced safety requirement is still satisfied.
+

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -250,18 +250,18 @@ invariants, and define the new tag on `delegation` function. This practice exten
 delegation of multiple tag discharges:
 
 ```rust
-#[safety::requires { MyInvaraint = "Invariants of A and C, but could be a more contextual name." }]
+#[safety::requires { MyInvariant = "Invariants of A and C, but could be a more contextual name." }]
 unsafe fn delegation() {
     unsafe {
-        #[safety::checked { A = "delegated to the caller's MyInvaraint", B }]
+        #[safety::checked { A = "delegated to the caller's MyInvariant", B }]
         foo();
-        #[safety::checked { C = "delegated to the caller's MyInvaraint", D }]
+        #[safety::checked { C = "delegated to the caller's MyInvariant", D }]
         bar();
     }
 }
 ```
 
-Note that discharing a tag that is not defined will raise a hard error.
+Note that discharing a tag that is not defined will raise a warning-by-default lint.
 
 ## Safety Tags are a Part of an Unsafe Function
 
@@ -289,7 +289,7 @@ NOTE:
 * `requires` or `checked` can be specified multiple times, and they will be merged together.
   * Duplicate tags in `requires` will trigger errors.
   * Duplicate tags in `checked` will trigger warning-by-default diagnostics.
-* the scope of a tag is limited to the defined unsafe function, so identical tag name on different
+* the scope of a tag is limited to the defining unsafe function, so identical tag name on different
   unsafe functions won't affect with each other.
 
 ## Auto Generate Safety Docs from Tags

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -344,7 +344,7 @@ While safety tags are less formally verified and intended to be a check list on 
 
 We can extend safety definitions to unsafe traits and require discharges in unsafe trait impls.
 
-Crates with heavy unsafe-trait usage will likely need. We’d welcome more minds on this.
+Crates with heavy unsafe-trait usage likely needs the extension. We’d welcome more minds on this.
 
 ## Tagging on Datastructures
 
@@ -353,11 +353,11 @@ enum, or union is neither needed nor permitted.
 
 ## Tagging on Unsafe Fields
 
-Unsafe fields are already declared and accessed with the `unsafe` keyword, often accompanied by
-safety comments. We could extend safety tags to cover unsafe fields as well, both in their
-definitions and at every access point they are discharged.
+[Unsafe fields] are declared and accessed with the `unsafe` keyword, often accompanied by safety
+comments. We could extend safety tags to cover unsafe fields as well, both in their definitions and
+at every access point they are discharged.
 
-[unsafe field]: https://github.com/rust-lang/rfcs/pull/3458
+[Unsafe fields]: https://github.com/rust-lang/rfcs/pull/3458
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -274,11 +274,7 @@ unsafe fn delegation() {
 
 Note that discharing a tag that is not defined will raise a hard error.
 
-## Safety Tags are Part of an Unsafe Function
-
-Tags are extra information of unsafe functions, so rustdoc can render documentation of tags,
-displaying each tag and its optional description below function's doc. Rust-Analyzer can also offer
-**full IDE support**: completion, go-to-definition, and doc-hover.
+## Safety Tags are a Part of an Unsafe Function
 
 Tags constitute a public API; therefore, any alteration to their definition must be evaluated
 against [Semantic Versioning][semver].
@@ -528,15 +524,15 @@ following cases:
    have to discharge `Deref` when this operation happens. (Is Deref tag enough?)
 2. Reading or writing a mutable or external static variable: we can relax `requires` to such static
    items, so tags can be defined on them as well as be discharged on such operation happens.
-3. Accessing a field of a union or an [unsafe field]:  we can extend tag definitions to such field,
-   so tags must be discharged at every access point.
+3. Accessing a union field or an [unsafe field]:  we can extend tag definitions to such field, so
+   tags must be discharged at every access point.
 4. Calling some kinds of safe functions like ones marked with a target_feature or an unsafe
    attribute or in an extern block: the definition and discharge rules is the same as that of
    ordinary unsafe functions.
 5. Implementing an unsafe trait: we can extend safety definitions to unsafe traits and require
    discharges in unsafe trait impls.
 
-[unsafe fields]: https://github.com/rust-lang/rfcs/pull/3458
+[unsafe field]: https://github.com/rust-lang/rfcs/pull/3458
 
 But we believe safety requirements are almost mostly imposed by unsafe functions, so tagging a
 struct, enum, or union is neither needed nor permitted.
@@ -546,9 +542,9 @@ struct, enum, or union is neither needed nor permitted.
 
 ## Better Rustdoc Rendering
 
-Because tags are surfaced as real API items, rustdoc can give `#[safety::declare_tag]`–annotated,
-uninhabited enums (the tag items) special treatment: it renders compact pages for them and
-establishes bidirectional links between tag items and unsafe functions requiring the tags.
+Because tags are surfaced as a part of API, rustdoc can render documentation of tags by displaying
+each tag name, its optional description, and possible deprecated state below the tagged function or
+other unsafe item.
 
 ## Generate Safety Docs from Tags
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -220,8 +220,8 @@ LLL | unsafe { ptr::read(ptr) }
 
 The process of verifying whether a tag is present is referred to as tag discharge.
 
-Note that it's allowed to discharge tags of unsafe callees onto the unsafe caller for unsafe
-delegation or propogation:
+Now consider forwarding invariants of unsafe callees onto the unsafe caller for unsafe delegation or
+propogation:
 
 ```rust
 #[safety::requires { ValidPtr, Aligned, Initialized }]
@@ -231,7 +231,7 @@ unsafe fn propogation<T>(ptr: *const T) -> T {
 }
 ```
 
-Tags defined on an unsafe function must be fully discharged at callsites. No partial discharge:
+Tags defined on an unsafe function must be **fully** discharged at callsites. No partial discharge:
 
 ```rust
 #[safety::requires { ValidPtr, Initialized }]
@@ -567,12 +567,12 @@ parameters represent the tag’s arguments. Unfortunately, this immediately rais
 1. **Argument types**. Which types are allowed in the declaration? Do we have to introduce new
    arguments types for each tag declaration?
 
-2. **Definition-side checking**. Will tag operations `safety::requires` and `safety::checked`
-   type-check against these arguments? If so, are we quietly reinventing a full contract system?
+2. **Type checking**. Will tag operations `safety::requires` and `safety::checked` type-check
+   against these arguments? If so, are we quietly reinventing a full contract system?
 
 I'd like to propose a solution or rather compromise here by trading strict precision for simplicity:
 
-We could keep uninhabited enums as the only tag declaration and allow *any* arguments at use sites
+We could keep uninhabited enums as the only tag declaration and allow *any* arguments in tag usage
 without validation. Tag arguments would still refine the description of an unsafe operation, but
 they are never type checked. An example:
 
@@ -585,6 +585,9 @@ enum ValidPtr {}
 
 #[safety::requires { ValidPtr(ptr) }]
 unsafe fn foo<T>(ptr: *const T) -> T { ... }
+
+#[safety::checked { ValidPtr(p) }]
+unsafe { bar(p) }
 ```
 
 ## Tagging on Unsafe Traits and Impls

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -519,24 +519,27 @@ unsafe fn foo<T>(ptr: *const T) -> T { ... }
 unsafe { bar(p) }
 ```
 
-## Tagging on Unsafe Traits and Impls
+## Tagging More Unsafe Operations
 
-We can extend safety definitions to unsafe traits and require discharges in unsafe trait impls.
+There are several other unsafe operations other than unsafe calls. We can extend safety tags in the
+following cases:
 
-Crates with heavy unsafe-trait usage likely needs the extension. We’d welcome more minds on this.
+1. Dereferencing a raw pointer: we can define such operation to have `Deref` tag, thus users will 
+   have to discharge `Deref` when this operation happens. (Is Deref tag enough?)
+2. Reading or writing a mutable or external static variable: we can relax `requires` to such static
+   items, so tags can be defined on them as well as be discharged on such operation happens.
+3. Accessing a field of a union or an [unsafe field]:  we can extend tag definitions to such field,
+   so tags must be discharged at every access point.
+4. Calling some kinds of safe functions like ones marked with a target_feature or an unsafe
+   attribute or in an extern block: the definition and discharge rules is the same as that of
+   ordinary unsafe functions.
+5. Implementing an unsafe trait: we can extend safety definitions to unsafe traits and require
+   discharges in unsafe trait impls.
 
-## Tagging on Datastructures
+[unsafe fields]: https://github.com/rust-lang/rfcs/pull/3458
 
-We believe safety requirements are almost always imposed by unsafe functions, so tagging a struct,
-enum, or union is neither needed nor permitted.
-
-## Tagging on Unsafe Fields
-
-[Unsafe fields] are declared and accessed with the `unsafe` keyword, often accompanied by safety
-comments. We could extend safety tags to cover unsafe fields as well, both in their definitions and
-at every access point they are discharged.
-
-[Unsafe fields]: https://github.com/rust-lang/rfcs/pull/3458
+But we believe safety requirements are almost mostly imposed by unsafe functions, so tagging a
+struct, enum, or union is neither needed nor permitted.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -285,7 +285,7 @@ unsafe fn deprecate_a_tag() {}
 
 // warning: Tag is deprecated, copy description to here.
 // error: NewTag is not discharged.
-#[safety::requires { Tag }]
+#[safety::checked { Tag }]
 unsafe { deprecate_a_tag() }
 ```
 
@@ -443,9 +443,9 @@ There are alternative discussion or Pre-RFCs on IRLO:
 Our proposed syntax looks closer to structured comments:
 
 ```rust
-#[safety {
-  ValidPtr, Align, Initialized: "`self.head_tail()` returns two slices to live elements.";
-  NotOwned: "because we incremented...";
+#[safety::checked {
+  ValidPtr, Align, Initialized = "`self.head_tail()` returns two slices to live elements.",
+  NotOwned = "because we incremented...",
 }]
 unsafe { ptr::read(elem) }
 ```

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -538,6 +538,38 @@ unsafe { ptr::read(elem) }
 unsafe { ptr::read(elem) }
 ```
 
+## Clippy lint `danger_not_accepted`
+
+The Clippy PR [#11600] attempted to introduce a new lint called `danger_not_accepted`, which is
+similar to safety tags but has several key differences:
+
+- **Attribute Names**: `#[clippy::dangerous]` vs. `#[safety::requires]`; `#[clippy::accept_danger]`
+  vs. `#[safety::checked]`.
+- **Applicability**: Danger attributes can be applied to safe code and modules, whereas safety tags
+  are specifically for unsafe operations. However, [entity-reference] might eventually support safe
+  code in the future.
+- **Lint Levels and Names**: Danger lint levels and names can be controlled at the module level,
+  while safety tags are controlled by `#[level(clippy::safety_requires)]` and
+  `#[level(clippy::safety_checked)]`, where the level can be `deny`, `allow`, or `warn`.
+- **Naming Conventions**: Danger names are path-based, while tag names are limited to unsafe APIs or
+  operations. There was some discussion in earlier iterations of this RFC about whether names should
+  be path-based, but we opted for this approach because it is simpler and avoids collisions.
+
+The PR was closed due to inactivity. However, I found some interesting insights:
+
+- It was discussed in a [weekly meeting][clippy-danger], where @flip1995 summarized, "I'm not
+  opposed to the idea, but to add this to Clippy, we must ensure it produces good diagnostics 
+  (reason field) and works across crates."
+  - Our proposal meets these criteria because definitions will be displayed if tags are not checked,
+    and as long as an unsafe function can be called, its tags will be available, ensuring they work
+    across crates.
+- Rustc developers have also expressed interest in this lint, as seen in
+  [this discussion][rustc-danger].
+
+[#11600]: https://github.com/rust-lang/rust-clippy/pull/11600
+[clippy-danger]: https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/Meeting.202023-10-03/near/394654500
+[rustc-danger]: https://github.com/rust-lang/rust/pull/126326#issuecomment-2165339577
+
 # Prior art
 [prior-art]: #prior-art
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -416,7 +416,7 @@ There are alternative discussion or Pre-RFCs on IRLO:
     [this thread in opsem channel](https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/Safety.20Property.20System/with/530679491).
   * The critical parts have already been refined from Clippy’s perspective in current proposal.
 
-## Alternatives from Rust for Linux
+## Safety Standard Proposal from Rust for Linux
 
 More importantly, our proposal is a big improvement to these proposals, which Rust for Linux care
 more about:
@@ -424,8 +424,14 @@ more about:
   proposed by Benno Lossin
   * These slides outline the motivations and objectives of safety-documentation standardization —
     exactly what our proposal aims to deliver.
-  * They omit implementation details; nevertheless, Predrag (see next line) and we remain faithful
-    to their intent.
+  * They omit implementation details; nevertheless, Predrag (see next section) and we remain
+    faithful to their intent.
+
+[meeting note]: https://hackmd.io/@qnR1-HVLRx-dekU5dvtvkw/SyUuR6SZgx
+[Rust Safety Standard]: https://kangrejos.com/2024/Rust%20Safety%20Standard.pdf
+
+## Why Not Structured Safety Comments?
+
 * 2024-10: [Automated checking of unsafe code requirements](https://hackmd.io/@predrag/ByVBjIWlyx)
   proposed by Predrag
   * Predrag’s proposal focuses on structured safety comments, entity references, requirement
@@ -435,14 +441,24 @@ more about:
     remain highly readable for humans, but not so much for tools, because line-comments are 
     discarded early by the compiler. This makes retrieving a rule for a specific expression far 
     harder than with [`stmt_expr_attributes`](https://github.com/rust-lang/rust/issues/15701).
+* 2025-07: [Reddit Post: Safety Property System](https://internals.rust-lang.org/t/pre-rfc-safety-property-system/23252/22)
+  discussed by Matthieum 
 
-Originally, we only focus on libstd's common safety propeties ([paper]), but noticed the RustWeek
-[meeting note] in zulipchat. Thus [tag-std#3](https://github.com/Artisan-Lab/tag-std/issues/3) is
-opened to support Rust for Linux on safety standard.
+Our proposed syntax looks closer to structured comments:
 
-[meeting note]: https://hackmd.io/@qnR1-HVLRx-dekU5dvtvkw/SyUuR6SZgx
-[Rust Safety Standard]: https://kangrejos.com/2024/Rust%20Safety%20Standard.pdf
-[paper]: https://arxiv.org/abs/2504.21312
+```rust
+#[safety {
+  ValidPtr, Align, Initialized: "`self.head_tail()` returns two slices to live elements.";
+  NotOwned: "because we incremented...";
+}]
+unsafe { ptr::read(elem) }
+```
+
+```rust
+//  SAFETY
+//  - ValidPtr, Aligned, Initialized: `self.head_tail()` returns two slices to live elements.
+//  - NotOwned: because we incremented...
+```
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -573,6 +573,14 @@ By comparison, our proposed syntax is
 [named arguments]: https://github.com/rust-lang/rfcs/pull/3842#discussion_r2247342603
 [Lint reasons]: https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-reasons
 
+## Encapsulate Tag Item Declaration with `define_safety_tag!`
+
+@clarfonthey [suggested][tool macro] a `define_safety_tag!` tool macro which will unlikely happen.
+
+But I think it'd be necessary and handy to hide tag declarations in some cases.
+
+[tool macro]: https://github.com/rust-lang/rfcs/pull/3842#discussion_r2245923920
+
 # Future possibilities
 [future-possibilities]: #future-possibilities
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -302,12 +302,13 @@ surface the deprecation warning whenever the tag is used w.r.t definitions and d
 
 ## Unstable Features
 
-Currently, safety tags requires the following unstable features
+Currently, safety tags requires the following features
 * `#![feature(proc_macro_hygiene, stmt_expr_attributes)]` for tagging statements or expressions.
 * `#![feature(custom_inner_attributes)]` for `#![safety::import(...)]`.
+* registering `safety` tool in every crate to create safety namespace.
 
 Since the safety-tag mechanism is implemented primarily in Clippy and Rust-Analyzer, no additional
-support is required from rustc except registering `safety` tool in every crate.
+significant support is required from rustc.
 
 But we ask the libs team to adopt safety tags for all public `unsafe` APIs in libstd, along with
 their call sites. To enable experimentation, a nightly-only library feature
@@ -356,7 +357,7 @@ developers can silence Clippy by discharging tags without verifying underlying s
 We argued in the [guide-level-explanation] why safety tags are necessary; here we justify the *way*
 they are proposed to implemente.
 
-1. Keep the compiler untouched. Tag checking is an API-style lint, not a language feature. All the
+1. It's linter's work. Tag checking is an API-style lint, not a language feature. All the
    `#[safety::*]` information is available in the HIR, so a linter (rather than the compiler) is the
    right place to enforce the rules.
 
@@ -371,6 +372,15 @@ they are proposed to implemente.
 3. IDE integration. The same reasoning applies to the language server. A custom server would again
    be tied to internal APIs and specific toolchains. Extending rust-analyzer is therefore the only
    practical way to give users first-class IDE support.
+
+We therefore seek approvals from the following teams:
+
+1. **Library team** – to allow the tagging of unsafe operations and to expose tag items as public
+   APIs.
+2. **Clippy team** – to integrate tag checking into the linter.  
+3. **Rust-Analyzer team** – to add IDE support for tags.  
+4. **Compiler team** – to reserve the `safety` namespace and gate the feature via
+   `#![feature(safety_tags)]`.
 
 [safety-tool]: https://github.com/Artisan-Lab/tag-std/blob/main/safety-tool
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -104,7 +104,7 @@ We can also attach comments for a tag or a group of tags to clarify how safety r
 
 ```rust
 #[clippy::safety {
-  ValidPtr, Aligned, Initialized: "addr range p..p+n is properly initialized from aligned memory"
+  ValidPtr, Aligned, Initialized: "addr range p..p+n is properly initialized from aligned memory";
   InBounded, ValidNum: "`n` won't exceed isize::MAX here, so `p.add(n)` is fine";
 }]
 for _ in 0..n {

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -101,12 +101,16 @@ ad-hoc practice with four concrete gains:
 2. **Semantic granularity**. Tags must label a single unsafe call, or an expression contains single 
    unsafe call. No longer constrained by the visual boundaries of `unsafe {}`. This sidesteps the
    precision vs completeness tension of unsafe blocks, and zeros in on real unsafe operations.
+   * To enable truly semantic checking, we envision an [entity-reference] system that meticulously
+     traces every unsafe operation that could break an invariant in source code.
 
 3. **Versioned invariants**. Tags are real items; any change to their declaration or definition is a
-   **semver-breaking** API change, so safety invariants evolve explicitly.
+   *semver-breaking* API change, so safety invariants evolve explicitly.
 
 4. **Lightweight checking**. Clippy only matches tag paths. No heavyweight formal proofs, keeping
    the system easy to adopt and understand.
+
+[entity-reference]: #entity-reference
 
 ## `#[safety]` Tool Attribute and Namespace
 
@@ -473,6 +477,8 @@ There are alternative discussion or Pre-RFCs on IRLO:
   * The practice of using a single unsafe call is good, but the postfix `.unsafe` requires more
     compiler support and does not offer suggestions for improving safe comments.
   * Our RFC, however, supports annotating safety tags on any expression, including single calls.
+* 2025-01: [RFC: Add safe blocks](https://github.com/rust-lang/rfcs/pull/3768)
+  * This is a continum of discussion of 2024-10, focusing on visual granularity.
 * 2025-05: [Pre-RFC: Granular Unsafe Blocks - A more explicit and auditable approach](https://internals.rust-lang.org/t/pre-rfc-granular-unsafe-blocks-a-more-explicit-and-auditable-approach/23022) proposed by Redlintles
   * The safety categories suggested are overly broad. In contrast, the safety properties outlined in
     our RFC are more granular and semantics-specific.
@@ -721,6 +727,8 @@ Another instance is `<*const T>::as_ref`, whose safety doc states that the calle
 applies.
 
 ## Entity References and Code Review Enhancement
+
+<a id="entity-reference"></a>
 
 To cut boilerplate or link related code locations, we introduce `#[safety::ref(...)]` which
 establishes a two-way reference.

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -15,11 +15,11 @@ requirement into a single, check-off reminder.
 The following snippet [compiles] today, but we expect Clippy and Rust-Analyzer to enforce tag checks
 and provide first-class IDE support.
 
-[compiles]: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=056cbe626a7cc92a317e38e9f54cb1fb
+[compiles]: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=2f49a8b255b8c066ffd5e3157a70b821
 
 ```rust
 #![feature(custom_inner_attributes)]
-#![clippy::safety::use(invariant::*)] // 💡
+#![clippy::safety::r#use(invariant::*)] // 💡
 
 pub mod invariant {
     #[clippy::safety::tag]
@@ -166,20 +166,20 @@ fn Aligned() {}
 Tags live in their own [type namespace] carry item-level [scopes] and obey [visibility] rules,
 keeping the system modular and collision-free. Since they are never referenced directly as real
 items, we propose importing them uses a dedicated syntax: inner-styled or outer-styled 
-`clippy::safety::use` tool attribute on modules:
+`clippy::safety::r#use` tool attribute on modules:
 
 ```rust
-#![clippy::safety::use { UseTree })] // {} signifies a delimiter here, thus () also works
+#![clippy::safety::r#use { UseTree })] // {} signifies a delimiter here, thus () also works
 ```
 
 [`UseTree`] follows the exact grammar of the `use` declaration. Some examples:
 
 ```rust
-#[clippy::safety::use { core::ptr::invariants::* }]
+#[clippy::safety::r#use { core::ptr::invariants::* }]
 mod foo;
 
 mod bar {
-    #![clippy::safety::use { core::ptr::invariants::{ValidPtr, Aligned} }]
+    #![clippy::safety::r#use { core::ptr::invariants::{ValidPtr, Aligned} }]
 }
 ```
 
@@ -217,7 +217,7 @@ surface the deprecation warning whenever the tag is used w.r.t definitions and d
 
 Currently, safety tags requires the following unstable features
 * `#![feature(proc_macro_hygiene, stmt_expr_attributes)]` for tagging statements or expressions.
-* `#![feature(custom_inner_attributes)]` for `#![clippy::safety::use(...)]` imports
+* `#![feature(custom_inner_attributes)]` for `#![clippy::safety::r#use(...)]` imports
 
 Since the safety-tag mechanism is implemented primarily in Clippy and Rust-Analyzer, no additional
 support is required from rustc.
@@ -236,7 +236,7 @@ Procedure:
    referenced tag is defined and accessible.
 3. Verify that every unsafe call carries the required safety tags:
    * Resolve the callee, collect its declared tags, then walk outward from the call site until the
-     function’s own signature confirms these tags are listed in its `#![clippy::safety::use(...)]`
+     function’s own signature confirms these tags are listed in its `#![clippy::safety::r#use(...)]`
      attribute.
    * Tags are only discharged inside or onto an `unsafe fn`; it's an error to tag a safe function.
    * If an unsafe call lacks any required tag, emit a diagnostic whose severity (warning or error)
@@ -250,7 +250,7 @@ definition and discharge is strictly valid.
 Safety-tag analysis requirements:
 
 * Harvest every item marked `#[clippy::safety::tag]`, including those pulled in from dependencies.
-* Offer tag path completion for `#![clippy::safety::use(...)]`.
+* Offer tag path completion for `#![clippy::safety::r#use(...)]`.
 * Offer tag name completion for `#[clippy::safety { ... }]` on unsafe functions, let-statements, or
   expressions.
 * Validate all tags inside `#[clippy::safety { ... }]`, and support “go-to-definition” plus inline

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -278,8 +278,9 @@ There are alternative discussion or Pre-RFCs on IRLO:
   * It’s a good idea to embed safety requirements into doc comments, which aligns with one of the
     goals in our RFC.
 * 2025-07: [Pre-RFC: Safety Property System](https://internals.rust-lang.org/t/pre-rfc-safety-property-system/23252) proposed by vague
-  * It's a draft of our current proposal, but more focused on custom linter's design.
-  * The critical parts have already been refined from Clippy’s perspective.
+  * It's a draft of our current proposal, but more focused on custom linter's design. Also see 
+    [this thread in opsem channel](https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/Safety.20Property.20System/with/530679491).
+  * The critical parts have already been refined from Clippy’s perspective in current proposal.
 
 ## Alternatives from Rust for Linux
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -245,6 +245,12 @@ unsafe fn delegation<T>(ptr: *const T) -> T {
 }
 ```
 
+The tags `ValidPtr` and `Initialized = "delegated to the caller"` are grouped together. We do not
+introduce new syntax for grouping tags but instead suggest visually grouping them for clarity. When
+`rustfmt` automatically formats `ValidPtr` to its own line, the only workaround is to set
+`attr_fn_like_width = 0` in the `rustfmt.toml` configuration file. For further discussion on this
+tag styling, see this [link](https://github.com/rust-lang/rfcs/pull/3842#discussion_r2296076785).
+
 In this delegation case, you're able to declare a new meaningful tag for ValidPtr and Initialized
 invariants, and define the new tag on `delegation` function. This practice extends to partial unsafe
 delegation of multiple tag discharges:
@@ -601,6 +607,23 @@ following cases:
 
 But we believe safety requirements are almost mostly imposed by unsafe functions, so tagging a
 struct, enum, or union is neither needed nor permitted.
+
+## Tag naming convention
+
+There are two primary conventions for naming tags: `PascalCase` (also known as `UpperCamelCase`) and
+`snake_case`.
+
+We might consider recommending just one convention for consistency, but it's challenging to
+determine whether a tag functions more like a type-level construct (semantically akin to an
+uninhabited enum) or a value-level construct (such as a function, especially if tags can take
+arguments).
+
+To accommodate both styles, we could provide an option that allows users to unify their code style
+or lint against the alternative convention:
+
+```rust
+#![safety::tag_naming_convention = "PascalCase"] // in root module
+```
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -91,6 +91,8 @@ precision as well as overhead of formal verification, making them too heavy for 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
+## From Motivation to Solution: Bridging the Identified Gaps
+
 We propose **checkable safety comments** via Clippy’s new **safety-tag** system, addressing today’s
 ad-hoc practice with four concrete gains:
 
@@ -103,7 +105,7 @@ ad-hoc practice with four concrete gains:
 3. **Semantic granularity**. Tags must label a single unsafe call, or an expression containing
    single unsafe call. No longer constrained by the visual boundaries of `unsafe {}`. This sidesteps
    the precision vs completeness tension of unsafe blocks, and zeros in on real unsafe operations.
-   * It's viable to extend tagging to [more unsafe operations] beyond unsafe calls.
+   * It's viable to extend tags to [more unsafe operations] beyond unsafe calls.
    * To enable truly semantic checking, we envision an [entity-reference] system that meticulously
      traces every unsafe related operation that could break an invariant in source code.
 
@@ -290,14 +292,14 @@ NOTE:
   * Duplicate tags in `requires` will trigger errors.
   * Duplicate tags in `checked` will trigger warning-by-default diagnostics.
 * the scope of a tag is limited to the defining unsafe function, so identical tag name on different
-  unsafe functions won't affect with each other.
+  unsafe functions won't affect each other.
 
 ## Auto Generate Safety Docs from Tags
 
 Since tag definitions duplicate safety comments, we propose `rustdoc` can recognize
 `#[safety::requires]` attributes and render them into safety docs.
 
-For `ptr::read`, the existing comments are replaced with safety tags:
+For `ptr::read`, replace the existing comments with safety tags:
 
 ```rust
 /// # Safety

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -717,3 +717,6 @@ locations and thus can assess if every referenced safety requirement is still sa
 Clippy can generate a diff-style report that pinpoints every location where changes to referenced
 HIR nodes occur between two commits or crate versions, enabling more focused code reviews. To
 improve dev experiences, Rust-Analyzer can retrieve every ref sites from a given ref tag object.
+
+NOTE: `ref` is a reserved keyword, so attribute candidates are `#[safety::tag]`, `#[safety::cue]`,
+and `#[safety::cite]`.

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -104,13 +104,13 @@ We can also attach comments for a tag or a group of tags to clarify how safety r
 
 ```rust
 #[clippy::safety {
-  InBounded, ValidNum: "`n` won't exceed isize::MAX here, so `p.add(n)` is fine";
   ValidPtr, Aligned, Initialized: "addr range p..p+n is properly initialized from aligned memory"
+  InBounded, ValidNum: "`n` won't exceed isize::MAX here, so `p.add(n)` is fine";
 }]
 for _ in 0..n {
     unsafe {
-        p = p.add(1);
         c ^= p.read();
+        p = p.add(1);
     }
 }
 ```

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -343,6 +343,39 @@ While safety tags are less formally verified and intended to be a check list on 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
+## Should Tags Take Arguments?
+
+If a tag takes arguments, how should the tag declared? An uninhabited enum doesn't express 
+correct semantics anymore. The closest item is a function with arguments. But it's brings
+many problems, like 
+* What argument types should be on such tag declaration functions? Do we need to declare extra 
+types specifically for such tag declaration?
+* Is there a argument check on tag definitions on unsafe functions? Are we reinventing contracts
+system again?
+* Or just only keep uninhabited enums as tag declaration, and allow any arguments for all tags,
+but don't check the validity arguments. Tag arguments enhance precision of safety operation,
+but no checks on them avoid any complicated interaction with type system. We can make a compromise.
+
+When a tag needs parameters, we must decide what its declaration looks like.  An uninhabited enum
+can no longer express “this tag carries data”, so the nearest legal item is a function whose
+parameters represent the tag’s arguments.  Unfortunately, this immediately raises design questions:
+
+1. **Argument types**  Which types are allowed in the declaration?  Do we have to introduce new,
+   purpose-built types just so the compiler can see them at the use-site?
+
+2. **Definition-side checking**  Will `unsafe fn` definitions be obliged to supply arguments that
+   type-check against the declaration?  If so, are we quietly reinventing a full contract system?
+
+I'd like to propose a solution or rather compromise here by trading strict precision for simplicity:
+
+We could keep uninhabited enums as the only formal declaration and allow *any* arguments at use
+sites, skipping all validation. Tag arguments would still refine the description of an unsafe
+operation, but they are never type checked.
+
+Also see [this][tag-args] RFC discussion for our thoughts.
+
+[tag-args]: https://github.com/rust-lang/rfcs/pull/3842#discussion_r2246551643
+
 ## Tagging on Unsafe Traits and Impls
 
 We can extend safety definitions to unsafe traits and require discharges in unsafe trait impls.

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -199,11 +199,11 @@ doc-hover.
 
 Tags constitute a public API; therefore, any alteration to their declaration or definition must be
 evaluated against [Semantic Versioning][semver].
-* Adding a tag is a **minor** change.
-* Removing a tag is a **major** change.
+* Adding a tag declaration or definition is a **minor** change.
+* Removing a tag declaration or definition is a **major** change.
 
 To give dependent crates time to migrate, mark obsolete tag items with `#[deprecated]`. Clippy will
-surface the deprecation warning whenever the tag is used.
+surface the deprecation warning whenever the tag is used w.r.t definitions and discharges.
 
 [semver]: https://doc.rust-lang.org/cargo/reference/semver.html
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -107,7 +107,7 @@ ad-hoc practice with four concrete gains:
    * To enable truly semantic checking, we envision an [entity-reference] system that meticulously
      traces every unsafe related operation that could break an invariant in source code.
 
-4. **Lightweight checking**. Clippy only matches tag paths. No heavyweight formal proofs, keeping
+4. **Lightweight checking**. Clippy only matches tags. No heavyweight formal proofs, keeping
    the system easy to adopt and understand.
 
 [more unsafe operations]: #tagging-more-unsafe-ops

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -268,7 +268,13 @@ Note that discharing a tag that is not defined will raise a hard error.
 Tags constitute a public API; therefore, any alteration to their definition must be evaluated
 against [Semantic Versioning][semver].
 * Adding a tag definition is a **major** change, because new tag is missing. 
-* Removing a tag definition is a **major** change, because the tag doesn't exist.
+* Removing a tag definition is a **minor** change. The tag doesn't exist anymore, and discharing
+  an undefined tag just emits a warning-by-default diagnostic.
+* Changing the definition of a tag in a way that *requires more*, is a **major** change, because
+  callsites only checked the weaker requirement for this tag. However, it's strongly discouraged to
+  change the tag in such way, as newly added requirements may blindly discharged by callsites.
+* Changing the definition of a tag in an *equivalent* or in a way that *requires less* (the old tag
+  implies the new tag), is a **minor** change.
 * Renaming a tag definition is a **major** change, because it's the result of removal and addition.
 
 [semver]: https://doc.rust-lang.org/cargo/reference/semver.html

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -477,5 +477,6 @@ fn try_rfold<B, F, R>(&mut self, mut init: B, mut f: F) -> R {
 
 These `#[ref]` annotations act as cross-references that nudge developers to inspect every linked
 site. When either end or the code around it changes, reviewers are instantly aware of all affected
-locations and can verify that every referenced safety requirement is still satisfied.
+locations that Clippy reports and thus can assess if every referenced safety requirement is still
+satisfied.
 

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-This RFC introduces a concise safety-comment convention for unsafe code in libstd-adjacent crates:
+This RFC introduces a concise safety-comment convention for unsafe code in standard libraries:
 tag every public unsafe function with `#[safety::requires]` and call with `#[safety::checked]`.
 
 Safety tags refine today’s safety-comment habits: a featherweight syntax that condenses every
@@ -102,7 +102,7 @@ ad-hoc practice with four concrete gains:
    unsafe call. No longer constrained by the visual boundaries of `unsafe {}`. This sidesteps the
    precision vs completeness tension of unsafe blocks, and zeros in on real unsafe operations.
    * To enable truly semantic checking, we envision an [entity-reference] system that meticulously
-     traces every unsafe operation that could break an invariant in source code.
+     traces every unsafe related operation that could break an invariant in source code.
 
 3. **Versioned invariants**. Tags are real items; any change to their declaration or definition is a
    *semver-breaking* API change, so safety invariants evolve explicitly.
@@ -477,7 +477,7 @@ There are alternative discussion or Pre-RFCs on IRLO:
   * The practice of using a single unsafe call is good, but the postfix `.unsafe` requires more
     compiler support and does not offer suggestions for improving safe comments.
   * Our RFC, however, supports annotating safety tags on any expression, including single calls.
-* 2025-01: [RFC: Add safe blocks](https://github.com/rust-lang/rfcs/pull/3768)
+* 2025-01: [RFC: Add safe blocks](https://github.com/rust-lang/rfcs/pull/3768) by Aversefun
   * This is a continum of discussion of 2024-10, focusing on visual granularity.
 * 2025-05: [Pre-RFC: Granular Unsafe Blocks - A more explicit and auditable approach](https://internals.rust-lang.org/t/pre-rfc-granular-unsafe-blocks-a-more-explicit-and-auditable-approach/23022) proposed by Redlintles
   * The safety categories suggested are overly broad. In contrast, the safety properties outlined in
@@ -555,17 +555,6 @@ While safety tags are less formally verified and intended to be a check list on 
 
 ## Should Tags Take Arguments?
 
-If a tag takes arguments, how should the tag declared? An uninhabited enum doesn't express 
-correct semantics anymore. The closest item is a function with arguments. But it's brings
-many problems, like 
-* What argument types should be on such tag declaration functions? Do we need to declare extra 
-types specifically for such tag declaration?
-* Is there a argument check on tag definitions on unsafe functions? Are we reinventing contracts
-system again?
-* Or just only keep uninhabited enums as tag declaration, and allow any arguments for all tags,
-but don't check the validity arguments. Tag arguments enhance precision of safety operation,
-but no checks on them avoid any complicated interaction with type system. We can make a compromise.
-
 When a tag needs parameters, we must decide what its declaration looks like.  An uninhabited enum
 can no longer express “this tag carries data”, so the nearest legal item is a function whose
 parameters represent the tag’s arguments. Unfortunately, this immediately raises design questions:
@@ -583,7 +572,7 @@ without validation. Tag arguments would still refine the description of an unsaf
 they are never type checked. An example:
 
 ```rust
-#[safety::define_safety_tag(
+#[safety::declare_tag(
   args = [ "p", "T", "len" ],
   desc = "pointer `{p}` must be valid for reading and writing the `sizeof({T})*{n}` memory from it"
 )]

--- a/text/0000-safety-tags.md
+++ b/text/0000-safety-tags.md
@@ -278,7 +278,8 @@ against [Semantic Versioning][semver].
   an undefined tag just emits a warning-by-default diagnostic.
 * Renaming a tag definition is a **major** change, because it's the result of removal and addition.
 * Changing the definition of a tag in an *equivalent* or in a way that *requires less* (the old tag
-  implies the new tag), is a **minor** change.
+  implies the new tag), is a **minor** change, as long as that new definition is correct for all
+  published versions within the same major version (**if unsure, rename the tag instead**).
 * Changing the definition of a tag in a way that *requires more*, is a **major** change, because
   callsites only checked the weaker requirement for this tag.
   * However, adding more safety requirements to an existing tag definition is strongly discouraged:


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3842)*

# Summary

This RFC introduces a concise safety-comment convention for unsafe code in standard libraries:
tag every public unsafe function with `#[safety::requires]` and call with `#[safety::checked]`.

Safety tags refine today’s safety-comment habits: a featherweight syntax that condenses every
requirement into a single, check-off reminder.

The following snippet [compiles] today if we enable enough nightly features, but we expect Clippy
and Rust-Analyzer to enforce tag checks and provide first-class IDE support.

[compiles]: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=6b7b341b8879bfdecb80ae72a8011a6d

```rust
#[safety::requires( // 💡 define safety tags on an unsafe function
    valid_ptr = "src must be [valid](https://doc.rust-lang.org/std/ptr/index.html#safety) for reads",
    aligned = "src must be properly aligned, even if T has size 0",
    initialized = "src must point to a properly initialized value of type T"
)]
pub unsafe fn read<T>(ptr: *const T) { }

fn main() {
    #[safety::checked( // 💡 discharge safety tags on an unsafe call
        valid_ptr, aligned, initialized = "optional reason"
    )]
    unsafe { read(&()) };
}
```


[Rendered](https://github.com/safer-rust/rfcs/blob/safety-tags/text/0000-safety-tags.md)