### PR TITLE
RFC: obj-action style method disambiguation 

### DIFF
--- a/text/3908-obj-action-method-disambiguation.md
+++ b/text/3908-obj-action-method-disambiguation.md
@@ -230,7 +230,7 @@ The `MethodCallExpr` grammar is extended in two specific ways:
 ## Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-*   **Syntax Choice**: Should we consider other bracket types to avoid confusion with tuple grouping? (e.g., `obj.<Trait::method>()` or `obj.[Trait::method]()` or)?
+*   **Syntax Choice**: Should we consider other bracket types to avoid confusion with tuple grouping? (e.g., `obj.<Trait::method>()` or `obj.[Trait::method]()`)?
 
 ## Future possibilities
 [future-possibilities]: #future-possibilities


### PR DESCRIPTION
I'll say upfront that I'm a Rust beginner, but the issue I'm discussing is exactly the kind of thing that experienced developers tend to avoid altogether. I suspect the reason it still exists in the language isn't that people don't know how to solve it, but simply that it doesn't occur frequently enough to annoy someone sufficiently to push for a language-level change. For me, as someone who's just learning the language, this problem has been nagging at me, and I feel I've spent enough time thinking it through and discussing it on the forum to arrive at a logical and straightforward solution.

My RFC proposes what I believe is the most intuitive and readable syntax for disambiguating method names that I can imagine. I think even without reading the full text, it's immediately clear what `obj.Self::method(args)`, `obj.Category::method(args)`, and `obj.(Library::Trait::method)(args)` do. You can even guess why the parentheses are required around `Library::Trait::method` but not around `obj.Self::method`.

I used an LLM to help turn the idea into a proper RFC, and now I have the persistent feeling that the list of edits I want to make isn't getting any shorter. It's hard to say I'd have done a better job myself, given my English proficiency and the fact that when you've been nursing an idea for long enough, no retelling — not even your own — ever feels complete. So it's possible I'm just overthinking it and can no longer distinguish real logical or presentation issues from a mere sense of incompleteness.

I'm really looking forward to your feedback so I can focus my revisions on what actually matters — things that are unclear to someone who isn't the author of RFC, or issues I've simply overlooked.

[Rendered](https://github.com/rust-lang/rfcs/blob/08670256b04bc8eebaf1c2b9b1aab8703b4fa69e/text/3908-obj-action-method-disambiguation.md)