### PR TITLE
update a broken/malicious documentation link to point to docs.rs

### DIFF
--- a/text/0390-enum-namespacing.md
+++ b/text/0390-enum-namespacing.md
@@ -161,7 +161,7 @@ pub trait MyTrait { ... }
 This strategy does not work for flat enums in general. It is not all that
 uncommon for an enum to have *many* variants - for example, take
 [`rust-postgres`'s `SqlState`
-enum](http://www.rust-ci.org/sfackler/rust-postgres/doc/postgres/error/enum.PostgresSqlState.html),
+enum](https://docs.rs/postgres/0.8.9/postgres/enum.SqlState.html),
 which contains 232 variants. It would be ridiculous to `pub use` all of them!
 With namespaced enums, this kind of reexport becomes a simple `pub use` of the
 enum itself.


### PR DESCRIPTION
Hi! I was reading [0390-enum-namespacing.md](https://github.com/rust-lang/rfcs/blob/b6d0de380d85d96eba68fb6accf34d6c5fb3bd7f/text/0390-enum-namespacing.md) on my Android phone when I accidentally tapped the link to `http://www.rust-ci.org`. Unfortunately, it redirected me to a malicious website, so I believe this link should be removed.

At first, I considered replacing it with a link to the corresponding page on docs.rs. However, the latest version of the `postgres` crate no longer includes this enum[^1], and the documentation for older versions is unavailable due to build failures [(example)](https://docs.rs/crate/postgres/0.1.0).

[^1]: `SqlState` is now a struct in the current API [(link)](https://docs.rs/postgres/0.19.10/postgres/error/struct.SqlState.html).

[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/0390-enum-namespacing.md)