### PR TITLE
Add automatic assignment to the internal-sites team

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -10,6 +10,17 @@ trigger-files = ["text/"]
 
 [assign]
 
+[assign.owners]
+"/.github/"           = ["internal-sites"]
+"/.gitattributes"     = ["internal-sites"]
+"/.gitignore"         = ["internal-sites"]
+"/book.toml"          = ["internal-sites"]
+"/generate-book.py"   = ["internal-sites"]
+"/LICENSE-APACHE"     = ["internal-sites"]
+"/LICENSE-MIT"        = ["internal-sites"]
+"/README.md"          = ["internal-sites"]
+"/triagebot.toml"     = ["internal-sites"]
+
 [shortcut]
 
 [range-diff]


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rfcs/pull/3865#issuecomment-3360018912, let's add us as the reviewer team for "not-rfc" changes in this repo.

r? @jieyouxu 