### PR TITLE
RFC: `#[cfg(version_since(rust, "1.95"))]` for Rust-version conditional compilation

### DIFF
--- a/text/3857-cfg-version.md
+++ b/text/3857-cfg-version.md
@@ -798,7 +798,15 @@ Accessible
 ## Other
 
 Swift:
-- Similar syntax, an attribute [`@available`](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes#available) with name/value pairs. Examples: `@available(swift 3.0.2)`, `@available(iOS 10.0, macOS 10.12)`.
+- A [`swift(_)` and `compiler(_)` platform condition](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/statements/#Conditional-Compilation-Block) for use with `#if`
+  - `compiler` is for current compiler version while `swift` is the language version mode set on the compiler
+  - Supports `>=` and `<` operators
+  - No whitespace
+  - Takes a bare word version, major is required but unlimited precision after
+  - Examples
+    - `#if compiler(>=5)`
+    - `#if swift(>=4.2)`
+    - `#if compiler(>=5) && swift(<5)`
 
 Python
 - Programmatic version: [`sys.version_info`](https://docs.python.org/3/library/sys.html#sys.version_info)


### PR DESCRIPTION
[Tracking issue (`#[cfg(version(..))]`](https://github.com/rust-lang/rust/issues/64796)

[Rendered](https://github.com/rust-lang/rfcs/blob/4551bbd827eb84fc6673ac0204506321274ea839/text/3857-cfg-version.md)

## Summary

Allow Rust-version conditional compilation by adding a built-in `--cfg rust=<version>` and a minimum-version `#[cfg]` predicate.

Say this was added before 1.70, you could do:
```toml
[target.'cfg(not(version_since(rust, "1.70")))'.dependencies"]
is-terminal = "0.4.16"
```

```rust
fn is_stderr_terminal() -> bool {
    #[cfg(version_since(rust, "1.70"))]
    use std::io::IsTerminal as _;
    #[cfg(not(version_since(rust, "1.70")))]
    use is_terminal::IsTerminal as _;

    std::io::stderr().is_terminal()
}
```

This supersedes the `cfg_version` subset of [RFC 2523](https://rust-lang.github.io/rfcs/2523-cfg-path-version.html).