### PR TITLE
fix: Correct minor grammar flaw

### DIFF
--- a/text/1236-stabilize-catch-panic.md
+++ b/text/1236-stabilize-catch-panic.md
@@ -92,10 +92,10 @@ example:
 
 With all that in mind, we've now identified problems that can arise via
 exceptions (an invariant is broken and then observed) as well as methods to
-ensure that prevent this from happening. In languages like C++ this means that
-we can be memory safe in the face of exceptions and in languages like Java we
-can ensure that our logical invariants are upheld. Given this background let's
-take a look at how any of this applies to Rust.
+ensure we prevent this from happening. In languages like C++ this means that we
+can be memory safe in the face of exceptions and in languages like Java we can
+ensure that our logical invariants are upheld. Given this background let's take
+a look at how any of this applies to Rust.
 
 ## Background: What is exception safety in Rust?
 


### PR DESCRIPTION
Correct minor typo / grammar flaw in the flow of text in one section.

[Rendered](https://github.com/rust-lang/rfcs/blob/90a5e73c1a606e41ac66e8d9ab77b3a141a7f213/text/1236-stabilize-catch-panic.md)