### PR TITLE
Add mdbook-extra-watch-dirs

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -12,3 +12,6 @@ heading-split-level = 0
 
 [output.html.playground]
 runnable = false
+
+[build]
+extra-watch-dirs = ["text"]


### PR DESCRIPTION
This helps when using `mdbook serve` so that mdbook will automatically reload whenever a file changes.

This doesn't handle adding new files because that requires running `generate-book.py`, but that should be fine.

r? internal-sites