### PR TITLE
build-std: context

### DIFF
--- a/text/3873-build-std-context.md
+++ b/text/3873-build-std-context.md
@@ -1,7 +1,7 @@
 - Feature Name: `build-std-context`
 - Start Date: 2025-06-05
 - RFC PR: [rust-lang/rfcs#3873](https://github.com/rust-lang/rfcs/pull/3873)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- Rust Issue: N/A
 
 ## Summary
 [summary]: #summary


### PR DESCRIPTION
While Rust's pre-built standard library has proven itself sufficient for the majority of use cases, there are a handful of use cases that are not well supported:

1. Rebuilding the standard library to match the user's profile
2. Rebuilding the standard library with ABI-modifying flags
3. Building the standard library for tier three targets

Proposals to solve these problems come broadly under the umbrella of "build-std" and date back over 10 years ago, though no complete solution has yet reached consensus.

**This RFC does not propose any changes directly, only document the background, history and motivations for build-std. It is part of a series of build-std RFCs and later RFCs will reference this one.** This RFC is part of the [build-std project goal](https://rust-lang.github.io/rust-project-goals/2025h2/build-std.html).

1. build-std context (this RFC)
2. `build-std="always"` (rust-lang/rfcs#3874)
3. Explicit standard library dependencies (rust-lang/rfcs#3875)
4. `build-std="compatible"` (RFC not opened yet)
5. `build-std="match-profile"` (RFC not opened yet)

There is also [a Zulip channel where you can ask questions about any of the build-std RFCs](https://rust-lang.zulipchat.com/#narrow/channel/516120-project-goals.2F2025h1.2Fbuild-std). This series of RFCs was drafted over many months with the help of stakeholders from many Rust project teams, we thank them for their help!

[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/3873-build-std-context.md)