### PR TITLE
Removed incorrect sentence about the procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ following.
 
   - Any semantic or syntactic change to the language that is not a bugfix.
   - Removing language features, including those that are feature-gated.
-  - Changes to the interface between the compiler and libraries, including lang
-    items and intrinsics.
   - Large additions to `std`.
 
 Some changes do not require an RFC:


### PR DESCRIPTION
This is not true today at all.

What *may* need an RFC is adding a new capability that doesn't exist today, like uninit `freeze`, but those things are very rare so I think it doesn't make sense to put it here.