### PR TITLE
repr(ordered_fields)

### DIFF
--- a/text/0000-repr-ordered-fields.md
+++ b/text/0000-repr-ordered-fields.md
@@ -140,7 +140,10 @@ The warning should come with a machine-applicable fix to switch `repr(C)` to `re
 # Prior art
 [prior-art]: #prior-art
 
-This is discussed in Rationale and Alternatives
+See Rationale and Alternatives as well
+
+* https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/expand.2Frevise.20repr.28.7BC.2Clinear.2C.2E.2E.2E.7D.29.20for.202024.20edition
+
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 

--- a/text/0000-repr-ordered-fields.md
+++ b/text/0000-repr-ordered-fields.md
@@ -1,0 +1,162 @@
+- Feature Name: (fill me in with a unique ident, `repr_ordered_fields`)
+- Start Date: (fill me in with today's date, 2025-08-01)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Introduce a new `repr` (let's call it `repr(ordered_fields)`, but that can be bikeshedded if this RFC get's accepted) which can be applied to `struct`, `enum`, and `union` types which guarantees a simple, and predictable layout. Then provide an initial migration plan to switch users from `repr(C)` to `repr(ordered_fields)`.
+
+# Motivation
+[motivation]: #motivation
+
+Currently `repr(C)` serves two roles
+1. Provide a consistent, cross-platform, predictable layout for a given type
+2. Match the target C compiler's struct/union layout algorithm and ABI
+
+But in some cases, these two cases are in tension due to platform weirdness (even on major platforms like Windows MSVC)
+* https://github.com/rust-lang/unsafe-code-guidelines/issues/521
+* https://github.com/rust-lang/rust/issues/81996
+
+Providing any fix for case 2 would subtly break any users of case 1, which makes this difficult to fix within a single edition. 
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Introduce a new `repr(ordered_fields)` which can be applied to `struct`, `enum`, and `union`. On all editions, `repr(ordered_fields)` would behave the same as `repr(C)` on edition 2024. (see reference level explanation for details). 
+
+On editions 2024 (maybe <= 2024), any use of `repr(C)` will trigger a new warning, `edition_2024_repr_c` which will be warn by default.
+This warning will suggest a machine applicable fix to switch `repr(C)` to `repr(ordered_fields)`, which is a no-op in the current edition, but helps prepare for changes to `repr(C)` early. This gives time for the community to switch over if they need to.
+
+For the FFI crates, they can safely ignore the warning by applying `#![allow(edition_2024_repr_c)]` to their crate root.
+For crates without any FFI, they can simply run the machine applicable fix.
+For crates with a mix, they will need to do some work to figure out which is which. But this is unavoidable to solve the stated motivation.
+
+For example, the warning could look like this:
+```
+warning: use of `repr(C)` in type `Foo`
+  --> src/main.rs:14:10
+   |
+14 |     #[repr(C)]
+   |       ^^^^^^^ help: consider switching to `repr(ordered_fields)`
+   |     struct Foo {
+   |
+   = note: `#[warn(edition_2024_repr_c)]` on by default
+   = note: `repr(C)` is planned to change meaning in the next edition to match the target platform's layout algorithm. This may change the layout of this type on certain platforms. To keep the current layout, switch to `repr(ordred_fields)`
+```
+
+
+On editions > 2024, `repr(ordered_fields)` may differ from `repr(C)`, so that `repr(C)` can match the platform's layout algorithm.
+
+On all editions, once people have made the switch this will make it easier to tell *why* the `repr` was applied to a given struct. If `repr(C)`, it's about FFI and interop, if `repr(ordered_fields)` then it's for a dependable layout. Unlike today, where `repr(C)` fills both roles.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This feature only touches `repr(C)`, other reprs are left as is. It introduces exactly one new repr, `repr(ordered_fields)` to take on one of the roles that `repr(C)` use to take.
+
+`repr(ordered_fields)` will use the same layout algorithm that `repr(C)` currently uses, details can be found in the [reference](https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#reprc-structs). I will give an informal overview here.
+
+For structs, `repr(ordered_fields)` lays out each fields in memory according to the declaration order of the fields.
+
+```rust
+#[repr(ordered_fields)]
+struct Foo {
+	a: u32,
+	b: u8,
+	c: u32,
+	d: u16,
+}
+```
+Would be laid out like so (where `.` are padding bytes)
+```
+#####...######..
+a   b   c   d
+```
+
+For unions, each field is laid out at offset 0, and never have niches.
+
+For enums, the discriminant size is left unspecified (unless another repr specifies it like `repr(ordered_fields, u8)`), but is guaranteed to be stable across rust versions for a given set of variants and fields in each variant.
+
+Enums are defined as a union of structs, where each struct corresponds to each variant of the enum, with the discriminant is prepended as the first field.
+
+For example, `Foo` and `Bar` have the same layout in the example below modulo niches.
+
+```rust
+#[repr(ordered_fields, u32)]
+enum Foo {
+	Variant1,
+	Variant2(u8, u64),
+	Variant3 {
+		name: String,
+	}
+}
+
+#[repr(ordered_fields)]
+union Bar {
+    variant1: BarVariant1,
+    variant2: BarVariant2,
+    variant3: BarVariant3,
+}
+
+#[repr(ordered_fields)]
+struct BarVariant1 {
+    discr: u32,
+}
+
+#[repr(ordered_fields)]
+struct BarVariant2(u32, u8, u64);
+
+#[repr(ordered_fields)]
+struct BarVariant3 {
+    discr: u32,
+    name: String,
+}
+```
+
+Introduce a new `repr(ordered_fields)` which can be applied to `struct`, `enum`, and `union`. On all editions, `repr(ordered_fields)` would behave the same as `repr(C)` on edition 2024. 
+
+On editions > 2024, `repr(ordered_fields)` may differ from `repr(C)`, so that `repr(C)` can match the platform's layout algorithm. For an extreme example, we could stop compiling `repr(C)` for ZST if the target C compiler doesn't allow ZSTs, or we could bump the size to 1 byte if the target C compiler does that by default (this is just an illustrative example, and not endorsed by RFC).
+
+As mentioned in the guide-level explanation, on edition 2024 (maybe <= 2024), any use of `repr(C)` would trigger a new warn by default diagnostic, `edition_2024_repr_c`. This warning could be phased out after at least two editions have passed. This gives the community enough time to migrate any code over to `repr(ordered_fields)` before the next edition after 2024, but doesn't burden Rust forever.
+
+The warning should come with a machine-applicable fix to switch `repr(C)` to `repr(ordered_fields)`, and this fix should be part of `cargo fix`. 
+# Drawbacks
+[drawbacks]: #drawbacks
+
+* This will cause a large amount of churn in the Rust ecosystem
+* If we don't end up actually switching `repr(C)` to mean the system layout/ABI, then we will have two identical reprs, which may cause confusion.
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+* `crabi`: http://github.com/rust-lang/rfcs/pull/3470
+	* Currently stuck in limbo since it has a much larger scope. doesn't actually serve to give a consistent cross-platform layout, since it defers to `repr(C)` (and it must, for it's stated goals)
+* https://internals.rust-lang.org/t/consistent-ordering-of-struct-fileds-across-all-layout-compatible-generics/23247
+	* This doesn't give a predictable layout that can be used to match the layouts (or prefixes) of different structs
+* https://github.com/rust-lang/rfcs/pull/3718
+	* This one is currently stuck due to a larger scope than this RFC
+* do nothing
+	* We keep getting bug reports on Windows (and other platforms), where `repr(C)` doesn't actually match the target C compiler. Or we break a bunch of subtle unsafe code to match the target C compiler.
+# Prior art
+[prior-art]: #prior-art
+
+This is discussed in Rationale and Alternatives
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+* The migration plan, as a whole needs to be ironed out
+	* Currently it is just a sketch, but we need timelines, dates, and guarantees to switch `repr(C)` to match the layout algorithm of the target C compiler.
+	* Before this RFC is accepted, t-compiler will need to commit to fixing the layout algorithm sometime in the next edition.
+* The name of the new repr `repr(ordered_fields)` is a mouthful (intentionally for this RFC), maybe we could pick a better name? This could be done after the RFC is accepted.
+	* `repr(linear)`
+	* `repr(ordered)`
+	* `repr(sequential)`
+	* something else?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+* Add more reprs for each target C compiler, for example `repr(C_gcc)` or  `repr(C_msvc)`, etc.
+	* This would allow a single rust app to target multiple compilers in a robust way, and would make it easier to specify `repr(C)`
+	* This would also allow fixing code in older editions
+* https://internals.rust-lang.org/t/consistent-ordering-of-struct-fileds-across-all-layout-compatible-generics/23247

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -111,13 +111,14 @@ union FooUnion {
 
 `FooUnion` has the same layout as `u32`, since `u32` has both the biggest size and alignment.
 ### enum
-The enum's tag is the smallest signed integer type which can hold all of the discriminant values (unless otherwise specified). The discriminants are assigned such that each variant without an explicit discriminant is exactly one more than the previous variant in declaration order.
+The enum's tag type is same type that is used for `repr(C)` in edition <= 2024, and the discriminants is assigned the same was as `repr(C)` (in edition <= 2024).  This means the discriminants are assigned such that each variant without an explicit discriminant is exactly one more than the previous variant in declaration order.
+This does mean that the tag type will be platform specific. To alleviate this concern, using `repr(ordered_fields)` on an enum without an explicit `repr(uN)`/`repr(iN)` will trigger a warning. This warning should suggest the smallest integer type which can hold the discriminant values (preferring signed integers to break ties).
 
 If an enum doesn't have any fields, then it is represented exactly by it's discriminant. 
 ```rust
 // tag = i16
 // represented as i16
-#[repr(ordered_fields)]
+#[repr(ordered_fields, i16)]
 enum FooEnum {
     VarA = 1,
     VarB, // discriminant = 2
@@ -140,7 +141,7 @@ Enums with fields will be laid out as if they were a union of structs.
 
 For example, this would be laid out the same as the union below
 ```rust
-#[repr(ordered_fields)]
+#[repr(ordered_fields, i8)]
 enum BarEnum {
     VarFieldless,
     VarTuple(u8, u32),
@@ -159,7 +160,7 @@ union BarUnion {
     var3: VarStruct,
 }
 
-#[repr(ordered_fields)]
+#[repr(ordered_fields, i8)]
 enum BarTag {
     VarFieldless,
     VarTuple,

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -20,6 +20,17 @@ But in some cases, these two cases are in tension due to platform weirdness (eve
 * https://github.com/rust-lang/rust/issues/81996
 
 Providing any fix for case 2 would subtly break any users of case 1, which makes this difficult to fix within a single edition. 
+
+As an example of this tension: on Windows MSVC, `repr(C)` doesn't always match what MSVC does for  ZST structs (see this [issue](https://github.com/rust-lang/rust/issues/81996) for more details)
+
+```rust
+// should have size 8, but has size 0
+#[repr(C)]
+struct SomeFFI([i64; 0]);
+```
+
+Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for case 1. They want it to be size 0 (as it currently is). 
+
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -66,7 +66,7 @@ The next two cases will not be solved by this RFC, but this RFC will provide the
 
 This also plays a role in [#3718](https://github.com/rust-lang/rfcs/pull/3718), where `repr(C, packed(N))` wants allow fields which are `align(M)` (while making the `repr(C, ...)` struct less packed). This is a footgun for normal uses of `repr(packed)`, so it would be better to relegate this strictly to the FFI use-case. However, since `repr(C)` plays two roles, this is difficult.
 
-By splitting `repr(ordered_fields)`  off of `repr(C)`, we can allow `repr(C, packed(N))` to contain over-aligned fields (while making the struct less packed), and (continuing to) disallow `repr(ordered_fields, packed(N))` from containing aligned fields. Thus keeping the Rust-only case free of warts, without compromising on FFI use-cases[<sup>1</sup>](ordered_fields_align).
+By splitting `repr(ordered_fields)`  off of `repr(C)`, we can allow `repr(C, packed(N))` to contain over-aligned fields (while making the struct less packed), and (continuing to) disallow `repr(ordered_fields, packed(N))` from containing aligned fields. Thus keeping the Rust-only case free of warts, without compromising on FFI use-cases[<sup>1</sup>](#ordered_fields_align).
 
 ## MSVC bug
 
@@ -410,7 +410,7 @@ See Rationale and Alternatives as well
 * Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)
 	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type
 * What should the lints look like? (can be decided after stabilization if needed, but preferably this is hammered out before stabilization and after this RFC is accepted)
-* <a name="ordered_fields_align"/> Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
+* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845/files#r2319098177
 	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
 # Future possibilities

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -75,7 +75,7 @@ The exact algorithm is deferred to whatever the default target C compiler does w
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
 ### struct
 Structs are laid out in memory in declaration order, with padding bytes added as necessary to preserve alignment.
-And their alignment would be the same as their most aligned field.
+And their alignment is the same as their most aligned field.
 
 ```rust
 // size 16, align 4
@@ -107,9 +107,9 @@ union FooUnion {
 }
 ```
 
-Would have the same layout as `u32`.
+`FooUnion` has the same layout as `u32`, since `u32` has both the biggest size and alignment.
 ### enum
-The enum discriminant will be the smallest signed integer type which can hold all of the discriminant values (unless otherwise specified). The discriminants are assigned such that each variant without an explicit discriminant is exactly one more than the previous variant in declaration order. 
+The enum discriminant is the smallest signed integer type which can hold all of the discriminant values (unless otherwise specified). The discriminants are assigned such that each variant without an explicit discriminant is exactly one more than the previous variant in declaration order. 
 
 If an enum doesn't have any fields, then it is represented exactly by it's discriminant. 
 ```rust
@@ -176,11 +176,11 @@ struct VarTuple(BarDiscriminant, u8, u32);
 struct VarStruct(BarDiscriminant, u16, u32);
 ```
 
-In Rust, the algorithm for calculating the layout is defined precisely as follows
+In Rust, the algorithm for calculating the layout is defined precisely as follows:
 
 ```rust
 /// Takes in the layout of each field (in declaration order)
-/// and returns the offsets of each field, and layout of the entire struct
+/// and returns the offsets of each field, and the layout of the entire struct
 fn get_layout_for_struct(field_layouts: &[Layout]) -> Result<(Vec<usize>, Layout), LayoutError> {
     let mut layout = Layout::new::<()>();
     let mut field_offsets = Vec::new();
@@ -217,7 +217,7 @@ fn get_layout_for_union(field_layouts: &[Layout]) -> Result<Layout, LayoutError>
 
 /// Takes in the layout of each variant (and their fields) (in declaration order)
 /// and returns the offsets of all fields of the enum, and the layout of the entire enum
-/// NOTE: all fields of the enum discriminant is always at offset 0
+/// NOTE: the enum discriminant is always at offset 0
 fn get_layout_for_enum(
     // the discriminants may be negative for some enums
     // or u128::MAX for some enums, so there is no one primitive integer type which works. So BigInteger

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -74,7 +74,8 @@ The exact algorithm is deferred to whatever the default target C compiler does w
 > 
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
 ### struct
-Structs are laid out in memory in declaration order.
+Structs are laid out in memory in declaration order, with padding bytes added as necessary to preserve alignment.
+And their alignment would be the same as their most aligned field.
 
 ```rust
 // size 16, align 4
@@ -93,6 +94,8 @@ Would be laid out in memory like so
 a...bbbbcc..dddd
 ```
 ### union
+Unions would be laid out with the same size as their largest field, and the same alignment as their most aligned field. 
+
 ```rust
 // size 4, align 4
 #[repr(ordered_fields)]

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -38,7 +38,9 @@ Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for c
 
 A tertiary motivation is to make progress on a workaround for the MSVC bug [rust-lang/rust/112480](https://github.com/rust-lang/rust/issues/112480). This proposal doesn't attempt a complete solution for the bug, but it will be a necessary component of any solution to the bug. 
 
-The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the `alignof` macro reports an alignment of 4 bytes, but in structs, it is aligned to 8 bytes. And on these platforms, we report the alignment as 8 bytes. Any proper work around will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting what `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way, if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
+The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the alignment of `u64`/`i64` is reported to be 8 bytes by `alignof` and is correctly aligned in structs. However, when placed on the stack, MSVC doesn't ensure that they are aligned to 8-bytes, and may instead only align them to 4 bytes.
+
+Any proper work around will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting what `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way, if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -29,7 +29,7 @@ Code in case 1 generally falls into one of these buckets:
 	* for example, zero-copy deserialization (see [rkyv](https://crates.io/crates/rkyv))
 * manually calculating the offsets of fields
 	* This is common in code written before the stabilization of `offset_of` (currently only stabilized for `struct`)/`&raw const`/`&raw mut`
-	* But sometimes this is still required if you are doing manually type-erasure and handling DSTs (for example, implementing [`erasable::Erasable`](https://docs.rs/erasable/1.3.0/erasable/trait.Erasable.html))
+	* But sometimes this is still required if you are manually doing type-erasure and handling DSTs (for example, implementing [`erasable::Erasable`](https://docs.rs/erasable/1.3.0/erasable/trait.Erasable.html))
 * manually calculating the layout for a DST, to prepare an allocation (see [slice-dst](https://crates.io/crates/slice-dst), specifically [here](https://github.com/CAD97/pointer-utils/blob/0fe399f8f7e519959224069360f3900189086683/crates/slice-dst/src/lib.rs#L162-L163))
 * match layouts of two different types (or even, two different monomorphizations of the same generic type)
 	* see [here](https://github.com/rust-lang/rust/pull/68099), where in `alloc` this is done for `Rc` and `Arc` to give a consistent layout for all `T`

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -36,7 +36,7 @@ struct SomeFFI([i64; 0]);
 
 Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for case 1. They want it to be size 0 (as it currently is). 
 
-The next two cases will not be solved by this RFC, but this RFC will provide the necessary parts steps towards the respective fixes.
+The next two cases will not be solved by this RFC, but this RFC will provide the necessary steps towards the respective fixes.
 
 This also plays a role in [#3718](https://github.com/rust-lang/rfcs/pull/3718), where `repr(C, packed(N))` wants allow fields which are `align(M)` (while making the `repr(C, ...)` struct less packed). This is a footgun for normal uses of `repr(packed)`, so it would be better to relegate this strictly to the FFI use-case. However, since `repr(C)` plays two roles, this is difficult.
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -27,10 +27,11 @@ But in some cases, these two cases are in tension due to platform weirdness (eve
 Code in case 1 generally falls into one of these buckets:
 * rely on the exact layout being consistent across platforms
 	* for example, zero-copy deserialization (see [rkyv](https://crates.io/crates/rkyv))
-* be manually calculating the offsets of fields
-	* This is common in code written before the stabilization of `offset_of` (currently only stabilized for `struct`)
-* be manually calculating the layout for a DST, to prepare an allocation (see [slice-dst](https://crates.io/crates/slice-dst), specifically [here](https://github.com/CAD97/pointer-utils/blob/0fe399f8f7e519959224069360f3900189086683/crates/slice-dst/src/lib.rs#L162-L163))
-* to match layouts of two different types (or even, two different monomorphizations of the same generic type)
+* manually calculating the offsets of fields
+	* This is common in code written before the stabilization of `offset_of` (currently only stabilized for `struct`)/`&raw const`/`&raw mut`
+	* But sometimes this is still required if you are doing manually type-erasure and handling DSTs (for example, implementing [`erasable::Erasable`](https://docs.rs/erasable/1.3.0/erasable/trait.Erasable.html))
+* manually calculating the layout for a DST, to prepare an allocation (see [slice-dst](https://crates.io/crates/slice-dst), specifically [here](https://github.com/CAD97/pointer-utils/blob/0fe399f8f7e519959224069360f3900189086683/crates/slice-dst/src/lib.rs#L162-L163))
+* match layouts of two different types (or even, two different monomorphizations of the same generic type)
 	* see [here](https://github.com/rust-lang/rust/pull/68099), where in `alloc` this is done for `Rc` and `Arc` to give a consistent layout for all `T`
 
 So, providing any fix for case 2 would subtly break any users of case 1. This breakage cannot be checked easily since it relies on unsafe code making assumptions about data layouts, which makes this difficult to fix within a single edition.

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -103,7 +103,7 @@ The exact algorithm is deferred to whatever the default target C compiler does w
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
 ### struct
 Structs are laid out in memory in declaration order, with padding bytes added as necessary to preserve alignment.
-And their alignment is the same as their most aligned field.
+The alignment of a struct is the same as the alignment of the most aligned field.
 
 ```rust
 // assuming that u32 is aligned to 4 bytes

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -1,6 +1,6 @@
-- Feature Name: (fill me in with a unique ident, `repr_ordered_fields`)
-- Start Date: (fill me in with today's date, 2025-08-01)
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Feature Name: `repr_ordered_fields`
+- Start Date: 2025-08-05
+- RFC PR: [rust-lang/rfcs#3845](https://github.com/rust-lang/rfcs/pull/3845)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 # Summary

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -306,6 +306,7 @@ See Rationale and Alternatives as well
     * `repr(ordered)`
     * `repr(sequential)`
     * `repr(consistent)`
+    * `repr(declaration_order)`
     * something else?
 * Is the ABI of `repr(ordered_fields)` specified (making it safe for FFI)? Or not?
 * Should unions expose some niches?

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -262,7 +262,7 @@ fn get_layout_for_union(field_layouts: &[Layout]) -> Result<Layout, LayoutError>
 }
 
 /// Takes in the layout of each variant (and their fields) (in declaration order), and returns the layout of the entire enum
-/// the offsets of all fields of the enum is left as an excersize for the readers
+/// the offsets of all fields of the enum is left as an exercise for the readers
 /// NOTE: the enum tag is always at offset 0
 fn get_layout_for_enum(
     // the discriminants may be negative for some enums

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -411,7 +411,7 @@ See Rationale and Alternatives as well
 	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type
 * What should the lints look like? (can be decided after stabilization if needed, but preferably this is hammered out before stabilization and after this RFC is accepted)
 * <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
-	* discussion: https://github.com/rust-lang/rfcs/pull/3845/files#r2319098177
+	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319098177
 	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
 * What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -241,7 +241,7 @@ fn get_layout_for_enum(
     let mut variant_field_offsets = Vec::new();
     
     let mut variant_with_tag = Vec::new();
-    // gives the smallest integer type which can represent the variants and the specified discriminants
+    // gives the tag used by `repr(C)` enums
     let tag_layout = get_layout_for_tag(discriminants);
     // ensure that the tag is the first field
     variant_with_tag.push(tag_layout);

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -78,6 +78,7 @@ Structs are laid out in memory in declaration order, with padding bytes added as
 And their alignment is the same as their most aligned field.
 
 ```rust
+// assuming that u32 is aligned to 4 bytes
 // size 16, align 4
 #[repr(ordered_fields)]
 struct FooStruct {
@@ -97,6 +98,7 @@ a...bbbbcc..dddd
 Unions would be laid out with the same size as their largest field, and the same alignment as their most aligned field. 
 
 ```rust
+// assuming that u32 is aligned to 4 bytes
 // size 4, align 4
 #[repr(ordered_fields)]
 union FooUnion {

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -6,7 +6,11 @@
 # Summary
 [summary]: #summary
 
-Introduce a new `repr` (let's call it `repr(ordered_fields)`, but that can be bikeshedded if this RFC is accepted) that can be applied to `struct`, `enum`, and `union` types, which guarantees a simple and predictable layout. Then provide an initial migration plan to switch users from `repr(C)` to `repr(ordered_fields)`.
+Introduce a new `repr` (let's call it `repr(ordered_fields)`, but that can be bikeshedded if this RFC is accepted) that can be applied to `struct`, `enum`, and `union` types, which guarantees a simple and predictable layout. Then provide an initial migration plan to switch users from `repr(C)` to `repr(ordered_fields)`. This allows restricting the meaning of `repr(C)` to just serve the FFI use-case.
+
+Introduce two new warnings
+1. An optional edition warning, when updating to the next edition, that the meaning of `repr(C)` is changing.
+2. A warning-by-default lint when `repr(ordered_fields)` is used on enums without the tag type specified. Since this is likely not what the user wanted.
 
 # Motivation
 [motivation]: #motivation

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -10,7 +10,7 @@ Introduce a new `repr` (let's call it `repr(ordered_fields)`, but that can be bi
 
 Introduce two new warnings
 1. An optional edition warning, when updating to the next edition, that the meaning of `repr(C)` is changing.
-2. A warning-by-default lint when `repr(ordered_fields)` is used on enums without the tag type specified. Since this is likely not what the user wanted.
+2. A warn-by-default lint when `repr(ordered_fields)` is used on enums without the tag type specified. Since this is likely not what the user wanted.
 
 # Motivation
 [motivation]: #motivation
@@ -35,6 +35,9 @@ struct SomeFFI([i64; 0]);
 
 Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for case 1. They want it to be size 0 (as it currently is). 
 
+A tertiary motivation is to make progress on a work around for the MSVC bug [rust-lang/rust/112480](https://github.com/rust-lang/rust/issues/112480). This proposal doesn't attempt a complete solution for the bug, but it will be a necessary component of any solution to the bug. 
+
+The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the `alignof` macro reports an alignment 4 bytes, but in structs it is aligned to 8 bytes. And on these platforms, we report the alignment as 8 bytes. Any proper work around will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting what `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -410,9 +410,11 @@ See Rationale and Alternatives as well
 * Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)
 	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type
 * What should the lints look like? (can be decided after stabilization if needed, but preferably this is hammered out before stabilization and after this RFC is accepted)
-* <a id="ordered_fields_align"> Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types). </a>
+* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845/files#r2319098177
 	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
+* What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
+	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105
 # Future possibilities
 [future-possibilities]: #future-possibilities
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -42,7 +42,7 @@ Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for c
 
 `repr(C)` in edition <= 2024 is an alias for `repr(ordered_fields)` and in all other editions, it matches the default C compiler for the given target for structs, unions, and field-less enums. Enums with fields will be laid out as if they are a union of structs with the corresponding fields.
 
-Using `repr(C)` in editions <= 2024 triggers a lint to use `repr(ordered_fields)` as an optional edition migration lint with a machine-applicable fix. If you are using `repr(C)` for FFI, then you may silence this lint. If you are using `repr(C)` for anything else, please switch over to `repr(ordered_fields)` so updating to future editions doesn't change the meaning of your code.
+Using `repr(C)` in editions <= 2024 triggers a lint to use `repr(ordered_fields)` as an optional edition compatibility lint with a machine-applicable fix. If you are using `repr(C)` for FFI, then you may silence this lint. If you are using `repr(C)` for anything else, please switch over to `repr(ordered_fields)` so updating to future editions doesn't change the meaning of your code.
 
 ```
 warning: use of `repr(C)` in type `Foo`
@@ -265,7 +265,7 @@ fn get_layout_for_enum(
 
 The migration will be handled as follows:
 * after `repr(ordered_fields)` is implemented
-    * add an optional edition migration warning for `repr(C)`
+    * add an optional edition compatibility lint for `repr(C)`
     	* this warning should be advertised publicly (maybe on the Rust Blog?), so that as many people use it. Since even if you are staying on edition <= 2024, it is helpful to switch to `repr(ordered_fields)` to make your intentions clearer
     * at this point both `repr(ordered_fields)` and `repr(C)` will have identical behavior
     * the warning will come with a machine-applicable fix

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -43,6 +43,8 @@ Here are some examples of the tension and some other RFCs which could benefit fr
 3. A Windows MSVC bug
 4. An [AIX](https://internals.rust-lang.org/t/repr-c-aix-struct-alignment/21594) layout bug
 
+Examples 3 and 4 cannot be solved with this RFC alone, but any fix would require splitting up `repr(C)`.
+
 ## MSVC ZST
 
 As an example of this tension: on Windows MSVC, `repr(C)` doesn't always match what MSVC does for ZST structs (see this [issue](https://github.com/rust-lang/rust/issues/81996) for more details)
@@ -59,8 +61,6 @@ Fixing the layout of this struct will also most likely let us remove a long-stan
 unlike all other ABIs, we do *not* entirely skip ZST with that ABI but instead mark them to be passed by-ptr.
 This is needed to correctly pass types like `SomeFFI`.
 If we fix our layout computation to match that of MSVC, we no longer need this special case in the ABI logic.
-
-The next two cases will not be solved by this RFC, but this RFC will provide the necessary steps towards the respective fixes.
 
 ## RFC #3718
 
@@ -410,7 +410,7 @@ See Rationale and Alternatives as well
 * Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)
 	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type
 * What should the lints look like? (can be decided after stabilization if needed, but preferably this is hammered out before stabilization and after this RFC is accepted)
-* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
+* <a id="ordered_fields_align"> Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types). </a>
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845/files#r2319098177
 	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
 # Future possibilities

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -315,7 +315,7 @@ See Rationale and Alternatives as well
     * This way we can evolve the repr (for example, by adding new niches)
 * Should we change the meaning of `repr(C)` in editions <= 2024 after we have reached edition 2033? Yes, it's a breaking change, but at that point it will likely only be breaking code no one uses.
     * Leaning towards no
-* Should we warn on `repr(ordered_fields)` when explicit tag type is specified (i.e. no `repr(u8)`/`repr(i32)`)
+* Should we warn on `repr(ordered_fields)` when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)
 	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type.
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -36,9 +36,9 @@ struct SomeFFI([i64; 0]);
 
 Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for case 1. They want it to be size 0 (as it currently is). 
 
-A tertiary motivation is to make progress on a work around for the MSVC bug [rust-lang/rust/112480](https://github.com/rust-lang/rust/issues/112480). This proposal doesn't attempt a complete solution for the bug, but it will be a necessary component of any solution to the bug. 
+A tertiary motivation is to make progress on a workaround for the MSVC bug [rust-lang/rust/112480](https://github.com/rust-lang/rust/issues/112480). This proposal doesn't attempt a complete solution for the bug, but it will be a necessary component of any solution to the bug. 
 
-The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the `alignof` macro reports an alignment 4 bytes, but in structs it is aligned to 8 bytes. And on these platforms, we report the alignment as 8 bytes. Any proper work around will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting what `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
+The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the `alignof` macro reports an alignment of 4 bytes, but in structs, it is aligned to 8 bytes. And on these platforms, we report the alignment as 8 bytes. Any proper work around will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting what `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way, if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -64,6 +64,8 @@ Using `repr(C)` on all editions (including > 2024) when there are no extern bloc
 
 If *any* extern block or function (including `extern "Rust"`) is used in the crate, then this lint will not be triggered. This way we don't have too many false positives for this lint. However, the lint should *not* suggest adding a `extern` block or function, since the problem is likely the `repr`.
 
+The `suspicious_repr_c` lint takes precedence over `edition_2024_repr_c`.
+
 ```
 warning: use of `repr(C)` in type `Foo`
   --> src/main.rs:14:10

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -103,7 +103,7 @@ This is because
 > In aggregates, the first member of this data type is aligned according to its natural alignment value; subsequent members of the aggregate are aligned on 4-byte boundaries.
 > - [IBM Documentation](https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=data-using-alignment-modes) (Table 1, Note 1)
 
-Even though on AIX `alignof(double)` is 8, it is still laid out an a 4-byte boundary. 
+Even though on AIX `__alignof__(double)` is 8, it is still laid out an a 4-byte boundary. 
 
 This is in stark contrast with `repr(C)` in Rust, which always lays out fields at their "natural alignment". Any fix for this would require splitting up `repr(C)` since anyone in case 2 cannot tolerate under-aligned fields (since it would disallow taking references to those fields).
 # Guide-level explanation

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -89,7 +89,7 @@ Field `b` would be laid out at offset 4, which is under-aligned (since `f64` has
 
 For more details, see this discussion on [irlo](https://internals.rust-lang.org/t/repr-c-aix-struct-alignment/21594/3).
 
-In AIX, the following struct `Floats` has the following field offsets: `[0, 64, 96]` (in bits)
+In AIX, the following struct `Floats` has the following field offsets: `[0, 8, 12]` (in bytes)
 
 ```C
 struct Floats {
@@ -103,7 +103,8 @@ This is because
 > In aggregates, the first member of this data type is aligned according to its natural alignment value; subsequent members of the aggregate are aligned on 4-byte boundaries.
 > - [IBM Documentation](https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=data-using-alignment-modes) (Table 1, Note 1)
 
-Even though on AIX `__alignof__(double)` is 8, it is still laid out an a 4-byte boundary. 
+Even though on AIX `__alignof__(double)` is 8, it is still laid out an a 4-byte boundary.
+(That's no contradiction since `__alignof__` designates the *preferred* alignment, not the *required* alignment.)
 
 This is in stark contrast with `repr(C)` in Rust, which always lays out fields at their "natural alignment". Any fix for this would require splitting up `repr(C)` since anyone in case 2 cannot tolerate under-aligned fields (since it would disallow taking references to those fields).
 # Guide-level explanation

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -183,6 +183,12 @@ warning: use of `repr(C)` in type `Foo`
 After enough time has passed, and the community has switched over:
 This makes it easier to tell *why* the `repr` was applied to a given struct. If `repr(C)`, it's about FFI and interop. If `repr(ordered_fields)`, then it's for a dependable layout.
 
+The idiom lint `repr_c_curr` will trigger on usages of `repr(C#editionCurr)`. This is allow-by-default on current editions and warn by default on new editions.
+On the current edition it will guide people towards `repr(C#editionNext)` or `repr(ordered_fields)`. 
+On future current editions it will guide people towards `repr(C)` or `repr(ordered_fields)`. 
+
+The idiom lint `repr_c_next` will trigger on usages of `repr(C#editionNext)`. This is allow-by-default on current editions and deny-by-default/warn-by-default in future editions. This comes with a machine applicable fix to switch to `repr(C)`.
+
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -187,8 +187,8 @@ a...bbbbcc..dddd
 ```
 ### union
 When applying `repr(ordered_fields)`, unions would be laid out as follows:
-* the same size as their largest field
 * the same alignment as their most aligned field
+* the same size as their largest field, rounded up to the next multiple of the union's alignment
 * all fields are at offset 0
 
 ```rust

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -432,6 +432,7 @@ The migration will be handled as follows:
     * The two idiom lints will come into effect to provide an off ramp for `repr(C#editionCurr)` and  `repr(C#editionNext)`
 * Once the following edition rolls around (2030?)
     * `repr(C#editionCurr)` and `repr(C#editionNext)` are no longer valid. You may only use `repr(ordered_fields)` or `repr(C)`
+    * unsure about this step, it's not necessary, but it seems nice to prevent usage of a migration step.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -206,6 +206,8 @@ see the current Rust reference entry for `repr(C)`: https://doc.rust-lang.org/st
 
 The exact algorithm is deferred to whatever the default target C compiler does with default settings (or if applicable, the most commonly used settings). `rustc` may grow extra flags to control the behavior of `repr(C)`, in order to match certain flags in the default C compiler, however those will need to be their own proposals. This RFC does not specify any extra control over `repr(C)`.
 
+If any bugs are found (i.e. differences between the target C compiler's layout/ABI and `repr(C)`) then the Rust team reserves the right to change the behavior of `repr(C)` to comply with the target C compiler.
+
 ## `repr(C)`
 
 This repr's meaning depends on the edition of the crate:
@@ -475,7 +477,7 @@ See Rationale and Alternatives as well
     * discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2291506953
 * What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105
-* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
+* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (over-aligned types).
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319098177
 	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
 * ~~Should unions expose some niches?~~ [no](https://github.com/rust-lang/rfcs/pull/3845#discussion_r3088073911)

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -591,7 +591,7 @@ See Rationale and Alternatives as well
 [unresolved-questions]: #unresolved-questions
 
 * The migration plan, as a whole, needs to be ironed out
-    * Currently, it is just a sketch, but we need timelines, dates, and guarantees to switch `repr(C)` to match the layout algorithm of the target C compiler.
+    * Currently, it is just a sketch, but we need timelines, dates, ~~and guarantees to switch `repr(C)` to match the layout algorithm of the target C compiler.~~ accepting this RFC will enforce this guarantee
     * Before this RFC is accepted, t-compiler will need to commit to fixing the layout algorithm sometime in the next edition.
 * ~~Should this `repr` be versioned?~~
     * This way we can evolve the repr (for example, by adding new niches)

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -165,7 +165,7 @@ The exact algorithm is deferred to whatever the default target C compiler does w
 > 
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
 ### struct
-Structs are laid out in memory in declaration order, with padding bytes added as necessary to preserve alignment.
+When applying `repr(ordered_fields)` structs are laid out in memory in declaration order, with padding bytes added as necessary to preserve alignment.
 The alignment of a struct is the same as the alignment of the most aligned field.
 
 ```rust
@@ -186,7 +186,10 @@ Would be laid out in memory like so
 a...bbbbcc..dddd
 ```
 ### union
-Unions would be laid out with the same size as their largest field, and the same alignment as their most aligned field. 
+When applying `repr(ordered_fields)` to an unions would be laid out as followed:
+* the same size as their largest field
+* the same alignment as their most aligned field
+* all fields are at offset 0
 
 ```rust
 // assuming that u32 is aligned to 4 bytes
@@ -202,8 +205,14 @@ union FooUnion {
 
 `FooUnion` has the same layout as `u32`, since `u32` has both the biggest size and alignment.
 ### enum
-The enum's tag type is the same type that is used for `repr(C)` in edition <= 2024, and the discriminants are assigned the same way as `repr(C)` (in edition <= 2024).  This means the discriminants are assigned such that each variant without an explicit discriminant is exactly one more than the previous variant in declaration order.
-This does mean that the tag type will be platform-specific. To alleviate this concern, using `repr(ordered_fields)` on an enum without an explicit `repr(uN)`/`repr(iN)` will trigger a warning (name TBD). This warning should suggest the smallest integer type that can hold the discriminant values (preferring signed integers to break ties).
+When applying `repr(ordered_fields)` to an enum, the enum's tag type and discriminant will be the same as when applying `repr(C)` to the enum in edition <= 2024.
+This does mean that the tag type will be platform-specific. To alleviate this concern, using `repr(ordered_fields)` on an enum without an explicit `repr(uN)`/`repr(iN)` will trigger a warning (name TBD).
+This warning should suggest the smallest integer type that can hold the discriminant values (preferring signed integers to break ties).
+
+For discriminants, this means that it will follow the given algorithm for each variant in declaration order of the variants:
+* if a variant has an explicit discriminant value, then that value is assigned
+* else if this is the first variant in declaration order, then the discriminant is zero
+* else the discriminant value is one more than the previous variant's discriminant (in declaration order)
 
 If an enum doesn't have any fields, then it is represented exactly by its discriminant. 
 ```rust
@@ -229,6 +238,8 @@ enum FooEnumUnsigned {
 ```
 
 Enums with fields will be laid out as if they were a struct containing the tag and a union of structs containing the data.
+NOTE: This is different from `repr(iN)`/`repr(uN)` which are laid out as a union of structs, where the first field of the struct is the tag.
+These two layouts are *NOT* compatible, and adding `repr(ordered_fields)` to `repr(iN)`/`repr(uN)` changes the layout of the enum!
 
 For example, this would be laid out the same as the union below
 ```rust

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -151,7 +151,7 @@ For more details, see this discussion on [irlo](https://internals.rust-lang.org/
 `repr(C)` in future editions is an alias for `repr(C#editionNext)`. It will lay out types in the same way as `C` would, and will use the same calling convention as `C`.
 
 Using `repr(C)` in all current editions triggers a lint (seen below) as an edition migration compatibility lint with a machine-applicable fix that switches it to `repr(C#editionCurr)`.
-* If you are using `repr(C)` for FFI, then you should switch to `repr(C#editionNext)`
+* If you are using `repr(C)` for FFI, then you should switch to `repr(C#editionNext)` or upgrade to the new edition
 * If you are not using `repr(C)` for FFI, then you should switch to `repr(ordered_fields)`
 
 The machine-applicable fix is provided to allow users to do migrations on their own terms. This way a user can do `cargo fix` to get warning free code. Then choose one of the following
@@ -173,7 +173,7 @@ warning: use of `repr(C)` in type `Foo`
 
 Using `repr(C)`/`repr(C#editionCurr)`/`repr(C#editionNext)` on all editions (including in future editions) when there are no extern blocks or functions in the crate will trigger a allow-by-default lint (`suspicious_repr_c`) suggesting to use `repr(ordered_fields)`.
 
-This is allow by default, since the edition lint should do the heavy lifting, so it's better to reduces the noise. This is still provided as a tool for interested users to reduce their reliance on `repr(C)` (or it's variants) when it is probably not needed. Since the largest difference between `repr(C)` and `repr(ordered_fields)` is calling convention.
+This is allow by default to reduce noise, since the edition lint should do the heavy lifting. This is still provided as a tool for interested users to reduce their reliance on `repr(C)` (or it's variants) when it is probably not needed. Since the largest difference between `repr(C)` and `repr(ordered_fields)` is calling convention.
 
 If *any* extern block or function (including `extern "Rust"`) uses the given type in the crate, then the `suspicious_repr_c` lint will not be triggered. This way, we don't have too many false positives for this lint. However, the lint should *not* suggest adding a `extern` block or function, since the problem is likely the `repr`.
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -18,9 +18,9 @@ Layout-wise, this is the same as `repr(C)` on all current editions where both co
 
 `repr(C#editionCurr)`: the same as `repr(C)` on all current editions. This will preserve the same layout and ABI as `repr(C)` on current editions. This repr is mainly targeted for use during the transition time. This way we can do an automated fix for `repr(C)` -> `repr(C#editionCurr)`, and you will know that this was done by an automated fix. If we used `repr(ordered_fields)` for this purpose, then it would be ambiguous if that was intentional or automated.
 
-`repr(C#editionNext)`: the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecemeal migration to the new edition while staying on the old edition.
+`repr(C#editionNext)`: the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecemeal migration to the new edition while staying on the old edition. This `repr` should *only* be used for FFI.
 
-`repr(C)`: On current editions the meaning will not change. On new this will be defined as the same representation as the platform C compiler, as specified by the target-triple. This `repr` should *only* be used for FFI.
+`repr(C)`: On current editions the meaning will not change. On future editions this will be defined as the same representation as the platform C compiler, as specified by the target-triple. In future editions, this `repr` should *only* be used for FFI.
 
 Introduce a few new warnings and errors
 1. A error when `repr(ordered_fields)` is used on enums without the tag type specified.

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -48,13 +48,13 @@ Furthermore, it is just fundamentally wrong for Rust to claim that `repr(C)` lay
 the C standard does not prescribe any particular struct layout, so any target/ABI is in principle free to come up with whatever bespoke rules they like. This puts us in a similar position to `std::env::set_var`, where Rust claimed that it was thread-safe, the POSIX standard said it's not, and Rust had to do a breaking change to fix this.
 
 Fixing this is hard because of (unsafe) code that relies on the other role of `repr(C)`, giving a deterministic layout.
-We therefore cannot just "fix" `repr(C)`, we need some sort of transition plan.
+We therefore cannot just "fix" `repr(C)`, we need a new `repr` and some sort of transition plan to move people to the new `repr`.
 This code generally falls into one of these buckets:
-* rely on the exact layout being consistent across platforms
+* rely on the exact layout being consistent across platforms/versions
 	* for example, zero-copy deserialization (see [rkyv](https://crates.io/crates/rkyv))
 * manually calculating the offsets of fields
 	* This is common in code written before the stabilization of `offset_of` (currently only stabilized for `struct`)/`&raw const`/`&raw mut`
-	* But sometimes this is still required if you are manually doing type-erasure and handling DSTs (for example, implementing [`erasable::Erasable`](https://docs.rs/erasable/1.3.0/erasable/trait.Erasable.html))
+	* This is still required if you are manually doing type-erasure and handling DSTs (for example, implementing [`erasable::Erasable`](https://docs.rs/erasable/1.3.0/erasable/trait.Erasable.html))
 * manually calculating the layout for a DST, to prepare an allocation (see [slice-dst](https://crates.io/crates/slice-dst), specifically [here](https://github.com/CAD97/pointer-utils/blob/0fe399f8f7e519959224069360f3900189086683/crates/slice-dst/src/lib.rs#L162-L163))
 * match layouts of two different types (or even, two different monomorphizations of the same generic type)
 	* see [here](https://github.com/rust-lang/rust/pull/68099), where in `alloc` this is done for `Rc` and `Arc` to give a consistent layout for all `T`. For example, by ensuring that the strong count is at offset `0`, and the weak count at offset `size_of::<usize>()`.
@@ -64,7 +64,7 @@ This breakage cannot be checked easily since it affects unsafe code making assum
 
 ### Guiding principle
 
-This RFC will require a large migration across the ecosystem. There are two major use-cases that are prioritized in this document.
+This RFC will require a large migration across the ecosystem for anyone upgrading to the next edition. There are two major use-cases that are prioritized in this document.
 * FFI-only crates, like `*-sys` crates or crates that expose a `C` interface
     * These crates should ideally have to do no work. They want the fixed `repr(C)`
 * Pure Rust crates that don't rely on the C calling convention

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -391,8 +391,8 @@ fn get_layout_for_enum(
 ) -> Result<Layout, LayoutError> {
     assert_eq!(discriminants.len(), variant_layouts.len());
 
+    // each variant's fields are represented as a struct
     let variant_data_layouts = variant_layouts.iter()
-        // each variant's fields are represented as a struct
         .map(|variant_fields_layout| get_layout_for_struct(variant_fields_layout).map(|x| x.1))
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -459,11 +459,12 @@ See Rationale and Alternatives as well
 * The migration plan, as a whole, needs to be ironed out
     * Currently, it is just a sketch, but we need timelines, dates, and guarantees to switch `repr(C)` to match the layout algorithm of the target C compiler.
     * Before this RFC is accepted, t-compiler will need to commit to fixing the layout algorithm sometime in the next edition.
-* Should this `repr` be versioned?
+* ~~Should this `repr` be versioned?~~
     * This way we can evolve the repr (for example, by adding new niches)
+    * no need to for now, this can be done as a future proposal
 * Should we change the meaning of `repr(C)` in editions <= 2024 after we have reached edition 2033 or some other later edition? Yes, it's a breaking change. But at that point, it will likely only be breaking code no one uses.
     * Leaning towards no
-* Is the ABI of `repr(ordered_fields)` specified (making it safe for FFI)? Or not?
+* ~~Is the ABI of `repr(ordered_fields)` specified (making it safe for FFI)? Or not?~~ Not in this RFC
     * discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2291506953
 * What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105
@@ -473,7 +474,7 @@ See Rationale and Alternatives as well
 * ~~Should unions expose some niches?~~ [no](https://github.com/rust-lang/rfcs/pull/3845#discussion_r3088073911)
     * For example, if all variants of the union are structs that have a common prefix, then any niches of that common prefix could be exposed (i.e. in the enum case, making a union of structs behave more like an enum).
     * This must be answered before stabilization, as it is set in stone after that
-* Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)
+* ~~Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)~~ This is now a hard error
 	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type
 * What should the lints look like? (can be decided after stabilization if needed, but preferably this is hammered out before stabilization and after this RFC is accepted)
 * The name of the new repr `repr(ordered_fields)` is a mouthful (intentionally for this RFC), maybe we could pick a better name? This could be done after the RFC is accepted.

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -580,6 +580,7 @@ See Rationale and Alternatives as well
     * `repr(stable)`
     * something else?
 * The name of the new repr `repr(C#editionCurr)` and `repr(C#editionNext)` are bad (intentionally for this RFC), maybe we could pick a better name? This could be done after the RFC is accepted.
+    * maybe instead of `repr(C#editionNext)`, it should have an edition agnostic name [zullip link](https://rust-lang.zulipchat.com/#narrow/channel/410673-t-lang.2Fmeetings/topic/Design.20meeting.202026-04-15.3A.20RFC.203845.20.60repr.28ordered_fields.29.60/near/585817094)
     * `repr(C#edition2024)`/`repr(C#edition2027)`
     * `repr(e24#C)`/`repr(e27#C)`
     * `repr(e2024#C)`/`repr(e2027#C)`

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -409,6 +409,22 @@ See Rationale and Alternatives as well
 * The migration plan, as a whole, needs to be ironed out
     * Currently, it is just a sketch, but we need timelines, dates, and guarantees to switch `repr(C)` to match the layout algorithm of the target C compiler.
     * Before this RFC is accepted, t-compiler will need to commit to fixing the layout algorithm sometime in the next edition.
+* Should this `repr` be versioned?
+    * This way we can evolve the repr (for example, by adding new niches)
+* Is the ABI of `repr(ordered_fields)` specified (making it safe for FFI)? Or not?
+* What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
+	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105
+* Should we change the meaning of `repr(C)` in editions <= 2024 after we have reached edition 2033 or some other later edition? Yes, it's a breaking change. But at that point, it will likely only be breaking code no one uses.
+    * Leaning towards no
+* Should unions expose some niches?
+    * For example, if all variants of the union are structs that have a common prefix, then any niches of that common prefix could be exposed (i.e. in the enum case, making a union of structs behave more like an enum).
+    * This must be answered before stabilization, as it is set in stone after that
+* Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)
+	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type
+* What should the lints look like? (can be decided after stabilization if needed, but preferably this is hammered out before stabilization and after this RFC is accepted)
+* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
+	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319098177
+	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
 * The name of the new repr `repr(ordered_fields)` is a mouthful (intentionally for this RFC), maybe we could pick a better name? This could be done after the RFC is accepted.
     * `repr(linear)`
     * `repr(ordered)`
@@ -417,22 +433,6 @@ See Rationale and Alternatives as well
     * `repr(consistent)`
     * `repr(declaration_order)`
     * something else?
-* Is the ABI of `repr(ordered_fields)` specified (making it safe for FFI)? Or not?
-* Should unions expose some niches?
-    * For example, if all variants of the union are structs that have a common prefix, then any niches of that common prefix could be exposed (i.e. in the enum case, making a union of structs behave more like an enum).
-    * This must be answered before stabilization, as it is set in stone after that
-* Should this `repr` be versioned?
-    * This way we can evolve the repr (for example, by adding new niches)
-* Should we change the meaning of `repr(C)` in editions <= 2024 after we have reached edition 2033? Yes, it's a breaking change. But at that point, it will likely only be breaking code no one uses.
-    * Leaning towards no
-* Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)
-	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type
-* What should the lints look like? (can be decided after stabilization if needed, but preferably this is hammered out before stabilization and after this RFC is accepted)
-* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
-	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319098177
-	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
-* What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
-	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105
 # Future possibilities
 [future-possibilities]: #future-possibilities
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -68,7 +68,7 @@ This RFC will require a large migration across the ecosystem. There are two majo
 * FFI-only crates, like `*-sys` crates or crates that expose a `C` interface
     * these crates should ideally have to do no work. They want the fixed `repr(C)`
 * Pure Rust crates that don't rely on the C calling convention
-    * This is for role 2, they typically don't want their layout changing from under them. So switching to `repr(ordered_fields)` will be the correct fix, with one exception: `enum`s with fields. This is likely a very small minority, since using `repr(C)` on an enum with fields is very niche, esp. because it's easy to get UB when using Rust enums with FFI.
+    * This is for role 2, they typically don't want their layout changing from under them. So switching to `repr(ordered_fields)` will be the correct fix, with one exception: `enum`s with fields. This is likely a very small minority, since using `repr(C)` on an enum with fields is very niche, esp. because it's easy to get UB when using Rust enums with FFI. Also it is already possible to get a platform independent layout for enums, using `repr(u*)` and `repr(i*)`.
 
 There are a number of other use-cases which aren't put on a pedestal like these two. Many of them are detailed near the [end](#migration-examples) of this document.
 
@@ -176,7 +176,7 @@ This does miss some potential use cases
 2. the crate wants to interact with hardware, and using `repr(C)` is the correct repr
 3. the crate wants is using shared memory with another process, and using `repr(C)` is the correct repr.
 
-Since this is an allow-by-default lint, I think this is fine.
+Since this is an allow-by-default lint, it is fine to have some false-positives.
 
 The `suspicious_repr_c` lint takes precedence over `edition_2024_repr_c` (i.e. `edition_2024_repr_c` shouldn't be emitted if `suspicious_repr_c` is emitted to reduce noise).
 
@@ -491,7 +491,7 @@ The plan
 * `cargo fix` in current edition - to replace all `repr(C)` with `repr(C#editionCurr)`
 * replace all `C#editionCurr` with `ordered_fields`
 * update any enums with an equivalent discriminant
-    * I expect there to be few cases of this, since you can already use `repr(u*)` and `repr(i*)` to get stable layouts for enums
+    * enums with `repr(C)` are expected to be uncommon
 * update to the new edition (this can be done at anytime after step 1)
 
 If you cannot switch to `ordered_fields`

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -62,6 +62,18 @@ This code generally falls into one of these buckets:
 So, providing any fix for role 2 of `repr(C)` would subtly break any users of role 1.
 This breakage cannot be checked easily since it affects unsafe code making assumptions about data layouts, making it difficult to fix within a single edition/existing editions.
 
+### Guiding principle
+
+This RFC will require a large migration across the ecosystem. There are two major use-cases that are prioritized in this document
+* FFI-only crates, like `*-sys` crates or crates that expose a `C` interface
+    * these crates should ideally have to do no work. They want the fixed `repr(C)`
+* Pure Rust crates that don't rely on the C calling convention
+    * This is for role 2, they typically don't want their layout changing from under them. So switching to `repr(ordered_fields)` will be the correct fix, with one exception: `enum`s with fields. This is likely a very small minority, since using `repr(C)` on an enum with fields is very niche, esp. because it's easy to get UB when using Rust enums with FFI.
+
+There are a number of other use-cases which aren't put on a pedestal like these two. Many of them are detailed near the [end](#migration-examples) of this document.
+
+For these other use-cases, this RFC should make it possible to upgrade to the new edition and get the behavior you want. But it may require more work or it may not look as pretty (after all the bikeshedding for this RFC is done).
+
 ### Layout issues
 
 Before we delve into the proposed solution, we go into a little more detail about the aforementioned platform layout issues.
@@ -440,6 +452,73 @@ The migration will be handled as follows:
     * `repr(C)` on the new edition will *not* warn. Instead, the meaning will have changed to mean *only* compatibility with C. The docs should be adjusted to mention this edition wrinkle.
     * The warning for previous editions will continue to be in effect
     * The two idiom lints will come into effect to provide an off ramp for `repr(C#editionCurr)` and  `repr(C#editionNext)`
+
+### Migration Examples
+
+In this section, we'll go over a few different crate archetypes, and one possible migration timeline for them. This is *not* an intended migration plan, forced migration plan, or anything of that nature. This is only to provide examples that show what archetypes were considered when designing this plan.
+
+They core here is to minimize the work needed to for the migration across a wide variety of types of crates. The biggest priority is ensuring that FFI-only crates don't have to do any work, and if you only have non-FFI use-cases it should be almost as simple as find/replace
+
+#### `*-sys` crate
+
+These crates typically only have `extern` blocks and types. They are universally only for FFI, so the migration plan is simple.
+
+* update edition to the next edition - no changes required
+
+#### crates exposing a C interface (only FFI usages of `repr(C)`)
+
+These are crates written in Rust, but expose an interface to be called from another language.
+
+* update edition to the next edition - no changes required
+
+#### crates help build a FFI interface
+
+This includes crates like `bindgen`, `cxx`, `pyo3`, `jni`, or `uniffi` which help build FFI interfaces.
+
+Depending on the tool, they may or may not be edition-aware. If they are edition aware, then they can use `repr(C#editionNext)` or `repr(C)` to get the fixed `repr(C)` depending on the edition.
+
+If they are not edition aware, then they may migrate to using `repr(C#editionNext)` exclusively to ensure they get the fixed `repr(C)` on all editions.
+
+#### crates using `repr(C)` purely for stable layout (no stable calling convention required)
+
+If you can switch to `ordered_fields`, for example because
+* you can migrate any existing data already stored
+* don't have any data stored
+* aren't using `repr(C)` with enums (the only difference in layout between `repr(ordered_fields)` and current `repr(C)`).
+
+The plan
+
+* `cargo fix` in current edition - to replace all `repr(C)` with `repr(C#editionCurr)`
+* replace all `C#editionCurr` with `ordered_fields`
+* update any enums with an equivalent discriminant
+    * I expect there to be few cases of this, since you can already use `repr(u*)` and `repr(i*)` to get stable layouts for enums
+* update to the new edition (this can be done at anytime after step 1)
+
+If you cannot switch to `ordered_fields`
+
+* `cargo fix` in current edition - to replace all `repr(C)` with `repr(C#editionCurr)`
+* update to the new edition, and just keep using `repr(C#editionCurr)`
+
+This use-case is expected to be a small minority of cases. It will still work, and preserve the old behavior on new editions, but it may not look as nice. The best case scenario is to try and migrate the existing data to the new format, and start using `repr(ordered_fields)`.
+
+#### If you need `repr(C)`'s current layout and calling convention
+
+* `cargo fix` in current edition - to replace all `repr(C)` with `repr(C#editionCurr)`
+* update to the new edition (this can be done at anytime after step 1)
+
+This use-case is expected to be a small minority of cases. It will still work, and preserve the old behavior on new editions, but it may 
+not look as nice.
+
+This use case cannot be catered to without expanding the scope of this RFC considerably, so it is out of scope. This plan will still allow migration to the new edition, but it may not look as nice.
+
+#### If you have a mixture of use-cases
+
+* `cargo fix` in current edition - to replace all `repr(C)` with `repr(C#editionCurr)`
+* for each `C#editionCurr`, choose which guarantee you need and switch to `repr(C#editionNext)` or `repr(ordered_fields)`
+* update to the next edition
+* `cargo fix` - to replace all `repr(C#editionNext)` with `repr(C)`
+
+This use-case has to take the brunt of the work, but this is unavoidable in any proposal to fix `repr(C)`. This plan allows gradually migrating all cases to their intended `repr`, and makes it easy to track progress.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -16,15 +16,24 @@ Introduce two new warnings
 # Motivation
 [motivation]: #motivation
 
-Currently `repr(C)` serves two roles
+Currently `repr(C)` serves two roles:
 1. Provide a consistent, cross-platform, predictable layout for a given type
 2. Match the target C compiler's struct/union layout algorithm and ABI
 
-But in some cases, these two cases are in tension due to platform weirdness (even on major platforms like Windows MSVC)
-* https://github.com/rust-lang/unsafe-code-guidelines/issues/521
-* https://github.com/rust-lang/rust/issues/81996
+But in some cases, these two roles are in tension due to platform's C layout not matching the [simple, general algorithm](https://doc.rust-lang.org/stable/reference/type-layout.html#r-layout.repr.c.struct.size-field-offset) Rust always uses:
+* On MSVC, a struct with a single field that is a zero-sized array has size 1. (https://github.com/rust-lang/rust/issues/81996)
+* On MSVC, a `repr(C, packed)` with `repr(align)` fields has special behavior: the inner `repr(align)` takes priority, so fields can be highly aligned even in a packed struct. (https://github.com/rust-lang/rust/issues/100743)
+  (Rust tries to avoid this by forbidding `repr(align)` fields in `repr(packed)` structs, but that check is easily bypassed with generics.)
+* On MSVC-x32, `u64` fields are 8-aligned in structs, but the type is only 4-aligned when allocated on the stack. (https://github.com/rust-lang/rust/issues/112480)
+* On AIX, `f64` fields sometimes but not always get 8-aligned in structs. (https://github.com/rust-lang/rust/issues/151910)
 
-Code in case 1 generally falls into one of these buckets:
+These are all niche cases, but they add up.
+Furthermore, it is just fundamentally wrong for Rust to claim that `repr(C)` layout matches C code for the same target while also specifying an exact algorithm for `repr(C)`:
+the C standard does not prescribe any particular struct layout, so any target/ABI is in principle free to come up with whatever bespoke rules they like.
+
+However, fixing this is hard because of (unsafe) code that relies on the other role of `repr(C)`, giving a deterministic layout.
+We therefore cannot just "fix" `repr(C)`, we need some sort of transition plan.
+This code generally falls into one of these buckets:
 * rely on the exact layout being consistent across platforms
 	* for example, zero-copy deserialization (see [rkyv](https://crates.io/crates/rkyv))
 * manually calculating the offsets of fields
@@ -34,20 +43,17 @@ Code in case 1 generally falls into one of these buckets:
 * match layouts of two different types (or even, two different monomorphizations of the same generic type)
 	* see [here](https://github.com/rust-lang/rust/pull/68099), where in `alloc` this is done for `Rc` and `Arc` to give a consistent layout for all `T`
 
-So, providing any fix for case 2 would subtly break any users of case 1. This breakage cannot be checked easily since it affects unsafe code making assumptions about data layouts. Making it difficult to fix within a single edition/existing editions.
+So, providing any fix for role 2 of `repr(C)` would subtly break any users of role 1.
+This breakage cannot be checked easily since it affects unsafe code making assumptions about data layouts, making it difficult to fix within a single edition/existing editions.
 
-Here are some examples of the tension and some other RFCs which could benefit from splitting up `repr(C)`'s two cases.
+### Layout issues
 
-1. Windows MSVC ZSTs
-2. the RFC [#3718](https://github.com/rust-lang/rfcs/pull/3718) for `repr(C, packed(N))` containing overaligned fields
-3. A Windows MSVC bug
-4. An [AIX](https://internals.rust-lang.org/t/repr-c-aix-struct-alignment/21594) layout bug
+Before we delve into the proposed solution, we go into a little more detail about the aforementioned platform layout issues.
+Some of them cannot be solved with this RFC alone, but all of them have require some approach to split up the two roles of `repr(C)`.
 
-Examples 3 and 4 cannot be solved with this RFC alone, but any fix would require splitting up `repr(C)`.
+## MSVC: zero-length arrays
 
-## MSVC ZST
-
-As an example of this tension: on Windows MSVC, `repr(C)` doesn't always match what MSVC does for ZST structs (see this [issue](https://github.com/rust-lang/rust/issues/81996) for more details)
+On Windows MSVC, `repr(C)` doesn't always match what MSVC does for ZST structs (see this [issue](https://github.com/rust-lang/rust/issues/81996) for more details)
 
 ```rust
 // should have size 8, but has size 0
@@ -57,50 +63,54 @@ struct SomeFFI([i64; 0]);
 
 Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for case 1. They want it to be size 0 (as it currently is). 
 
-## RFC #3718
+## MSVC: `repr(align)` inside `repr(packed)`
 
-This also plays a role in [#3718](https://github.com/rust-lang/rfcs/pull/3718), where `repr(C, packed(N))` wants allow fields which are `align(M)` (while making the `repr(C, ...)` struct less packed). This is a footgun for normal uses of `repr(packed)`, so it would be better to relegate this strictly to the FFI use-case. However, since `repr(C)` plays two roles, this is difficult.
+This also plays a role in [#3718](https://github.com/rust-lang/rfcs/pull/3718), where `repr(C, packed(N))` wants to allow fields which are `align(M)`.
+On most targets, and with Rust's `repr(C, packed)` specification, the `packed` takes precedence:
 
-By splitting `repr(ordered_fields)`  off of `repr(C)`, we can allow `repr(C, packed(N))` to contain over-aligned fields (while making the struct less packed), and (continuing to) disallow `repr(ordered_fields, packed(N))` from containing aligned fields. Thus keeping the Rust-only case free of warts, without compromising on FFI use-cases[<sup>1</sup>](#ordered_fields_align).
+```rust
+#[repr(C, align(8))]
+struct I(u8);
 
-## MSVC bug
-
-Splitting `repr(C)` also allows making progress on a workaround for the MSVC bug [rust-lang/rust/112480](https://github.com/rust-lang/rust/issues/112480). 
-
-The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the alignment of `u64`/`i64` is reported to be 8 bytes by `alignof` and is correctly aligned in structs. However, when placed on the stack, MSVC doesn't ensure that they are aligned to 8 bytes, and may instead only align them to 4 bytes.
-
-Any proper workaround will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way, if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
-
-For AIX, the issue is that `f64` is treated as aligned to 4 bytes if it is not the first field in a struct. i.e.
-```C
-struct Foo {
-	char a;
-	double b;
+#[repr(C, packed)]
+struct O {
+  // At offset 0
+  f1: u8,
+  // At offset 1
+  f2: I,
 }
 ```
-Field `b` would be laid out at offset 4, which is under-aligned (since `f64` has alignment 8 in Rust). Again, any proper workaround will require reducing the alignment of `f64`, and adjusting `repr(C)`.
 
-## AIX layout bug
+However, MSVC will put `f2` at offset 8, so arguably that is what `repr(C, packed)` should do on that target.
+This is a footgun for normal uses of `repr(packed)`, so it would be better to relegate this strictly to the FFI use-case. However, since `repr(C)` plays two roles, this is difficult.
 
+By splitting `repr(ordered_fields)`  off of `repr(C)`, we can allow `repr(C, packed(N))` to contain over-aligned fields (while making the struct less packed), and (continuing to) disallow `repr(ordered_fields, packed(N))` from containing aligned fields. This keeps the Rust-only case free of warts without compromising on FFI use-cases[<sup>1</sup>](#ordered_fields_align).
+
+## MSVC-x32: u64 alignment
+
+Splitting `repr(C)` also allows making progress on dealing with the MSVC "quirk" [rust-lang/rust/112480](https://github.com/rust-lang/rust/issues/112480).
+
+The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the alignment of `u64`/`i64` is reported to be 8 bytes by `alignof` and is correctly aligned in structs. However, when placed on the stack, MSVC doesn't ensure that they are aligned to 8 bytes, and may instead only align them to 4 bytes.
+Our interpretation of this behavior is that `alignof` reports the *preferred* alignment (rather than the required alignment) for the type, and MSVC chooses to sometimes overalign `u64` fields in structs.
+
+No matter the reason for this behavior, any proper solution to this issue will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way, if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
+
+## AIX: f64 alignment
+
+For AIX, the issue is that `f64` is sometimes treated as aligned to 8 bytes and sometimes as aligned to 4 bytes (the comments indicate the desired layout as computed by a C compiler):
+```rust
+// Size: 24
+#[repr(C)]
+struct Floats {
+  a: f64, // at offset 0
+  b: u8, // at offset 8
+  c: f64, // at offset 12
+}
+```
+There is no way to obtain such a layout using Rust's `repr(C)` layout algorithm.
 For more details, see this discussion on [irlo](https://internals.rust-lang.org/t/repr-c-aix-struct-alignment/21594/3).
 
-In AIX, the following struct `Floats` has the following field offsets: `[0, 8, 12]` (in bytes) and a size of 24 bytes. Since the first field has a natural alignment of 8 bytes - AKA its size is 8 bytes.
-
-```C
-struct Floats {
-    double a;
-    char b;
-    double c;
-};
-```
-
-This is because
-> In aggregates, the first member of this data type is aligned according to its natural alignment \[its size\] value; subsequent members of the aggregate are aligned on 4-byte boundaries.
-> - [IBM Documentation](https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=data-using-alignment-modes) (Table 1, Note 1, which applies to `double` and `long double` data types)
-
-On AIX `__alignof__(double)` is 8, but field `c` is laid out at a 4-byte boundary. This is fine because `__alignof__` designates the *preferred* alignment, not the *required* alignment. Note that in Rust, we only ever use the *required* alignment and don't have a concept of a *preferred* alignment. So in Rust, we have designated the alignment of `f64` to be 8 bytes.
-
-Any fix for this would require splitting up `repr(C)`, since reducing the alignment of `f64` would reduce the size of `Floats` from `24` to `20`, which also doesn't match `C`, and we cannot special case the alignment of `Floats` to be larger since that doesn't match the algorithm currently specified for `repr(C)` (making it a breaking change).
+Any fix for this requires splitting up `repr(C)`.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -421,20 +421,21 @@ See Rationale and Alternatives as well
     * Before this RFC is accepted, t-compiler will need to commit to fixing the layout algorithm sometime in the next edition.
 * Should this `repr` be versioned?
     * This way we can evolve the repr (for example, by adding new niches)
-* Is the ABI of `repr(ordered_fields)` specified (making it safe for FFI)? Or not?
-* What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
-	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105
 * Should we change the meaning of `repr(C)` in editions <= 2024 after we have reached edition 2033 or some other later edition? Yes, it's a breaking change. But at that point, it will likely only be breaking code no one uses.
     * Leaning towards no
+* Is the ABI of `repr(ordered_fields)` specified (making it safe for FFI)? Or not?
+    * discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2291506953
+* What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
+	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105
+* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
+	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319098177
+	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
 * Should unions expose some niches?
     * For example, if all variants of the union are structs that have a common prefix, then any niches of that common prefix could be exposed (i.e. in the enum case, making a union of structs behave more like an enum).
     * This must be answered before stabilization, as it is set in stone after that
 * Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)
 	* Since it's likely they didn't want the same tag type as `C`, and wanted the smallest possible tag type
 * What should the lints look like? (can be decided after stabilization if needed, but preferably this is hammered out before stabilization and after this RFC is accepted)
-* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
-	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319098177
-	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
 * The name of the new repr `repr(ordered_fields)` is a mouthful (intentionally for this RFC), maybe we could pick a better name? This could be done after the RFC is accepted.
     * `repr(linear)`
     * `repr(ordered)`

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -139,7 +139,7 @@ If *any* extern block or function (including `extern "Rust"`) is used in the cra
 
 This does miss one potential use case, where a crate provides a suite of FFI-capable types, but does not actually provide any `extern` functions or blocks. This should be an extremely small minority of crates, and they can silence this warning crate-wide.
 
-The `suspicious_repr_c` lint takes precedence over `edition_2024_repr_c`.
+The `suspicious_repr_c` lint takes precedence over `edition_2024_repr_c`. It will be triggered whenever there is a `repr(C)` type, but no `extern` blocks/functions in the crate. This is a basic heuristic to reduce noise, since it is unlikely that you want the `C` repr unless you are interacting with `C` or some other language.
 
 ```
 warning: use of `repr(C)` in type `Foo`
@@ -225,7 +225,7 @@ union FooUnion {
 
 When applying `repr(ordered_fields)` to an enum, the enum's tag type and discriminant will be the same as when applying `repr(C)` to the enum in edition <= 2024.
 This does mean that the tag type will be platform-specific. To alleviate this concern, using `repr(ordered_fields)` on an enum without an explicit `repr(uN)`/`repr(iN)` will trigger a warning (name TBD).
-This warning should suggest the smallest integer type that can hold the discriminant values (preferring signed integers to break ties).
+This warning should suggest the smallest integer type that can hold the discriminant values (preferring signed integers to break ties). Since this changes the layout of the type, the warning should mention that the layout will change.
 
 For discriminants, this means that it will follow the given algorithm for each variant in declaration order of the variants:
 * if a variant has an explicit discriminant value, then that value is assigned
@@ -356,14 +356,17 @@ fn get_layout_for_enum(
 ) -> Result<Layout, LayoutError> {
     assert_eq!(discriminants.len(), variant_layouts.len());
 
-    let variant_data_layout = variant_layouts.iter()
-        .try_fold(
-            Layout::new::<()>(),
-            |acc, variant_layout| Ok(layout_max(acc, get_layout_for_struct(variant_layout)?.1)?)
-        )?;
-    
+    let variant_data_layouts = variant_layouts.iter()
+        // each variant's fields are represented as a struct
+        .map(|variant_fields_layout| get_layout_for_struct(variant_fields_layout).map(|x| x.1))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // then the set of all variants is represented as a union
+    let variant_data_layout = get_layout_for_union(variant_data_layouts)?;
+
     let tag_layout = get_layout_for_tag(discriminants);
 
+    // the tag is then prepended to that union
     let (_, layout) = get_layout_for_struct(&[
         tag_layout,
         variant_data_layout
@@ -430,7 +433,7 @@ See Rationale and Alternatives as well
 * <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (overaligned types).
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319098177
 	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
-* Should unions expose some niches?
+* ~~Should unions expose some niches?~~ [no](https://github.com/rust-lang/rfcs/pull/3845#discussion_r3088073911)
     * For example, if all variants of the union are structs that have a common prefix, then any niches of that common prefix could be exposed (i.e. in the enum case, making a union of structs behave more like an enum).
     * This must be answered before stabilization, as it is set in stone after that
 * Should we warn on `repr(ordered_fields)` applied to enums when explicit tag type is missing (i.e. no `repr(u8)`/`repr(i32)`)

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -580,7 +580,7 @@ See Rationale and Alternatives as well
     * `repr(stable)`
     * something else?
 * The name of the new repr `repr(C#editionCurr)` and `repr(C#editionNext)` are bad (intentionally for this RFC), maybe we could pick a better name? This could be done after the RFC is accepted.
-    * maybe instead of `repr(C#editionNext)`, it should have an edition agnostic name [zullip link](https://rust-lang.zulipchat.com/#narrow/channel/410673-t-lang.2Fmeetings/topic/Design.20meeting.202026-04-15.3A.20RFC.203845.20.60repr.28ordered_fields.29.60/near/585817094)
+    * maybe instead of `repr(C#editionNext)`, it should have an edition agnostic name [zulip link](https://rust-lang.zulipchat.com/#narrow/channel/410673-t-lang.2Fmeetings/topic/Design.20meeting.202026-04-15.3A.20RFC.203845.20.60repr.28ordered_fields.29.60/near/585817094)
     * `repr(C#edition2024)`/`repr(C#edition2027)`
     * `repr(e24#C)`/`repr(e27#C)`
     * `repr(e2024#C)`/`repr(e2027#C)`

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -13,14 +13,14 @@ Introduce a few new `repr`s (all names are placeholders and can be bikeshedded i
 
 And the meaning of `repr(C)` will change in the next edition (presumably `Edition 2027`). All the new reprs can be applied to `struct`, `enum`, and `union` types. 
 
-`repr(ordered_fields)` provides a simple, predicable in memory layout for types. This RFC does *NOT* specify a stable ABI for `repr(ordered_fields)` - that should either be handled by a future RFC or another `repr`.
+`repr(ordered_fields)`: provides a simple, predicable in memory layout for types. This RFC does *NOT* specify a stable ABI for `repr(ordered_fields)` - that should either be handled by a future RFC or another `repr`.
 Layout-wise, this is the same as `repr(C)` on all current editions where both compile.
 
-`repr(C#editionCurr)` is the same as `repr(C)` on all current editions. This will preserve the same layout and ABI as `repr(C)` on current editions. This repr is mainly targeted for use during the transition time. This way we can do an automated fix for `repr(C)` -> `repr(C#editionCurr)`, and you will know that this was done by an automated fix. If we used `repr(ordered_fields)` for this purpose, then it would be ambiguous if that was intentional or automated.
+`repr(C#editionCurr)`: the same as `repr(C)` on all current editions. This will preserve the same layout and ABI as `repr(C)` on current editions. This repr is mainly targeted for use during the transition time. This way we can do an automated fix for `repr(C)` -> `repr(C#editionCurr)`, and you will know that this was done by an automated fix. If we used `repr(ordered_fields)` for this purpose, then it would be ambiguous if that was intentional or automated.
 
-`repr(C#editionNext)` is the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecemeal migration to the new edition while staying on the old edition.
+`repr(C#editionNext)`: the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecemeal migration to the new edition while staying on the old edition.
 
-`repr(C)`, this will be defined as the same representation as the platform C compiler, as specified by the target-triple. This `repr` should *only* be used for FFI.
+`repr(C)`: On current editions the meaning will not change. On new this will be defined as the same representation as the platform C compiler, as specified by the target-triple. This `repr` should *only* be used for FFI.
 
 Introduce a few new warnings and errors
 1. A error when `repr(ordered_fields)` is used on enums without the tag type specified.
@@ -145,14 +145,19 @@ Any fix for this requires splitting up `repr(C)`.
 
 `repr(ordered_fields)` is a new representation that can be applied to `struct`, `enum`, and `union` to give them a consistent, cross-platform, and predictable in-memory layout.
 
-`repr(C)` in edition <= 2024 is an alias for `repr(ordered_fields)` and in all other editions, it matches the default C compiler for the given target triple for structs, unions, and field-less enums. Enums with fields are laid out as a struct containing a tag and payload. With the payload being a union of structs of all the variants. (This is how they are currently laid out in `repr(C)`)
+`repr(C)` in current editions is an alias for `repr(C#editionCurr)` and in all other editions, it matches the default C compiler for the given target triple for structs, unions, and field-less enums. Enums with fields are laid out as a struct containing a tag and payload. With the payload being a union of structs of all the variants. This is how they are currently laid out in `repr(C)`. The calling convention of `repr(C)` will also remain the same and all current editions.
 
-Using `repr(C)` in editions <= 2024 triggers a lint (seen below) as an edition migration compatibility lint with a machine-applicable fix that switches it to `repr(C#editionCurr)`.
+`repr(C)` in future editions is an alias for `repr(C#editionNext)`. It will lay out types in the same way as `C` would, and will use the same calling convention as `C`.
+
+Using `repr(C)` in all current editions triggers a lint (seen below) as an edition migration compatibility lint with a machine-applicable fix that switches it to `repr(C#editionCurr)`.
 * If you are using `repr(C)` for FFI, then you should switch to `repr(C#editionNext)`
 * If you are not using `repr(C)` for FFI, then you should switch to `repr(ordered_fields)`
 
-The machine-applicable fix is provided to allow users to do migrations on their own terms. This way a user can do `cargo fix`, update the edition themselves, then fix uses of `repr(C#editionCurr)` in the new edition.
+The machine-applicable fix is provided to allow users to do migrations on their own terms. This way a user can do `cargo fix` to get warning free code. Then choose one of the following
+* fix uses of `repr(C#editionCurr)` at their leisure, then update to new edition
+* update to new edition, then fix uses of `repr(C#editionCurr)` at their leisure
 
+Here's an example of how the lint could look
 ```
 warning: use of `repr(C)` in type `Foo`
   --> src/main.rs:14:10
@@ -165,11 +170,11 @@ warning: use of `repr(C)` in type `Foo`
    = note: `repr(C)` is planned to change meaning in the next edition to match the target platform's layout algorithm. This may change the layout of this type on certain platforms. To keep the current layout, switch to `repr(C#editionNext)` or `repr(ordered_fields)`
 ```
 
-Using `repr(C)` on all editions (including > 2024) when there are no extern blocks or functions in the crate will trigger a allow-by-default lint (`suspicious_repr_c`) suggesting to use `repr(ordered_fields)`.
+Using `repr(C)`/`repr(C#editionCurr)`/`repr(C#editionNext)` on all editions (including in future editions) when there are no extern blocks or functions in the crate will trigger a allow-by-default lint (`suspicious_repr_c`) suggesting to use `repr(ordered_fields)`.
 
-This is allow by default, since the edition lint should do the heavy lifting. This reduces the noise, and provides a tool for interested users to reduce their reliance on `repr(C)` when it is probably not needed.
+This is allow by default, since the edition lint should do the heavy lifting, so it's better to reduces the noise. This is still provided as a tool for interested users to reduce their reliance on `repr(C)` (or it's variants) when it is probably not needed. Since the largest difference between `repr(C)` and `repr(ordered_fields)` is calling convention.
 
-If *any* extern block or function (including `extern "Rust"`) is used in the crate, then the `suspicious_repr_c` lint will not be triggered. This way, we don't have too many false positives for this lint. However, the lint should *not* suggest adding a `extern` block or function, since the problem is likely the `repr`.
+If *any* extern block or function (including `extern "Rust"`) uses the given type in the crate, then the `suspicious_repr_c` lint will not be triggered. This way, we don't have too many false positives for this lint. However, the lint should *not* suggest adding a `extern` block or function, since the problem is likely the `repr`.
 
 This does miss some potential use cases
 1. where a crate provides a suite of FFI-capable types, but does not actually provide any `extern` functions or blocks.
@@ -193,13 +198,13 @@ warning: use of `repr(C)` in type `Foo`
 ```
 
 The idiom lint `repr_c_curr` will trigger on usages of `repr(C#editionCurr)`. This is allow-by-default on current editions and warn by default on new editions.
-On the current edition it will guide people towards `repr(C#editionNext)` or `repr(ordered_fields)`. 
-On future current editions it will guide people towards `repr(C)` or `repr(ordered_fields)`. 
+* On the current edition it will guide people towards `repr(C#editionNext)` or `repr(ordered_fields)`.
+* On future current editions it will guide people towards `repr(C)` or `repr(ordered_fields)`.
 
 The idiom lint `repr_c_next` will trigger on usages of `repr(C#editionNext)`. This is allow-by-default on current editions and deny-by-default/warn-by-default in future editions. This comes with a machine applicable fix to switch to `repr(C)`.
 
 After enough time has passed, and the community has switched over:
-This makes it easier to tell *why* the `repr` was applied to a given struct. If `repr(C)`, it's about FFI and interop. If `repr(ordered_fields)`, then it's for a dependable layout.
+This makes it easier to tell *why* the `repr` was applied to a given struct. If `repr(C)`, it's about FFI and interop. If `repr(ordered_fields)`, then it's for a dependable layout unrelated to FFI.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -212,7 +217,7 @@ See the current Rust reference entry for `repr(C)`: https://doc.rust-lang.org/st
 
 ## `repr(C#editionNext)`
 
-Note: This will be a consistent way to refer to the fixed `repr(C)`. It is intended to only be used for the migration between editions, however it is possible to use this to have an edition-agnostic way to refer to the fixed `repr(C)`. This second use-case is considered, but will not be prioritized.
+Note: This will be a consistent way to refer to the fixed `repr(C)`. It is intended to only be used for the migration between editions. It is possible to use this to have an edition-agnostic way to refer to the fixed `repr(C)`. This second use-case is considered, but will not be prioritized.
 
 > The `C#editionNext` representation is designed for one purpose: creating types that are interoperable with the C Language.
 > 
@@ -220,17 +225,17 @@ Note: This will be a consistent way to refer to the fixed `repr(C)`. It is inten
 > 
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
 
-The exact algorithm is deferred to whatever the default target C compiler does with default settings (or if applicable, the most commonly used settings). `rustc` may grow extra flags to control the behavior of `repr(C)`, in order to match certain flags in the default C compiler, however those will need to be their own proposals. This RFC does not specify any extra control over `repr(C)`.
+The exact algorithm is deferred to whatever the default target `C` compiler does with default settings (or if applicable, the most commonly used settings). `rustc` may grow extra flags to control the behavior of `repr(C)`, in order to match certain flags in the default C compiler, however those will need to be their own proposals. This RFC does not specify any extra control over `repr(C)`.
 
-If any bugs are found (i.e. differences between the target C compiler's layout/ABI and `repr(C)`) then the Rust team reserves the right to change the behavior of `repr(C)` to comply with the target C compiler.
+If any bugs are found (i.e. differences between the target C compiler's layout/ABI and `repr(C)`) then the Rust team reserves the right to change the behavior of `repr(C)` to conform with the target C compiler.
 
 ## `repr(C)`
 
 Note: This preserves the nice name of `repr(C)`, and gives it the intended meaning.
 
 This repr's meaning depends on the edition of the crate:
-* on editions < `editionNext`, this means `repr(C#editionCurr)`
-* on editions >= `editionNext`, this means `repr(C#editionNext)`
+* on current editions this means `repr(C#editionCurr)`
+* on future editions, this means `repr(C#editionNext)`
 
 ## `repr(ordered_fields)` 
 
@@ -288,14 +293,14 @@ union FooUnion {
 
 ### enum
 
-When applying `repr(ordered_fields)` to an enum, the tag type must be specified. i.e. `repr(ordered_fields, u8)` or `repr(ordered_fields, i32)`. If a tag type is not specified, then this results in a hard error, which should suggest the smallest integer type that can hold the discriminant values (preferring signed integers to break ties).
+When applying `repr(ordered_fields)` to an enum, the tag type must be specified. i.e. `repr(ordered_fields, u8)` or `repr(ordered_fields, i32)`. It is a hard error to leave the tag type unspecified. The error should suggest the smallest integer type that can hold the discriminant values.
 
 For discriminants, this means that it will follow the given algorithm for each variant in declaration order of the variants:
 * if a variant has an explicit discriminant value, then that value is assigned
 * else if this is the first variant in declaration order, then the discriminant is zero
 * else the discriminant value is one more than the previous variant's discriminant (in declaration order)
 
-If an enum doesn't have any fields, then it is represented exactly by its discriminant. 
+If an enum doesn't have any fields, then it is represented exactly by its discriminant.
 ```rust
 // tag = i16
 // represented as i16
@@ -339,6 +344,8 @@ enum BarEnum {
 #[repr(ordered_fields)]
 struct BarEnumRepr {
 	tag: BarTag,
+    // note that there may be padding here depending on the enum,
+    // which is why the layout differs from `#[repr(uN)]`/`#[repr(iN)]`
 	data: BarEnumData,
 }
 
@@ -408,8 +415,9 @@ fn get_layout_for_union(field_layouts: &[Layout]) -> Result<Layout, LayoutError>
     Ok(layout.pad_to_align())
 }
 
-/// Takes in the layout of each variant (and their fields) (in declaration order), and returns the layout of the entire enum
-/// the offsets of all fields of the enum are left as an exercise for the readers
+/// Takes in the layout of each variant (and their fields) (in declaration order),
+/// and returns the layout of the entire enum the offsets of all fields of
+/// the enum are left as an exercise for the readers
 /// NOTE: the enum tag is always at offset 0
 fn get_layout_for_enum(
     // the discriminants may be negative for some enums

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -41,13 +41,13 @@ But in some cases, these two roles are in tension due to platform's C layout not
 * On MSVC, a `repr(C, packed)` with `repr(align)` fields has special behavior: the inner `repr(align)` takes priority, so fields can be highly aligned even in a packed struct. (https://github.com/rust-lang/rust/issues/100743)
   (Rust tries to avoid this by forbidding `repr(align)` fields in `repr(packed)` structs, but that check is easily bypassed with generics.)
 * On MSVC-x32, `u64` fields are 8-aligned in structs, but the type is only 4-aligned when allocated on the stack. (https://github.com/rust-lang/rust/issues/112480)
-* On AIX, `f64` fields sometimes but not always get 8-aligned in structs. (https://github.com/rust-lang/rust/issues/151910)
+* On AIX, `f64` fields are sometimes, but not always, get 8-aligned in structs. (https://github.com/rust-lang/rust/issues/151910)
 
 These are all niche cases, but they add up.
 Furthermore, it is just fundamentally wrong for Rust to claim that `repr(C)` layout matches C code for the same target while also specifying an exact algorithm for `repr(C)`:
-the C standard does not prescribe any particular struct layout, so any target/ABI is in principle free to come up with whatever bespoke rules they like.
+the C standard does not prescribe any particular struct layout, so any target/ABI is in principle free to come up with whatever bespoke rules they like. This puts us in a similar position to `std::env::set_var`, where Rust claimed that it was thread-safe, the POSIX standard said it's not, and Rust had to do a breaking change to fix this.
 
-However, fixing this is hard because of (unsafe) code that relies on the other role of `repr(C)`, giving a deterministic layout.
+Fixing this is hard because of (unsafe) code that relies on the other role of `repr(C)`, giving a deterministic layout.
 We therefore cannot just "fix" `repr(C)`, we need some sort of transition plan.
 This code generally falls into one of these buckets:
 * rely on the exact layout being consistent across platforms
@@ -64,20 +64,23 @@ This breakage cannot be checked easily since it affects unsafe code making assum
 
 ### Guiding principle
 
-This RFC will require a large migration across the ecosystem. There are two major use-cases that are prioritized in this document
+This RFC will require a large migration across the ecosystem. There are two major use-cases that are prioritized in this document.
 * FFI-only crates, like `*-sys` crates or crates that expose a `C` interface
-    * these crates should ideally have to do no work. They want the fixed `repr(C)`
+    * These crates should ideally have to do no work. They want the fixed `repr(C)`
 * Pure Rust crates that don't rely on the C calling convention
     * This is for role 2, they typically don't want their layout changing from under them. So switching to `repr(ordered_fields)` will be the correct fix, with one exception: `enum`s with fields. This is likely a very small minority, since using `repr(C)` on an enum with fields is very niche, esp. because it's easy to get UB when using Rust enums with FFI. Also it is already possible to get a platform independent layout for enums, using `repr(u*)` and `repr(i*)`.
 
-There are a number of other use-cases which aren't put on a pedestal like these two. Many of them are detailed near the [end](#migration-examples) of this document.
+There are a number of other use-cases which aren't as highly prioritized like these two. Many of them are detailed near the [end](#migration-examples) of this document.
 
 For these other use-cases, this RFC should make it possible to upgrade to the new edition and get the behavior you want. But it may require more work or it may not look as pretty (after all the bikeshedding for this RFC is done).
+
+This is justified because it is expected that these two major cases will cover the vast majority of cases seen in the wild.
 
 ### Layout issues
 
 Before we delve into the proposed solution, we go into a little more detail about the aforementioned platform layout issues.
 Some of them cannot be solved with this RFC alone, but all of them have require some approach to split up the two roles of `repr(C)`.
+Since this RFC is trying to be the minimal fix to split `repr(C)`, any fix will either depend on this RFC or contain this RFC as part of the fix. Accepting this RFC will provide an incremental upgrade to the situation.
 
 ## MSVC: zero-length arrays
 
@@ -116,7 +119,7 @@ By splitting `repr(ordered_fields)`  off of `repr(C)`, we can allow `repr(C, pac
 
 ## MSVC-x32: u64 alignment
 
-Splitting `repr(C)` also allows making progress on dealing with the MSVC "quirk" [rust-lang/rust/112480](https://github.com/rust-lang/rust/issues/112480).
+Splitting `repr(C)` also allows making progress on dealing with the MSVC "quirk" [rust-lang/rust#112480](https://github.com/rust-lang/rust/issues/112480).
 
 The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the alignment of `u64`/`i64` is reported to be 8 bytes by `alignof` and is correctly aligned in structs. However, when placed on the stack, MSVC doesn't ensure that they are aligned to 8 bytes, and may instead only align them to 4 bytes.
 Our interpretation of this behavior is that `alignof` reports the *preferred* alignment (rather than the required alignment) for the type, and MSVC chooses to sometimes overalign `u64` fields in structs.

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -92,7 +92,7 @@ On Windows MSVC, `repr(C)` doesn't always match what MSVC does for ZST structs (
 struct SomeFFI([i64; 0]);
 ```
 
-Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for case 1. They want it to be size 0 (as it currently is). 
+Of course, making `SomeFFI` size 8 doesn't work for anyone using `repr(C)` for role 1. They want it to be size 0 (as it currently is). 
 
 ## MSVC: `repr(align)` inside `repr(packed)`
 
@@ -138,10 +138,8 @@ struct Floats {
   c: f64, // at offset 12
 }
 ```
-There is no way to obtain such a layout using Rust's `repr(C)` layout algorithm.
+There is no way to obtain such a layout using Rust's `repr(C)` layout algorithm. Currently, `c`is at offset `16`, and the size is `24` bytes. If we simply lower the alignment of `f64` to 4, we'll get the right offsets, but the size will be `20` bytes. So either way, we'll need to adjust the rules for `repr(C)` to get a proper fix.
 For more details, see this discussion on [irlo](https://internals.rust-lang.org/t/repr-c-aix-struct-alignment/21594/3).
-
-Any fix for this requires splitting up `repr(C)`.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -247,7 +247,7 @@ Note: This provides a nice name for a Rust-specific, stable, consistent layout.
 > 
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
 
-### struct
+### `struct`
 
 When applying `repr(ordered_fields)` structs are laid out in memory in declaration order, with padding bytes added as necessary to preserve alignment.
 The alignment of a struct is the same as the alignment of the most aligned field.
@@ -270,7 +270,7 @@ Would be laid out in memory like so
 a...bbbbcc..dddd
 ```
 
-### union
+### `union`
 
 When applying `repr(ordered_fields)`, unions would be laid out as follows:
 * the same alignment as their most aligned field
@@ -291,7 +291,7 @@ union FooUnion {
 
 `FooUnion` has the same layout as `u32`, since `u32` has both the biggest size and alignment.
 
-### enum
+### `enum`
 
 When applying `repr(ordered_fields)` to an enum, the tag type must be specified. i.e. `repr(ordered_fields, u8)` or `repr(ordered_fields, i32)`. It is a hard error to leave the tag type unspecified. The error should suggest the smallest integer type that can hold the discriminant values.
 
@@ -447,6 +447,39 @@ fn get_layout_for_enum(
 }
 ```
 
+### `packed`
+
+When `repr(ordered_fields, packed(N))` is applied to a struct, any field who's type has an alignment > `N` has it's alignment capped to `N`. Even if that type has a `repr(align(M))` attribute applied. Otherwise the rules are the same as described above.
+
+For example, for a struct
+
+```rust
+// size = 64, align = 64
+#[repr(align(64))]
+struct OverAligned(u8);
+
+// size = 64, align = 4
+#[repr(ordered_fields, packed(4))]
+struct X {
+    val: OverAligned
+}
+
+// size = 64, align = 1
+#[repr(ordered_fields, packed)]
+struct Y {
+    val: OverAligned
+}
+```
+
+This behavior is chosen since it is consistent with the handling of naturally over-aligned fields (such as if the field has type `u64`), and since pre-mono errors don't work in the context of generic types. So a behavior has to be chosen for the following type, and the only consistent behavior is the one described above:
+
+```rust
+#[repr(ordered_fields, packed)]
+struct Underalign<T> {
+    val: T,
+}
+```
+
 ## Migration Plan
 
 The migration will be handled as follows:
@@ -569,7 +602,7 @@ See Rationale and Alternatives as well
     * discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2291506953
 * What should `repr(C)` do when a given type wouldn't compile in the corresponding `C` compiler (like fieldless structs in MSVC)? 
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319138105
-* <a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (over-aligned types).
+* ~~<a id="ordered_fields_align"></a>Should `repr(ordered_fields, packed(N))` allow `align(M)` types where `M > N` (over-aligned types).~~ yes
 	* discussion: https://github.com/rust-lang/rfcs/pull/3845#discussion_r2319098177
 	* One option is to allow it and cap those fields to be aligned to `N`. This seems consistent with the handling of other over-aligned types. (i.e. putting a `u32` in a `repr(packed(2))` type)
 * ~~Should unions expose some niches?~~ [no](https://github.com/rust-lang/rfcs/pull/3845#discussion_r3088073911)

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -484,6 +484,12 @@ See Rationale and Alternatives as well
     * `repr(consistent)`
     * `repr(declaration_order)`
     * something else?
+* The name of the new repr `repr(C#editionCurr)` and `repr(C#editionNext)` are bad (intentionally for this RFC), maybe we could pick a better name? This could be done after the RFC is accepted.
+    * `repr(C#edition2024)`/`repr(C#edition2027)`
+    * `repr(e24#C)`/`repr(e27#C)`
+    * `repr(e2024#C)`/`repr(e2027#C)`
+    * ~~`repr(C24)`/`repr(C27)`~~ - likely too confusing to actual C standards
+    * something else?
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -6,12 +6,28 @@
 # Summary
 [summary]: #summary
 
-Introduce a new `repr` (let's call it `repr(ordered_fields)`, but that can be bikeshedded if this RFC is accepted) that can be applied to `struct`, `enum`, and `union` types, which guarantees a simple and predictable layout. Then provide an initial migration plan to switch users from `repr(C)` to `repr(ordered_fields)`. This allows restricting the meaning of `repr(C)` to just serve the FFI use-case.
+Introduce a few new `repr`s (all names can be bikeshedded if this RFC is accepted):
+* `repr(ordered_fields)`
+* `repr(C#editionCurr)`
+* `repr(C#editionNext)`
 
-Introduce two new warnings
-1. An edition migration warning, when updating to the next edition, that the meaning of `repr(C)` is changing
-2. A warn-by-default lint when `repr(ordered_fields)` is used on enums without the tag type specified. Since this is likely not what the user wanted
+And the meaning of `repr(C)` will change in the next edition (presumably `Edition 2027`). All the new reprs can be applied to `struct`, `enum`, and `union` types. 
+
+`repr(ordered_fields)` provides a simple, predicable in memory layout for types. This RFC does *NOT* specify a stable ABI for `repr(ordered_fields)` - that should either be handled by a future RFC or another `repr`.
+Layout-wise, this is the same as `repr(C)` on all current editions where both compile.
+
+`repr(C#editionCurr)` is the same as `repr(C)` on all current editions. This will preserve the same layout and ABI as `repr(C)` on current editions. This repr is mainly targeted for use during the transition time. This way we can do an automated fix for `repr(C)` -> `repr(C#editionCurr)`, and you will know that this was done by an automated fix. If we used `repr(ordered_fields)` for this purpose, then it would be ambiguous if that was intentional or automated.
+
+`repr(C#editionNext)` is the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecewise migration to the new edition while staying on the old edition.
+
+`repr(C)`, this will be defined as the same representation as the platform C compiler, as specified by the target-triple. This `repr` should *only* be used for FFI.
+
+Introduce a few new warnings and errors
+1. A error when `repr(ordered_fields)` is used on enums without the tag type specified.
+2. An edition migration warning, when updating to the next edition, that the meaning of `repr(C)` is changing. This will have an automated fix to `repr(C#editionCurr)`
 3. A warn-by-default lint when `repr(C)` is used, and there are no `extern` blocks or functions in the crate (on all editions)
+4. An idiom lint when `repr(C#editionNext)` is used on the next edition, with an automated fix to `repr(C)`.
+5. An idiom lint when `repr(C#editionCurr)` is used on the next edition. No automated fix is provided, instead the lint should guide users to choose between `repr(C)` or `repr(ordered_fields)`
 
 # Motivation
 [motivation]: #motivation
@@ -117,29 +133,40 @@ Any fix for this requires splitting up `repr(C)`.
 
 `repr(ordered_fields)` is a new representation that can be applied to `struct`, `enum`, and `union` to give them a consistent, cross-platform, and predictable in-memory layout.
 
-`repr(C)` in edition <= 2024 is an alias for `repr(ordered_fields)` and in all other editions, it matches the default C compiler for the given target for structs, unions, and field-less enums. Enums with fields will be laid out as if they are a union of structs with the corresponding fields.
+`repr(C)` in edition <= 2024 is an alias for `repr(ordered_fields)` and in all other editions, it matches the default C compiler for the given target triple for structs, unions, and field-less enums. Enums with fields are laid out as a struct containing a tag and payload. With the payload being a union of structs of all the variants. (This is how they are currently laid out in `repr(C)`)
 
-Using `repr(C)` in editions <= 2024 triggers a lint to use `repr(ordered_fields)` as an edition migration compatibility lint with a machine-applicable fix. If you are using `repr(C)` for FFI, then you may silence this lint. If you are using `repr(C)` for anything else, please switch over to `repr(ordered_fields)` so updating to future editions doesn't change the meaning of your code.
+Using `repr(C)` in editions <= 2024 triggers a lint (seen below) as an edition migration compatibility lint with a machine-applicable fix that switches it to `repr(C#editionCurr)`.
+* If you are using `repr(C)` for FFI, then you should switch to `repr(C#editionNext)`
+* If you are not using `repr(C)` for FFI, then you should switch to `repr(ordered_fields)`
+
+The machine-applicable fix is provided to allow users to do migrations on their own terms. This way a user can do `cargo fix`, update the edition themselves, then fix uses of `repr(C#editionCurr)` in the new edition.
 
 ```
 warning: use of `repr(C)` in type `Foo`
   --> src/main.rs:14:10
    |
 14 |     #[repr(C)]
-   |       ^^^^^^^ help: consider switching to `repr(ordered_fields)`
+   |       ^^^^^^^ help: consider switching to `repr(C#editionNext)` or `repr(ordered_fields)`
    |     struct Foo {
    |
    = note: `#[warn(edition_2024_repr_c)]` on by default
-   = note: `repr(C)` is planned to change meaning in the next edition to match the target platform's layout algorithm. This may change the layout of this type on certain platforms. To keep the current layout, switch to `repr(ordered_fields)`
+   = note: `repr(C)` is planned to change meaning in the next edition to match the target platform's layout algorithm. This may change the layout of this type on certain platforms. To keep the current layout, switch to `repr(C#editionNext)` or `repr(ordered_fields)`
 ```
 
-Using `repr(C)` on all editions (including > 2024) when there are no extern blocks or functions in the crate will trigger a warn-by-default lint suggesting to use `repr(ordered_fields)`. Since the most likely reason to do this is if you haven't heard of `repr(ordered_fields)` or are upgrading to the most recent Rust version (which now contains `repr(ordered_fields)`).
+Using `repr(C)` on all editions (including > 2024) when there are no extern blocks or functions in the crate will trigger a allow-by-default lint (`suspicious_repr_c`) suggesting to use `repr(ordered_fields)`.
 
-If *any* extern block or function (including `extern "Rust"`) is used in the crate, then this lint will not be triggered. This way, we don't have too many false positives for this lint. However, the lint should *not* suggest adding a `extern` block or function, since the problem is likely the `repr`.
+This is allow by default, since the edition lint should do the heavy lifting. This reduces the noise, and provides a tool for interested users to reduce their reliance on `repr(C)` when it is probably not needed.
 
-This does miss one potential use case, where a crate provides a suite of FFI-capable types, but does not actually provide any `extern` functions or blocks. This should be an extremely small minority of crates, and they can silence this warning crate-wide.
+If *any* extern block or function (including `extern "Rust"`) is used in the crate, then the `suspicious_repr_c` lint will not be triggered. This way, we don't have too many false positives for this lint. However, the lint should *not* suggest adding a `extern` block or function, since the problem is likely the `repr`.
 
-The `suspicious_repr_c` lint takes precedence over `edition_2024_repr_c`. It will be triggered whenever there is a `repr(C)` type, but no `extern` blocks/functions in the crate. This is a basic heuristic to reduce noise, since it is unlikely that you want the `C` repr unless you are interacting with `C` or some other language.
+This does miss some potential use cases
+1. where a crate provides a suite of FFI-capable types, but does not actually provide any `extern` functions or blocks.
+2. the crate wants to interact with hardware, and using `repr(C)` is the correct repr
+3. the crate wants is using shared memory with another process, and using `repr(C)` is the correct repr.
+
+Since this is an allow-by-default lint, I think this is fine.
+
+The `suspicious_repr_c` lint takes precedence over `edition_2024_repr_c` (i.e. `edition_2024_repr_c` shouldn't be emitted if `suspicious_repr_c` is emitted).
 
 ```
 warning: use of `repr(C)` in type `Foo`
@@ -150,7 +177,7 @@ warning: use of `repr(C)` in type `Foo`
    |     struct Foo {
    |
    = note: `#[warn(suspicious_repr_c)]` on by default
-   = note: `repr(C)` is intended for FFI, and since there are no `extern` blocks or functions, it's likely that you meant to use `repr(ordered_fields)` to get a stable and consistent layout for your type
+   = note: `repr(C)` is intended for FFI, and since there are no `extern` blocks or functions, it's likely that you meant to use `repr(ordered_fields)` to get a stable and consistent layout for your type.
 ```
 
 After enough time has passed, and the community has switched over:
@@ -159,15 +186,25 @@ This makes it easier to tell *why* the `repr` was applied to a given struct. If 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-## `repr(C)`
+## `repr(C#editionCurr)`
 
-> The `C` representation is designed for one purpose: creating types that are interoperable with the C Language.
+see the current Rust reference entry for `repr(C)`: https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation
+
+## `repr(C#editionNext)`
+
+> The `C#editionNext` representation is designed for one purpose: creating types that are interoperable with the C Language.
 > 
-> This representation can be applied to structs, unions, and enums. The exception is [zero-variant enums](https://doc.rust-lang.org/stable/reference/items/enumerations.html#zero-variant-enums) for which the `C` representation is an error.
+> This representation can be applied to structs, unions, and enums. The exception is [zero-variant enums](https://doc.rust-lang.org/stable/reference/items/enumerations.html#zero-variant-enums) for which the `C#editionNext` representation is an error.
 > 
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
 
-The exact algorithm is deferred to whatever the default target C compiler does with default settings (or if applicable, the most commonly used settings). 
+The exact algorithm is deferred to whatever the default target C compiler does with default settings (or if applicable, the most commonly used settings). `rustc` may grow extra flags to control the behavior of `repr(C)`, in order to match certain flags in the default C compiler, however those will need to be their own proposals. This RFC does not specify any extra control over `repr(C)`.
+
+## `repr(C)`
+
+This repr's meaning depends on the edition of the crate:
+* on editions < `editionNext`, this means `repr(C#editionCurr)`
+* on editions >= `editionNext`, this means `repr(C#editionNext)`
 
 ## `repr(ordered_fields)` 
 
@@ -223,9 +260,7 @@ union FooUnion {
 
 ### enum
 
-When applying `repr(ordered_fields)` to an enum, the enum's tag type and discriminant will be the same as when applying `repr(C)` to the enum in edition <= 2024.
-This does mean that the tag type will be platform-specific. To alleviate this concern, using `repr(ordered_fields)` on an enum without an explicit `repr(uN)`/`repr(iN)` will trigger a warning (name TBD).
-This warning should suggest the smallest integer type that can hold the discriminant values (preferring signed integers to break ties). Since this changes the layout of the type, the warning should mention that the layout will change.
+When applying `repr(ordered_fields)` to an enum, the tag type must be specified. i.e. `repr(ordered_fields, u8)` or `repr(ordered_fields, i32)`. If a tag type is not specified, then this results in a hard error, which should suggest the smallest integer type that can hold the discriminant values (preferring signed integers to break ties).
 
 For discriminants, this means that it will follow the given algorithm for each variant in declaration order of the variants:
 * if a variant has an explicit discriminant value, then that value is assigned
@@ -376,19 +411,21 @@ fn get_layout_for_enum(
 }
 ```
 
-### Migration to `repr(ordered_fields)`
+## Migration Plan
 
 The migration will be handled as follows:
-* after `repr(ordered_fields)` is implemented
-    * add an edition migration lint for `repr(C)`
+* after the reprs outlined in this RFC are implemented
+    * at this point `repr(C)` and `repr(C#editionCurr)` will have identical behavior
+    * add an edition migration lint for `repr(C)` (`edition_2024_repr_c`)
     	* this warning should be advertised publicly (maybe on the Rust Blog?), so that as many people use it. Since even if you are staying on edition <= 2024, it is helpful to switch to `repr(ordered_fields)` to make your intentions clearer
-    * at this point both `repr(ordered_fields)` and `repr(C)` will have identical behavior
-    * the warning will come with a machine-applicable fix
-        * Any crate that does not have FFI can just apply the autofix
-        * Any crate which uses `repr(C)` for FFI can ignore the warning crate-wide
-        * Any crate that mixes both must do extra work to figure out which is which. (This is likely a tiny minority of crates)
-* Once the next edition rolls around (2027?), `repr(C)` on the new edition will *not* warn. Instead, the meaning will have changed to mean *only* compatibility with C. The docs should be adjusted to mention this edition wrinkle.
+    * add the `suspicious_repr_c` lint to help people migrate away from `repr(C)`. 
+* Once the next edition rolls around (2027?)
+    * at this point all of `repr(C)` and `repr(C#editionNext)` will have identical behavior
+    * `repr(C)` on the new edition will *not* warn. Instead, the meaning will have changed to mean *only* compatibility with C. The docs should be adjusted to mention this edition wrinkle.
     * The warning for previous editions will continue to be in effect
+    * The two idiom lints will come into effect to provide an off ramp for `repr(C#editionCurr)` and  `repr(C#editionNext)`
+* Once the following edition rolls around (2030?)
+    * `repr(C#editionCurr)` and `repr(C#editionNext)` are no longer valid. You may only use `repr(ordered_fields)` or `repr(C)`
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -69,7 +69,7 @@ Splitting `repr(C)` also allows making progress on a workaround for the MSVC bug
 
 The issue here is that MSVC is inconsistent about the alignment of `u64`/`i64` (and possibly `f64`). In MSVC, the alignment of `u64`/`i64` is reported to be 8 bytes by `alignof` and is correctly aligned in structs. However, when placed on the stack, MSVC doesn't ensure that they are aligned to 8 bytes, and may instead only align them to 4 bytes.
 
-Any proper workaround will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting what `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way, if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
+Any proper workaround will require reducing the alignment of `u64`/`i64` to 4 bytes, and adjusting `repr(C)` to treat `u64`/`i64`'s alignment as 8 bytes. This way, if you have references/pointers to `u64`/`i64` (for example, as out pointers), then the Rust side will not break when the C side passes a 4-byte aligned pointer (but not 8-byte aligned). This could happen if the C side put the integer on the stack, or was manually allocated at some 4-byte alignment.
 
 For AIX, the issue is that `f64` is treated as aligned to 4 bytes if it is not the first field in a struct. i.e.
 ```C
@@ -84,7 +84,7 @@ Field `b` would be laid out at offset 4, which is under-aligned (since `f64` has
 
 For more details, see this discussion on [irlo](https://internals.rust-lang.org/t/repr-c-aix-struct-alignment/21594/3).
 
-In AIX, the following struct `Floats` has the following field offsets: `[0, 8, 12]` (in bytes) and a size of 24 bytes. Since the first field has a natural alignment of 8 bytes - AKA the size is 8 bytes.
+In AIX, the following struct `Floats` has the following field offsets: `[0, 8, 12]` (in bytes) and a size of 24 bytes. Since the first field has a natural alignment of 8 bytes - AKA its size is 8 bytes.
 
 ```C
 struct Floats {
@@ -186,7 +186,7 @@ Would be laid out in memory like so
 a...bbbbcc..dddd
 ```
 ### union
-When applying `repr(ordered_fields)` to an unions would be laid out as followed:
+When applying `repr(ordered_fields)`, unions would be laid out as follows:
 * the same size as their largest field
 * the same alignment as their most aligned field
 * all fields are at offset 0
@@ -403,6 +403,7 @@ See Rationale and Alternatives as well
     * `repr(linear)`
     * `repr(ordered)`
     * `repr(sequential)`
+    * `repr(serial)`
     * `repr(consistent)`
     * `repr(declaration_order)`
     * something else?

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -57,7 +57,7 @@ This code generally falls into one of these buckets:
 	* But sometimes this is still required if you are manually doing type-erasure and handling DSTs (for example, implementing [`erasable::Erasable`](https://docs.rs/erasable/1.3.0/erasable/trait.Erasable.html))
 * manually calculating the layout for a DST, to prepare an allocation (see [slice-dst](https://crates.io/crates/slice-dst), specifically [here](https://github.com/CAD97/pointer-utils/blob/0fe399f8f7e519959224069360f3900189086683/crates/slice-dst/src/lib.rs#L162-L163))
 * match layouts of two different types (or even, two different monomorphizations of the same generic type)
-	* see [here](https://github.com/rust-lang/rust/pull/68099), where in `alloc` this is done for `Rc` and `Arc` to give a consistent layout for all `T`
+	* see [here](https://github.com/rust-lang/rust/pull/68099), where in `alloc` this is done for `Rc` and `Arc` to give a consistent layout for all `T`. For example, by ensuring that the strong count is at offset `0`, and the weak count at offset `size_of::<usize>()`.
 
 So, providing any fix for role 2 of `repr(C)` would subtly break any users of role 1.
 This breakage cannot be checked easily since it affects unsafe code making assumptions about data layouts, making it difficult to fix within a single edition/existing editions.

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Introduce a few new `repr`s (all names can be bikeshedded if this RFC is accepted):
+Introduce a few new `repr`s (all names are placeholders and can be bikeshedded if this RFC is accepted):
 * `repr(ordered_fields)`
 * `repr(C#editionCurr)`
 * `repr(C#editionNext)`
@@ -18,7 +18,7 @@ Layout-wise, this is the same as `repr(C)` on all current editions where both co
 
 `repr(C#editionCurr)` is the same as `repr(C)` on all current editions. This will preserve the same layout and ABI as `repr(C)` on current editions. This repr is mainly targeted for use during the transition time. This way we can do an automated fix for `repr(C)` -> `repr(C#editionCurr)`, and you will know that this was done by an automated fix. If we used `repr(ordered_fields)` for this purpose, then it would be ambiguous if that was intentional or automated.
 
-`repr(C#editionNext)` is the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecewise migration to the new edition while staying on the old edition.
+`repr(C#editionNext)` is the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecemeal migration to the new edition while staying on the old edition.
 
 `repr(C)`, this will be defined as the same representation as the platform C compiler, as specified by the target-triple. This `repr` should *only* be used for FFI.
 
@@ -166,7 +166,7 @@ This does miss some potential use cases
 
 Since this is an allow-by-default lint, I think this is fine.
 
-The `suspicious_repr_c` lint takes precedence over `edition_2024_repr_c` (i.e. `edition_2024_repr_c` shouldn't be emitted if `suspicious_repr_c` is emitted).
+The `suspicious_repr_c` lint takes precedence over `edition_2024_repr_c` (i.e. `edition_2024_repr_c` shouldn't be emitted if `suspicious_repr_c` is emitted to reduce noise).
 
 ```
 warning: use of `repr(C)` in type `Foo`
@@ -180,23 +180,27 @@ warning: use of `repr(C)` in type `Foo`
    = note: `repr(C)` is intended for FFI, and since there are no `extern` blocks or functions, it's likely that you meant to use `repr(ordered_fields)` to get a stable and consistent layout for your type.
 ```
 
-After enough time has passed, and the community has switched over:
-This makes it easier to tell *why* the `repr` was applied to a given struct. If `repr(C)`, it's about FFI and interop. If `repr(ordered_fields)`, then it's for a dependable layout.
-
 The idiom lint `repr_c_curr` will trigger on usages of `repr(C#editionCurr)`. This is allow-by-default on current editions and warn by default on new editions.
 On the current edition it will guide people towards `repr(C#editionNext)` or `repr(ordered_fields)`. 
 On future current editions it will guide people towards `repr(C)` or `repr(ordered_fields)`. 
 
 The idiom lint `repr_c_next` will trigger on usages of `repr(C#editionNext)`. This is allow-by-default on current editions and deny-by-default/warn-by-default in future editions. This comes with a machine applicable fix to switch to `repr(C)`.
 
+After enough time has passed, and the community has switched over:
+This makes it easier to tell *why* the `repr` was applied to a given struct. If `repr(C)`, it's about FFI and interop. If `repr(ordered_fields)`, then it's for a dependable layout.
+
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
 ## `repr(C#editionCurr)`
 
-see the current Rust reference entry for `repr(C)`: https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation
+Note: This will be identical to `repr(C)` on current editions.
+
+See the current Rust reference entry for `repr(C)`: https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation
 
 ## `repr(C#editionNext)`
+
+Note: This will be a consistent way to refer to the fixed `repr(C)`. It is intended to only be used for the migration between editions, however it is possible to use this to have an edition-agnostic way to refer to the fixed `repr(C)`. This second use-case is considered, but will not be prioritized.
 
 > The `C#editionNext` representation is designed for one purpose: creating types that are interoperable with the C Language.
 > 
@@ -210,11 +214,15 @@ If any bugs are found (i.e. differences between the target C compiler's layout/A
 
 ## `repr(C)`
 
+Note: This preserves the nice name of `repr(C)`, and gives it the intended meaning.
+
 This repr's meaning depends on the edition of the crate:
 * on editions < `editionNext`, this means `repr(C#editionCurr)`
 * on editions >= `editionNext`, this means `repr(C#editionNext)`
 
 ## `repr(ordered_fields)` 
+
+Note: This provides a nice name for a Rust-specific, stable, consistent layout.
 
 > The `ordered_fields` representation is designed for one purpose: to create types that you can soundly perform operations on that rely on data layout, such as reinterpreting values as a different type
 > 
@@ -432,9 +440,6 @@ The migration will be handled as follows:
     * `repr(C)` on the new edition will *not* warn. Instead, the meaning will have changed to mean *only* compatibility with C. The docs should be adjusted to mention this edition wrinkle.
     * The warning for previous editions will continue to be in effect
     * The two idiom lints will come into effect to provide an off ramp for `repr(C#editionCurr)` and  `repr(C#editionNext)`
-* Once the following edition rolls around (2030?)
-    * `repr(C#editionCurr)` and `repr(C#editionNext)` are no longer valid. You may only use `repr(ordered_fields)` or `repr(C)`
-    * unsure about this step, it's not necessary, but it seems nice to prevent usage of a migration step.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -493,6 +498,7 @@ See Rationale and Alternatives as well
     * `repr(serial)`
     * `repr(consistent)`
     * `repr(declaration_order)`
+    * `repr(stable)`
     * something else?
 * The name of the new repr `repr(C#editionCurr)` and `repr(C#editionNext)` are bad (intentionally for this RFC), maybe we could pick a better name? This could be done after the RFC is accepted.
     * `repr(C#edition2024)`/`repr(C#edition2027)`

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -155,6 +155,7 @@ warning: use of `repr(C)` in type `Foo`
 
 After enough time has passed, and the community has switched over:
 This makes it easier to tell *why* the `repr` was applied to a given struct. If `repr(C)`, it's about FFI and interop. If `repr(ordered_fields)`, then it's for a dependable layout.
+
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
@@ -167,6 +168,7 @@ This makes it easier to tell *why* the `repr` was applied to a given struct. If 
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
 
 The exact algorithm is deferred to whatever the default target C compiler does with default settings (or if applicable, the most commonly used settings). 
+
 ## `repr(ordered_fields)` 
 
 > The `ordered_fields` representation is designed for one purpose: to create types that you can soundly perform operations on that rely on data layout, such as reinterpreting values as a different type
@@ -174,7 +176,9 @@ The exact algorithm is deferred to whatever the default target C compiler does w
 > This representation can be applied to structs, unions, and enums.
 > 
 > - edited version of the [reference](https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation) on `repr(C)`
+
 ### struct
+
 When applying `repr(ordered_fields)` structs are laid out in memory in declaration order, with padding bytes added as necessary to preserve alignment.
 The alignment of a struct is the same as the alignment of the most aligned field.
 
@@ -195,7 +199,9 @@ Would be laid out in memory like so
 ```
 a...bbbbcc..dddd
 ```
+
 ### union
+
 When applying `repr(ordered_fields)`, unions would be laid out as follows:
 * the same alignment as their most aligned field
 * the same size as their largest field, rounded up to the next multiple of the union's alignment
@@ -214,7 +220,9 @@ union FooUnion {
 ```
 
 `FooUnion` has the same layout as `u32`, since `u32` has both the biggest size and alignment.
+
 ### enum
+
 When applying `repr(ordered_fields)` to an enum, the enum's tag type and discriminant will be the same as when applying `repr(C)` to the enum in edition <= 2024.
 This does mean that the tag type will be platform-specific. To alleviate this concern, using `repr(ordered_fields)` on an enum without an explicit `repr(uN)`/`repr(iN)` will trigger a warning (name TBD).
 This warning should suggest the smallest integer type that can hold the discriminant values (preferring signed integers to break ties).
@@ -364,6 +372,7 @@ fn get_layout_for_enum(
     Ok(layout)
 }
 ```
+
 ### Migration to `repr(ordered_fields)`
 
 The migration will be handled as follows:
@@ -396,6 +405,7 @@ The migration will be handled as follows:
     * This one is currently stuck due to a larger scope than this RFC
 * do nothing
     * We keep getting bug reports on Windows (and other platforms), where `repr(C)` doesn't actually match the target C compiler, or we break a bunch of subtle unsafe code to match the target C compiler.
+
 # Prior art
 [prior-art]: #prior-art
 
@@ -433,6 +443,7 @@ See Rationale and Alternatives as well
     * `repr(consistent)`
     * `repr(declaration_order)`
     * something else?
+
 # Future possibilities
 [future-possibilities]: #future-possibilities
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -11,14 +11,14 @@ Introduce a few new `repr`s (all names are placeholders and can be bikeshedded i
 * `repr(C#editionCurr)`
 * `repr(C#editionNext)`
 
-And the meaning of `repr(C)` will change in the next edition (presumably `Edition 2027`). All the new reprs can be applied to `struct`, `enum`, and `union` types. 
+The meaning of `repr(C)` will change from `C#editionCurr` in the current edition to `C#editionNext`  in the next edition (presumably `Edition 2027`). All the new reprs can be applied to `struct`, `enum`, and `union` types. 
 
-`repr(ordered_fields)`: provides a simple, predicable in memory layout for types. This RFC does *NOT* specify a stable ABI for `repr(ordered_fields)` - that should either be handled by a future RFC or another `repr`.
+`repr(ordered_fields)`: provides a simple, predicable in-memory layout for types. This RFC does *NOT* specify a stable ABI for `repr(ordered_fields)` - that should either be handled by a future RFC or another `repr`.
 Layout-wise, this is the same as `repr(C)` on all current editions where both compile.
 
 `repr(C#editionCurr)`: the same as `repr(C)` on all current editions. This will preserve the same layout and ABI as `repr(C)` on current editions. This repr is mainly targeted for use during the transition time. This way we can do an automated fix for `repr(C)` -> `repr(C#editionCurr)`, and you will know that this was done by an automated fix. If we used `repr(ordered_fields)` for this purpose, then it would be ambiguous if that was intentional or automated.
 
-`repr(C#editionNext)`: the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecemeal migration to the new edition while staying on the old edition. This `repr` should *only* be used for FFI.
+`repr(C#editionNext)`: the same as `repr(C)` on the next edition. This repr is mainly targeted for use during the transition time. This `repr` should *only* be used for FFI. This serves the dual purpose of `repr(C#editionCurr)`, it allows piecemeal migration to the new edition while staying on the old edition.
 
 `repr(C)`: On current editions the meaning will not change. On future editions this will be defined as the same representation as the platform C compiler, as specified by the target-triple. In future editions, this `repr` should *only* be used for FFI.
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -173,7 +173,7 @@ warning: use of `repr(C)` in type `Foo`
 
 Using `repr(C)`/`repr(C#editionCurr)`/`repr(C#editionNext)` on all editions (including in future editions) when there are no extern blocks or functions in the crate will trigger a allow-by-default lint (`suspicious_repr_c`) suggesting to use `repr(ordered_fields)`.
 
-This is allow by default to reduce noise, since the edition lint should do the heavy lifting. This is still provided as a tool for interested users to reduce their reliance on `repr(C)` (or it's variants) when it is probably not needed. Since the largest difference between `repr(C)` and `repr(ordered_fields)` is calling convention.
+This is allow by default to reduce noise, since the edition lint should do the heavy lifting. This is still provided as a tool for interested users to reduce their reliance on `repr(C)` (or its variants) when it is probably not needed. Since the largest difference between `repr(C)` and `repr(ordered_fields)` is calling convention.
 
 If *any* extern block or function (including `extern "Rust"`) uses the given type in the crate, then the `suspicious_repr_c` lint will not be triggered. This way, we don't have too many false positives for this lint. However, the lint should *not* suggest adding a `extern` block or function, since the problem is likely the `repr`.
 
@@ -450,7 +450,7 @@ fn get_layout_for_enum(
 
 ### `packed`
 
-When `repr(ordered_fields, packed(N))` is applied to a struct, any field who's type has an alignment > `N` has its alignment capped to `N`. This applies even if that type has a `repr(align(M))` attribute applied. Otherwise, the rules are the same as described above.
+When `repr(ordered_fields, packed(N))` is applied to a struct, any field with a type of alignment > `N` has its alignment capped to `N`. This applies even if that type has a `repr(align(M))` attribute applied. Otherwise, the rules are the same as described above.
 
 For example, for a struct
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -37,7 +37,7 @@ Currently `repr(C)` serves two roles:
 2. Match the target C compiler's struct/union layout algorithm and ABI
 
 But in some cases, these two roles are in tension due to platform's C layout not matching the [simple, general algorithm](https://doc.rust-lang.org/stable/reference/type-layout.html#r-layout.repr.c.struct.size-field-offset) Rust always uses:
-* On MSVC, a struct with a single field that is a zero-sized array has size 1. (https://github.com/rust-lang/rust/issues/81996)
+* On MSVC, a struct with a single field that is a zero-sized array has non-zero size. (https://github.com/rust-lang/rust/issues/81996)
 * On MSVC, a `repr(C, packed)` with `repr(align)` fields has special behavior: the inner `repr(align)` takes priority, so fields can be highly aligned even in a packed struct. (https://github.com/rust-lang/rust/issues/100743)
   (Rust tries to avoid this by forbidding `repr(align)` fields in `repr(packed)` structs, but that check is easily bypassed with generics.)
 * On MSVC-x32, `u64` fields are 8-aligned in structs, but the type is only 4-aligned when allocated on the stack. (https://github.com/rust-lang/rust/issues/112480)

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -326,7 +326,7 @@ enum FooEnumUnsigned {
 
 Enums with fields will be laid out as if they were a struct containing the tag and a union of structs containing the data.
 NOTE: This is different from `repr(iN)`/`repr(uN)` which are laid out as a union of structs, where the first field of the struct is the tag.
-These two layouts are *NOT* compatible, and adding `repr(ordered_fields)` to `repr(iN)`/`repr(uN)` changes the layout of the enum!
+These two layouts are *NOT* compatible, and adding `repr(ordered_fields)` to `repr(iN)`/`repr(uN)` changes the layout of the enum! This may be surprising, but it matches precedent -- adding `repr(C)` to `repr(iN)`/`repr(uN)` has a similar effect.
 
 For example, this would be laid out the same as the union below
 ```rust
@@ -450,7 +450,7 @@ fn get_layout_for_enum(
 
 ### `packed`
 
-When `repr(ordered_fields, packed(N))` is applied to a struct, any field who's type has an alignment > `N` has it's alignment capped to `N`. Even if that type has a `repr(align(M))` attribute applied. Otherwise the rules are the same as described above.
+When `repr(ordered_fields, packed(N))` is applied to a struct, any field who's type has an alignment > `N` has its alignment capped to `N`. This applies even if that type has a `repr(align(M))` attribute applied. Otherwise, the rules are the same as described above.
 
 For example, for a struct
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -146,9 +146,17 @@ For more details, see this discussion on [irlo](https://internals.rust-lang.org/
 
 `repr(ordered_fields)` is a new representation that can be applied to `struct`, `enum`, and `union` to give them a consistent, cross-platform, and predictable in-memory layout.
 
-`repr(C)` in current editions is an alias for `repr(C#editionCurr)` and in all other editions, it matches the default C compiler for the given target triple for structs, unions, and field-less enums. Enums with fields are laid out as a struct containing a tag and payload. With the payload being a union of structs of all the variants. This is how they are currently laid out in `repr(C)`. The calling convention of `repr(C)` will also remain the same and all current editions.
+`repr(C#editionCurr)` is the same as `repr(C)` on current editions. It lays out
+* `struct` fields in order, while ensuring that they are well aligned
+* `union` fields at offset 0
+* field-less `enum`s as an implementation defined integer
+* general `enum`s as a struct of a tag and a union. Where each field of the union is a struct containing each field of the variants. (NOTE: this is how they are handled in `repr(C)` in current editions)
 
-`repr(C)` in future editions is an alias for `repr(C#editionNext)`. It will lay out types in the same way as `C` would, and will use the same calling convention as `C`.
+`repr(C#editionNext)` will be defined as the same as what the `C` compiler of the given target would do (both in terms of layout and calling convention).
+
+`repr(C)` has an edition specific definition
+* on current editions, it matches `repr(C#editionCurr)`
+* on future editions, it matches `repr(C#editionNext)`
 
 Using `repr(C)` in all current editions triggers a lint (seen below) as an edition migration compatibility lint with a machine-applicable fix that switches it to `repr(C#editionCurr)`.
 * If you are using `repr(C)` for FFI, then you should switch to `repr(C#editionNext)` or upgrade to the new edition

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -173,7 +173,7 @@ warning: use of `repr(C)` in type `Foo`
 
 Using `repr(C)`/`repr(C#editionCurr)`/`repr(C#editionNext)` on all editions (including in future editions) when there are no extern blocks or functions in the crate will trigger a allow-by-default lint (`suspicious_repr_c`) suggesting to use `repr(ordered_fields)`.
 
-This is allow by default to reduce noise, since the edition lint should do the heavy lifting. This is still provided as a tool for interested users to reduce their reliance on `repr(C)` (or its variants) when it is probably not needed. Since the largest difference between `repr(C)` and `repr(ordered_fields)` is calling convention.
+This is allow by default to reduce noise, since the edition lint should do the heavy lifting. This is still provided as a tool for interested users to reduce their reliance on `repr(C)` (or its variants) when it is probably not needed. The only improvement that `repr(C)` provides over `repr(ordered_fields)` is by having a stable calling convention. So when that's taking out of the picture it is usually better to select `repr(ordered_fields)`, which provides better cross-platform guarantees than `repr(C)`.
 
 If *any* extern block or function (including `extern "Rust"`) uses the given type in the crate, then the `suspicious_repr_c` lint will not be triggered. This way, we don't have too many false positives for this lint. However, the lint should *not* suggest adding a `extern` block or function, since the problem is likely the `repr`.
 

--- a/text/3845-repr-ordered-fields.md
+++ b/text/3845-repr-ordered-fields.md
@@ -238,6 +238,88 @@ The exact algorithm is deferred to whatever the default target `C` compiler does
 
 If any bugs are found (i.e. differences between the target C compiler's layout/ABI and `repr(C)`) then the Rust team reserves the right to change the behavior of `repr(C)` to conform with the target C compiler.
 
+### Flexible Array Members
+
+Given that all major `C` compilers (at the time of writing) put `T field[N];` and `T field[];` at the same offset. `repr(C#editionNext)` will make a guarantee for the last field of a `repr(C#editionNext)` struct.
+* If the only difference between two `repr(C#editionNext)` structs is the type of their last field
+* If the fields' types are `[T]` or `[T; N]`
+* Then the exact offset will also be the same as the equivalent `C` type that has the field type as a flexible array member, i.e. `T field[];`
+* Then the exact offset will also be the same as the equivalent `C` type that has the field type as an array member, i.e. `T field[N];` (of any `N`)
+* Then the offset of that field only depends on `T` (and cannot depend on the length of the array/slice)
+
+If a generic `repr(C#editionNext)` type has an generic unsized final field (see `Coercable<T>`  below), then the obvious unsizing coercion from `Coercable<[T; N]>` to `Coercable<[T]>` is allowed. i.e. `Coercable<[T; N]>: Unsize<Coercable<[T]>>`.
+
+```rust
+#[repr(C#editionNext)]
+struct Coercable<T: ?Sized> {
+    len: usize,
+    data: T,
+}
+```
+
+This means that the following four types have `data_array` and `data_slice` at the same offset.
+
+```rust
+// in Rust
+#[repr(C#editionNext)]
+struct DataWithArray {
+    header: i32,
+    len: usize,
+    data_array: [T; N],
+}
+
+#[repr(C#editionNext)]
+struct DataWithSlice {
+    header: i32,
+    len: usize,
+    data_slice: [T],
+}
+```
+
+```C
+// in C
+struct DataWithArray {
+    int32_t header;
+    uintptr_t len;
+    T data_array[N];
+};
+
+struct DataWithSlice {
+    int32_t header;
+    uintptr_t len;
+    T data_slice[N];
+};
+```
+
+If there exists a target where the `C` compiler doesn't put `T field[N];` and `T field[];` at the same offset, then these rules may be revised on those targets. Currently, allow known `C` compiler put array members and flexible array members at the same offset.
+
+### Trait objects
+
+If field of a `repr(C#editionNext)` has the type of a trait object, then the layout of the type is unspecified. If this came from a generic instantiation, then coercions form a concrete type to the trait object are disabled. For example
+* you could not derive `Coercable<i32>: Unsize<Coercable<dyn Debug>>`
+* you could not cast from `*const Coercable<i32>` to `*const Coercable<dyn Debug>`
+* the layout of `Coercable<dyn Debug>` is unspecified
+
+```rust
+#[repr(C#editionNext)]
+struct Coercable<T: ?Sized> {
+    len: usize,
+    data: T,
+}
+```
+
+If the type of a field is always a trait object, then a hard error is reported.
+
+```rust
+#[repr(C#editionNext)]
+struct BadReprC {
+    len: usize,
+    data: dyn Debug, // ERROR: `repr(C#editionNext)` types cannot contain trait objects
+}
+```
+
+Note: the layout is unspecified to avoid adding a new post-mono error. By making the coercion impossible, it becomes impossible to safely construct a valid pointer to a `*const Coercable<dyn Debug>`. When using `feature(ptr_metadata)`, it may be possible to construct a pointer to `*const Coercable<dyn Debug>` using `core::ptr::from_raw_parts`, but it is not safe to use.
+
 ## `repr(C)`
 
 Note: This preserves the nice name of `repr(C)`, and gives it the intended meaning.
@@ -605,6 +687,7 @@ See Rationale and Alternatives as well
 * ~~Should this `repr` be versioned?~~
     * This way we can evolve the repr (for example, by adding new niches)
     * no need to for now, this can be done as a future proposal
+* Should a generic `repr(C#editionNext)` struct instantiated with a trait object as it's trailing field be a post-mono error?
 * Should we change the meaning of `repr(C)` in editions <= 2024 after we have reached edition 2033 or some other later edition? Yes, it's a breaking change. But at that point, it will likely only be breaking code no one uses.
     * Leaning towards no
 * ~~Is the ABI of `repr(ordered_fields)` specified (making it safe for FFI)? Or not?~~ Not in this RFC


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3845)*

Add `repr(ordered_fields)` and provide a migration path to switch users from `repr(C)` to `repr(ordered_fields)`, then change the meaning of `repr(C)` in the next edition.

This RFC is meant to be an MVP, and any extensions (for example, adding more `repr`s) are not in scope. This is done to make it as easy as possible to accept this RFC and make progress on the issue of `repr(C)` serving two opposing roles.

[Rendered](https://github.com/RustyYato/rfcs/blob/repr_ordered_fields/text/3845-repr-ordered-fields.md)

To avoid endless bikeshedding, I'll make a poll if this RFC is accepted with all the potential names for the new `repr`. If you have a new name, I'll add it to the list of names in the unresolved questions section, and will include it in the poll.