### PR TITLE
RFC: Introduce `DerefInto` and `DerefMutInto` for RAII access

### DIFF
--- a/text/3880-deref_into.md
+++ b/text/3880-deref_into.md
@@ -1,7 +1,7 @@
 - Feature Name: `deref_into`
 - Start Date: 2025-11-10
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- RFC PR: [rust-lang/rfcs#3880](https://github.com/rust-lang/rfcs/pull/3880)
+- Rust Issue: [rust-lang/rust#3880](https://github.com/rust-lang/rust/issues/3880)
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
This RFC introduce `DerefInto` and `DerefMutInto`, supertraits of [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) / [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html) that return targets by value, enabling ergonomic RAII access for types like RefCell, Mutex, and RwLock.

[Rendered](https://github.com/rust-lang/rfcs/blob/8276a3ccb497cc58ba83e1d751d20559dd159499/text/3880-deref_into.md)