### PR TITLE
mention ACPs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ following.
   - Removing language features, including those that are feature-gated.
   - Changes to the interface between the compiler and libraries, including lang
     items and intrinsics.
-  - Additions to `std`.
+  - Large additions to `std`.
 
 Some changes do not require an RFC:
 
@@ -55,6 +55,7 @@ Some changes do not require an RFC:
     more errors, etc.)
   - Additions only likely to be _noticed by_ other developers-of-rust,
     invisible to users-of-rust.
+  - Minor additions to `std`: these only require an [ACP](https://std-dev-guide.rust-lang.org/development/feature-lifecycle.html).
 
 If you submit a pull request to implement a new feature without going through
 the RFC process, it may be closed with a polite request to submit an RFC first.


### PR DESCRIPTION
Users frequently open RFCs for adding new methods to `std` that are subsequently closed with a note to open an ACP instead (examples: #3870, #3835, #3827, ...).
However, ACPs were not mentioned in the README at all until now.
@rustbot label not-rfc