### PR TITLE
RFC: Exhaustive traits. Traits that enable cross trait casting between trait objects.

### DIFF
--- a/text/3885-exhaustive-traits.md
+++ b/text/3885-exhaustive-traits.md
@@ -162,8 +162,8 @@ We would have compiler intrinsics that would enable us to get the VTable for a t
 ```rust
 use core::ptr;
 
-// Auto implemented by traits that are exhaustive. Cannot be manually implemented.
-pub trait Exhaustive: 'static {}
+// Auto implemented by 'dyn Trait' types that are exhaustive. Cannot be manually implemented.
+pub trait Exhaustive {}
 
 #[rustc_intrinsic]
 pub const unsafe fn exhaustive_vtable_of<


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3885)*

This RFC proposes #[exhaustive] traits to enable sound cross-trait casting for trait objects. 

For any concrete type T, the set of #[exhaustive] traits it implements is finite and deterministic, allowing runtime checks like “if this dyn A also implements dyn B, cast and use it.” 

The design adds a per-type exhaustive trait→vtable map and enforces four rules (type-crate ownership of implementation, trait arguments determined by Self, object safe, and 'static only) to keep the mapping coherent under separate compilation. 

Use cases include capability-based game entities (e.g., Damageable, Walkable traits) and GUI widgets (e.g., Clickable, Scrollable), 
 avoiding manual registry/macro approaches such as bevy_reflect. 

 This enables patterns such as: "if dyn Character is dyn Flyable, then character.fly()"

[Rendered](https://github.com/izagawd/exhaustive_traits/blob/exhaustive_traits/text/3885-exhaustive-traits.md)