### PR TITLE
Change 3872 section headers to 2nd level Markdown

### DIFF
--- a/text/3872-crates-io-security.md
+++ b/text/3872-crates-io-security.md
@@ -1,7 +1,7 @@
 - Feature Name: crates-io-security
 - Start Date: 2025-10-27
 - RFC PR: [rust-lang/rfcs#3872](https://github.com/rust-lang/rfcs/pull/3872)
-- Rust Issue: [rust-lang/rust#3872](https://github.com/rust-lang/rust/issues/3872)
+- Rust Issue: [rust-lang/crates.io#12507](https://github.com/rust-lang/crates.io/issues/12507)
 
 ## Summary
 


### PR DESCRIPTION
Updated section headers to use Markdown 2nd level headings. As part of https://github.com/rust-lang/rfcs/pull/3883 we switched the template to not use level-1 headings.

r? Turbo87


[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/3872-crates-io-security.md)