### PR TITLE
Cargo RFC for min publish age

### DIFF
--- a/text/0000-cargo-min-publish-age.md
+++ b/text/0000-cargo-min-publish-age.md
@@ -1,0 +1,327 @@
+- Feature Name: cargo_min_publish_age
+- Start Date: 2026-01-21
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+## Summary
+[summary]: #summary
+
+This proposal adds a new configuration option to cargo that specifies a minimum age for package
+updates. When adding or updating a dependency, cargo won't use a version of that crate that
+is newer than the minimum age, unless no possible version is older.
+
+## Motivation
+[motivation]: #motivation
+
+There are a couple of reasons why one may wish not to use the most recent version of a package.
+
+One such reason is to mitigate the risk of [supply chain attacks](https://en.wikipedia.org/wiki/Supply_chain_attack). Often, supply chain
+attacks are found fairly quickly after they are deployed. Thus, if the dependency isn't updated
+immediately after a release, you can have some protection against a new release of a dependency
+containing malicious code. In light of recent supply chain attacks on the NPM ecosystem,
+there has been an increased interest in using automated tools to ensure that packages used
+are older than some age. This creates a window of time between when a dependency is compromised
+and when that release is used by your project. See for example the blog post
+"[We should all be using dependency cooldowns](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns)".
+
+Another reason to wish to delay using a new release, is because new versions can introduce new bugs. By only
+using versions that have had some time to "mature", you can mitigate the risk of encountering those bugs a little.
+Hopefully the bugs will be found before you start using the new version and thus could update to a version that fixes those bugs,
+or lock your version, so you don't get the buggy version, if the bugs apply to you.
+
+Although cargo, of course, allows you to specify exact versions in `Cargo.toml` and has a lock file that can freeze the versions used,
+that requires manually inspecting each version of each transitive dependency to confirm it complies with a policy of
+using a version older than some age.
+
+As such, it would be useful to have an option to put a limit on commands like `cargo add` and `cargo update`
+so that they can only use package releases that are older than some threshold.
+
+
+## Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+The `registry.global-min-publish-age` [configuration option][1][^1] for Cargo can be used to specify a minimum age for published versions to use.
+
+When set, it contains a duration specified as an integer followed by a unit of "seconds", "minutes", "days", "weeks", or "months".
+If a new crate would be added with a command such as `cargo add` or `cargo update`, it will use a version with a publish
+time ("pubtime") before that is older than that duration, if possible.
+
+The `resolver.incompatible-publish-age` configuration can also be used to control how `cargo` handles versions whose
+publish time is newer than the min-publish-age. By default, it will try to use an older version, unless none is available
+that also complies with the specified version constraint, or the `rust-version`. However by setting this to "allow"
+it is possible to disable the min-publish-age checking.
+
+It is also possible to configure the `min-publish-age` per cargo registry. `registries.<name>.min-publish-age` sets
+the minimum publish age for the `<name>` registry. And `registry.min-publish-age` sets it for the default registry
+crates.io registry.
+
+[1]: https://doc.rust-lang.org/cargo/reference/config.html
+[^1]: As specified in `.cargo/config.toml` files
+
+## Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This RFC adds a few new configuration options to [cargo configuration](https://doc.rust-lang.org/cargo/reference/config.html).
+
+### Added to [Configuration Format](https://doc.rust-lang.org/cargo/reference/config.html#configuration-format)
+
+```toml
+ [resolver]
+ incompatible-publish-age = "fallback" # Specifies how resolver reacts to these
+
+ [registries.<name>]
+ min-publish-age = "..."  # Override `registry.global-min-publish-age` for this registry
+
+ [registry]
+ min-publish-age = "0"  # Override `registry.global-min-publish-age` for crates.io
+ global-min-publish-age = "0"  # Minimum time span allowed for packages from this registry
+ ```
+
+### Added to [`[resolver]`](https://doc.rust-lang.org/cargo/reference/config.html#resolver)
+#### `resolver.incompatible-publish-age`
+
+* Type: String
+* Default: `"fallback"`
+* Environment: `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE`
+
+
+When resolving the version of a dependency to use, specify the behavior for versions with a `pubtime` (if present) that is incompatible with `registry.min-publish-age`. Values include:
+
+* `allow`: treat pubtime-incompatible versions like any other version
+* `fallback`: only consider pubtime-incompatible versions if no other version matched
+
+
+If the value is `fallback`, then cargo will print a warning if no suitable version can be found and the resolver is forced to select a version that is newer
+than allowed by the appropriate `min-publish-age` setting.
+
+
+ See the [resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#rust-version) chapter for more details.
+### Added to [`[registries]`](https://doc.rust-lang.org/cargo/reference/config.html#registries)
+#### `registries.min-publish-age`
+
+* Type: String
+* Default: none
+* Environment: `CARGO_REGISTRIES_<name>_MIN_PUBLISH_AGE`
+
+
+ Specifies the minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages from this registry. If not set, `registry.global-min-publish-age` will be used.
+
+ Will be ignored if the registry does not support this.
+
+ It supports the following values:
+
+* An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
+* `"0"` to allow all packages
+
+
+### Added to [`[registry]`](https://doc.rust-lang.org/cargo/reference/config.html#registry)
+#### `registry.min-publish-age`
+
+* Type: String
+* Default: none
+* Environment: `CARGO_REGISTRY_<name>_MIN_PUBLISH_AGE`
+
+
+ Specifies the minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages from crates.io not set, `registry.global-min-publish-age` will be used.
+
+ It supports the following values:
+
+ * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
+ * `"0"` to allow all packages
+
+
+#### `registry.global-min-publish-age`
+
+* Type: String
+* Default: `"0"`
+* Environment: `CARGO_GLOBAL_REGISTRY_<name>_MIN_PUBLISH_AGE`
+
+ Specifies the global minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages. If `min-publish-age` is not set for a specific registry using `registries.<name>.min-publish-age`, Cargo will use this minimum publish age.
+
+ It supports the following values:
+
+* An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
+* `"0"` to allow all packages
+
+
+### Behavior
+
+In addition to what is specified above
+
+* `min-publish-age` only apply to dependencies fetched from a registry, such as crates.io. They do not apply to git or path dependencies, in
+  part because there is not always an obvious publish time, or a way to find alternative versions.
+* At this time, if a specific version is explicitly specified in Cargo.toml, or on the command line, that has higher precedence than the publish time check,
+  and will be assumed to be valid. In the future it may be possible to change this behavior.
+* `cargo add`
+    * If a version is not explicitly specified by the user and the package is fetched from a registry (not a path or git), `min-publish-age` options
+      will be respected.
+* `cargo install`
+    * If a specific version is not specified by the user, respect `registries.min-publish-age` for the version of the crate itself,
+      as well as transitive dependencies when possible.
+* `cargo update`
+    * Unless `--precise` is used to specify a specific version, any crates updated from the registry will only consider versions published
+      before the time specified by the appropriate `min-publish-age` option. If `--precise` is used, that version will be used, even if it
+      newer than the policy would otherwise allow (although in the future, there may be an option to deny that).
+    * If the version of a crate in the lockfile is already newer than `min-publish-age`, then `cargo update` will not update that crate, nor will
+      it downgrade to an older version. It will leave the version as it is.
+* When a lockfile is generated, as with `cargo generate-lockfile` or other commands such as `cargo build` that can do so, then versions will be
+  selected that comply with the `min-publish-age` policy, if possible.
+* If the only version of a crate that satisfies the `min-publish-age` constraint is a yanked version, it will behave as if no versions satisfied the
+  `min-publish-age` constraint. In other words, yanked versions has higher priority than the `min-publish-age` configuration.
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+The biggest drawback is that if this is widely used, it could potentially lead to it taking longer for problems to be discovered after a version is published.
+However, most likely, there will be a spread of values used, depending on risk tolerance, and hopefully the result is actually that there will be a more gradual rollout in most
+cases.
+
+## Rationale and Alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+### Why not leave this to third party tools?
+
+There are already some third party tools that fulfill this functionality to some degree. For example, dependabot and renovate can
+be used for updating Cargo.toml and Cargo.lock, and both support some form of minimum publish age. And the cargo-cooldown project provides
+an alternative to `cargo update` that respects a minimum publish age.
+
+However, these tools only work for updating and adding dependencies outside of cargo itself, they do not
+have any impact on explicitly run built-in cargo commands such as `cargo update` and `cargo add`.
+Having built-in support makes it easier to enforce a minimum publish age policy.
+
+
+### Configuration Locations
+
+The locations and names of the configuration options in this proposal were chosen to be
+consistent with existing Cargo options, as described in [Related Options in Cargo](#related-options).
+
+## Prior Art
+[prior-art]: #prior-art
+
+### pnpm
+
+`minimumReleaseAge` is a configuration option which takes a number of minutes as an argument. It then won't update or install releases that were released less than that many minutes ago. This also applies to transitive dependencies.
+
+`minimumReleaseAgeExclude` is an array of package names, or package patterns for which the `minimumReleaseAge` does not apply, and the newest applicable release is always used. It also allows specifying specific versions to be allowed.
+
+Both configuration options can be set in global config, a project-specific config file, or with environment variables (for a specific invocation).
+
+### yarn
+
+Has a configuration setting that can be used in `.yarnrc.yml` named `npmMinimalAgeGate` that can be used to set the minimum age for installed package releases. It looks like it allows specifying units, as the example for three days is `3d`, however I haven't found any definitive description of the syntax.
+
+As far as I can tell, there is no way to provide exclusions to this rule, or different times for different packages or repositories.
+
+### uv
+
+The `--exclude-newer` option can be used to set a timestamp (using RFC 3339 format), or a duration (either "friendly" or ISO 8601 format)
+and won't use releases that happened after that timestamp. There is also an `--exclude-newer-package` option, which allows overriding the `exclude-newer` time for individual packages.
+
+Both of these settings can also be used in the `uv` configuration file (`pyproject.toml`).
+
+### pip
+
+Pip has an `--uploaded-prior-to` option that only uses versions that were uploaded prior to an ISO 8601 timestamp. Can also be controlled with the `PIP_UPLOADED_PRIOR_TO`
+environment variable.
+
+### dependabot
+
+The `cooldown` option provides a number of settings, including:
+
+- `default-days` – Default minimum age of release, in days
+- `semver-major-days`, `semver-minor-days`, `smever-patch-days` -- Override the cooldown/minimum-release-age based on what kind of release it is.
+- `include` / `exclude` – a list of packages to include/exclude in the "cooldown". Supports wildcards. `exclude` has higher priority than `include`.
+
+"Security" updates bypass the `cooldown` settings.
+
+Dependabot doesn't support cooldown for all package managers.
+
+This is specified in the dependabot configuration file.
+
+### renovate
+
+The options below can be provided in global, or project-specific configuration files, as a CLI option, or as an environment variable.
+
+`minimumReleaseAge` specifies a duration which all updates must be older than for renovate to create an update. It looks like the duration specification uses units (ex. "3 days"), however, again I can't find a precise specification for the syntax.
+
+I think it is possible to create separate rules with different `minimumReleaseAge` configurations.
+
+"Security" updates bypass the minimum release age checks.
+
+### deno
+
+Deno supports a [configuration option](https://deno.com/blog/v2.6#controlling-dependency-stability) for `minimumDependencyAge` in the configuration file, or
+`--minimum-dependency-age` on the CLI. It supports an ISO-8601 duration, RFC 3339 timestamp, or an integer of minutes.
+
+### cargo-cooldown
+
+There is an existing experimental third-party crate that provides a plugin for enforcing a cooldown: [https://github.com/dertin/cargo-cooldown]
+
+### Related Options in Cargo
+[related-options]: #related-options-in-cargo
+
+ Some precedents in Cargo
+
+ [`cache.auto-clean-frequency`](https://doc.rust-lang.org/cargo/reference/config.html#cacheauto-clean-frequency)
+
+     * "never" — Never deletes old files.
+
+     * "always" — Checks to delete old files every time Cargo runs.
+
+     * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
+
+
+ [`resolver.incompatible-rust-versions`](https://doc.rust-lang.org/cargo/reference/config.html#resolverincompatible-rust-versions)
+
+     * Controls behavior in relation to your [`package.rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) and those set by potential dependendencies
+
+     * Values:
+
+       * allow: treat rust-version-incompatible versions like any other version
+       * fallback: only consider rust-version-incompatible versions if no other version matched
+
+
+ [`package.resolver`](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) is only a version number. When adding `incompatible-rust-version`, we intentionally deferred anything being done in manifests.
+
+ [`[registry]`](https://doc.rust-lang.org/cargo/reference/config.html#registry)
+
+     * Set default registry
+
+     * Sets credential providers for all registries
+
+     * Sets crates.io values
+
+
+ [`[registries]`](https://doc.rust-lang.org/cargo/reference/config.html#registries)
+
+     * Sets registry specific values
+
+
+ `yanked`: can't do new resolves to it but left in if already there. Unstable support to force it with `--precise` but that doesn't apply recursively.
+
+ pre-release: requires opt-in through version requirement. Unstable support to force it with `--precise` but that doesn't apply recursively.
+
+ We use the term `publish` and not `release`
+
+
+## Unresolved Questions
+[unresolved-questions]: #unresolved-questions
+
+* Should "deny" be an allowed value for `resolver.incompatible-publish-age`? And if so, how does that behave? What is the error message? Is it overridden
+  by a version specified in `Cargo.lock` or with the `--precise` flag?
+* Would it be better to have `registry.min-publish-age` be the global setting, and `registries.crates-io.min-publish-age` be the setting for the crates.io registry?
+  The current proposal is based on precedent of "credential-provider" and "global-credential-provider", but perhaps we shouldn't follow that precedent?
+* How do we make it clear when things are held back?
+    * The "locking" message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) lists one time but the time here is dependent on where any given package is from
+    * We list MSRVs for unselected packages, should we also list publish times? I'm assuming that should be in local time
+    * Locking message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) is in UTC time, see [Tracking Issue for _lockfile-publish-time_ #16271](https://github.com/rust-lang/cargo/issues/16271), when relative time differences likely make local time more relevant
+* Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
+* `fallback` precedence between this and `incompatible-rust-version`?
+
+## Future Possibilities
+[future-possibilities]: #future-possibilities
+
+- Support "deny" for `resolver.incompatible-publish-age`.
+    - This is initially excluded, because it isn't clear how this should behave with respect to versions already in Cargo.lock, or use with the `--precise` flag.
+- Add a way to specify that the minimum age doesn't apply to certain packages
+

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -461,7 +461,7 @@ Some precedents in Cargo
 
 > * Sets registry specific values
 
-`yanked`: can't do new resolves to it but left in if already there. Unstable support to force it with `--precise` but that doesn't apply recursively.
+`yanked`: can't do new resolves to it but left in if already there. `--precise` can force it but that doesn't apply recursively.
 
 pre-release: requires opt-in through version requirement. Unstable support to force it with `--precise` but that doesn't apply recursively.
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -480,6 +480,12 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
   * We list MSRVs for unselected packages, should we also list publish times? I'm assuming that should be in local time
   * Locking message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) is in UTC time, see [Tracking Issue for _lockfile-publish-time_ #16271](https://github.com/rust-lang/cargo/issues/16271), when relative time differences likely make local time more relevant
 * Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
+* Is `resolver.incompatible-publish-age` needed at all?
+  Setting `registry.global-min-publish-age = "0"` achieves the same as `resolver.incompatible-publish-age = "allow"`.
+  The resolver setting provides a clearer intent for transient overrides
+  and a path to `fallback` in the future, but adds configuration complexity,
+  especially if we never expand the values beyond "allow" and "deny".
+  The resolver setting also doesn't support per-registry config.
 * `deny` precedence between this and `incompatible-rust-version`?
   * Both produce errors, but `incompatible-rust-version` will likely be evaluated first to increase the chance of builds succeeding.
 * Can we, and should we make any guarantees about security when using this feature, such as "a release of a malicious version of a crate will not compromise the build

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -61,7 +61,8 @@ global-min-publish-age = "7 days"
 running a command like `cargo update`, `cargo add`, `cargo build`, etc. will prefer to use versions of required crates that were published
 at least 7 days ago.
 
-The time can be indicated as an integer followed by a time unit such as minutes, hours, days, etc.
+The time can be indicated as an integer followed by a time unit such as minutes, hours, days, etc. Note that it
+is best not to use a time longer than a couple of weeks.
 
 Crates that use path or git, rather than a registry will never trigger this check, as there isn't a relevant publish time to use. Also,
 this check won't be preformed for crates published on registries that don't publish the `pubtime` information (note that crates.io does

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -278,13 +278,46 @@ Adding a new dependency can cause you to pull in transitive dependencies that ar
 your desired minimum age. There isn't a manageable way to run `cargo update` and intentionally
 get versions that are inside of your desired minimum age.
 
-### Configuration Locations
+### Configuration Locations and Names
 
 The locations and names of the configuration options in this proposal were chosen to be
 consistent with existing Cargo options, as described in [Related Options in Cargo](#related-options).
 
+The term "publish" was used rather than "package", "version", or "release" to make it
+clear that this only applies to crates that are published in a registry.
+
+### fallback and deny
+
+We default `resolver.incompatible-publish-age` to "fallback" rather than deny
+and defer support for "deny" to future possibilities, because that allows user to allow
+users to easily override the minimum age for specific crates when necessary.
+
+Specifically, with "fallback" it is possible to override the minimum age behavior for
+specific crates by specifying a more specific version in Cargo.toml, or using `cargo update --precise`.
+
+Furthermore, with "fallback", and the ability to override versions as mentioned above,
+it isn't as critical to have a way to list crates to exclude from the rule in configuration.
+
+We anticipate that "fallback" will be sufficient for most use cases, but the possibility of a  "deny" option
+can be revisited if necessary.
+
+### Per-registry configuration
+
+Allowing the minimum age to be configurable per registry provides a simple mechanism
+to use different minimum ages for different sets of packages, including possibly no
+minimum in common situations such as using an internal registry where the crates
+are completely trusted.
+
+This makes it less necessary to have more complicated configuration for rules for including
+and excluding sets of packages from the age policy, or setting different age policies
+for different packages.
+
+
 ## Prior Art
 [prior-art]: #prior-art
+
+["Package Managers Need to Cool Down"](https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html) discusses several implementations of this in various
+package managers (including this RFC).
 
 ### Debian "testing"
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -326,6 +326,10 @@ Exclude lists tend to be used either for:
 
 One problem with an exclude list is that they tend to be a static solution (all versions) for a transient problem (a subset of versions).
 This can lead people open to an attack after a high-value upgrade.
+An exclude list of just names is helpful for "I have a trusted package source" scenario,
+but less so for "I need a security fix now".
+The user must remember to remove the exclusion once it is no longer needed,
+or they lose protection for future versions of that package.
 We could make the exclude list use the [Package ID Spec](https://doc.rust-lang.org/cargo/reference/pkgid-spec.html) format and even require a full version to be specified.
 
 Users likely will need to exclude transitive dependencies as well.
@@ -485,11 +489,8 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
     a malicious actor could yank safe versions and force the resolver to fall back to a too-new malicious version.
   - May be useful for risk-tolerant workflows that prefer a degraded resolve over an error
     when with other tool/mechanism help validating too-new versions are safe to use.
-- Add a way to specify that the minimum age doesn't apply to certain packages. For example, by having an array of crates that should always use the newest version.
-  - The use case is solved through other means and we'll need to get runtime and gather use cases before deciding how to further evolve this
-  - The "I need a security fix now" use case is handled by `cargo update --precise` and bumping versions in `Cargo.toml`
-  - The "I have a trusted package source" is handled by the making this configurable per-registry
-    - Note: an exclude list of just names is helpful for "I have a trusted package source" but an attack vector for "I need a security fix now" because it leaves it to the user to remove it once it is no longer needed
+- Add an exclude list for `min-publish-age`
+  (see [Exclude list](#exclude-list) for why this is deferred).
 - When all compatible older-than-min-age versions are yanked
   and a newer non-yanked version exists,
   Cargo could alert the user that they may want to override with `--precise`.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -1,5 +1,5 @@
 - Feature Name: cargo_min_publish_age
-- Start Date: 2026-01-21
+- Start Date: 2026-02-23
 - RFC PR: [rust-lang/rfcs#3923](https://github.com/rust-lang/rfcs/pull/3923)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -49,7 +49,7 @@ Note that this is **not** a full solution to compromised dependencies. It can in
 [guide-level-explanation]: #guide-level-explanation
 
 The `registry.global-min-publish-age` [configuration option][1][^1] for Cargo can be used to specify a minimum age for published versions to use.
-When set, Cargo treats versions with a publish time ("pubtime") newer than that duration like yanked versions:
+When set, Cargo treats versions with a publish time ("pubtime") newer than that duration:
 Cargo will not use a too-new version unless it is already recorded in `Cargo.lock`,
 and will generate an error if there are no longer any compatible versions.
 
@@ -173,9 +173,9 @@ global-min-publish-age = "0"  # Minimum time span allowed for packages from this
 When resolving the version of a dependency, specify the behavior for versions with a `pubtime` (if present) that is incompatible with `registry.min-publish-age`. Values include:
 
 * `allow`: treat pubtime-incompatible versions like any other version
-* `deny`: treat pubtime-incompatible versions like yanked versions
+* `deny`: ignore pubtime-incompatible versions unless they already exist in the lock file
 
- See the [resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#rust-version) chapter for more details.
+See the resolver chapter for more details.
 
 ### Added to [`[registries]`](https://doc.rust-lang.org/cargo/reference/config.html#registries)
 
@@ -224,33 +224,40 @@ Generally, `"0"`, `"N days"`, and `"N weeks"` will be used.
 * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
 * `"0"` to allow all packages
 
-### Behavior
+### Added to [Resolver](https://doc.rust-lang.org/cargo/reference/resolver.html)
 
-In addition to what is specified above
+_"Pubtime-incompatible versions" as a sibling section to [Yanked versions]_
 
-* Only applies to dependencies fetched from a registry that publishes `pubtime`, such as crates.io.
-  * They do not apply to git or path dependencies, in
-    part because there is not always an obvious publish time, or a way to find alternative versions.
-  * They do not apply to registries that don't set `pubtime`, as there is no reliable way to know when the version was published.
-  * For [source replacement],
-    registry mirrors are expected to preserve `pubtime` from the index to be applicable.
-    Local registries and directory (vendored) sources typically don't have `pubtime`,
-    so the check does not apply.
-* When resolving dependencies,
-  pubtime-incompatible versions follow the same rules as [yanked versions]:
-  * They are not considered for new resolves,
-    but if already present in `Cargo.lock`, they are left in place.
-  * If no version satisfies both the version requirement and the minimum publish age,
-    the resolve will error.
-  * A status message will be printed when selecting a non-latest version
-    as well for incompatible versions.
-  * [`cargo update --precise`] can override the policy,
-    just as it can select a yanked version.
-  * `cargo install` skips pubtime-incompatible versions as well
+Versions with a publish time newer than the configured [`min-publish-age`]
+are considered pubtime-incompatible.
+When [`resolver.incompatible-publish-age`] is set to `deny`,
+the resolver will ignore these versions
+unless they already exist in the `Cargo.lock` file.
+Setting the config to `allow` would disables the check,
+which if combined with `cargo update --precise`,
+cargo would pull in a specific version and its transitive dependencies.
+
+[`resolver.incompatible-publish-age`]: config.md#resolverincompatible-publish-age
+[`min-publish-age`]: config.md#registryglobal-min-publish-age
+[Yanked versions]: https://doc.rust-lang.org/cargo/reference/resolver.html#yanked-versions
+
+### Applicability
+
+The minimum publish age check applies to the following dependency sources:
+
+* Dependencies fetched from a registry that publishes `pubtime`, such as crates.io.
+* Does not apply to git or path dependencies,
+  in part because there is not always an obvious publish time,
+  or a way to find alternative versions.
+* Does not apply to registries that don't set `pubtime`,
+  as there is no reliable way to know when the version was published.
+* For [source replacement],
+  registry mirrors are expected to preserve `pubtime` from the index to be applicable.
+  Local registries and directory (vendored) sources typically don't have `pubtime`,
+  so the check does not apply.
+* `cargo install` also skips pubtime-incompatible versions.
 
 [source replacement]: https://doc.rust-lang.org/cargo/reference/source-replacement.html
-[yanked versions]: https://doc.rust-lang.org/cargo/reference/resolver.html#yanked-versions
-[`cargo update --precise`]: https://doc.rust-lang.org/cargo/commands/cargo-update.html#option-cargo-update---precise
 
 ## Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -8,7 +8,7 @@
 
 This proposal adds a new configuration option to cargo that specifies a minimum age for package
 updates. When adding or updating a dependency, cargo won't use a version of that crate that
-is newer than the minimum age by default with a way to override to get urgent security fixes.
+is newer than the minimum age when specified, with a way to override to get urgent security fixes.
 
 An example configuration would be:
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -514,8 +514,6 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 
 ### Before stabilization
 
-* Would it be better to have `registry.min-publish-age` be the global setting, and `registries.crates-io.min-publish-age` be the setting for the crates.io registry?
-  The current proposal is based on precedent of "credential-provider" and "global-credential-provider", but perhaps we shouldn't follow that precedent?
 * How do we make it clear when things are held back?
   * The "locking" message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) lists one time but the time here is dependent on where any given package is from
   * We list MSRVs for unselected packages, should we also list publish times? I'm assuming that should be in local time

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -162,31 +162,30 @@ global-min-publish-age = "0"  # Minimum time span allowed for packages from this
  ```
 
 ### Added to [`[resolver]`](https://doc.rust-lang.org/cargo/reference/config.html#resolver)
+
 #### `resolver.incompatible-publish-age`
 
 * Type: String
 * Default: `"fallback"`
 * Environment: `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE`
 
-
-When resolving the version of a dependency to use, specify the behavior for versions with a `pubtime` (if present) that is incompatible with `registry.min-publish-age`. Values include:
+When resolving the version of a dependency, specify the behavior for versions with a `pubtime` (if present) that is incompatible with `registry.min-publish-age`. Values include:
 
 * `allow`: treat pubtime-incompatible versions like any other version
 * `fallback`: only consider pubtime-incompatible versions if no other version matched
 
-
 If the value is `fallback`, then cargo will print a warning if no suitable version can be found and the resolver is forced to select a version that is newer
 than allowed by the appropriate `min-publish-age` setting.
 
-
  See the [resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#rust-version) chapter for more details.
+
 ### Added to [`[registries]`](https://doc.rust-lang.org/cargo/reference/config.html#registries)
+
 #### `registries.min-publish-age`
 
 * Type: String
 * Default: none
 * Environment: `CARGO_REGISTRIES_<name>_MIN_PUBLISH_AGE`
-
 
  Specifies the minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages from this registry. If not set, `registry.global-min-publish-age` will be used.
 
@@ -197,14 +196,13 @@ than allowed by the appropriate `min-publish-age` setting.
 * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
 * `"0"` to allow all packages
 
-
 ### Added to [`[registry]`](https://doc.rust-lang.org/cargo/reference/config.html#registry)
+
 #### `registry.min-publish-age`
 
 * Type: String
 * Default: none
 * Environment: `CARGO_REGISTRY_<name>_MIN_PUBLISH_AGE`
-
 
  Specifies the minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages from crates.io not set, `registry.global-min-publish-age` will be used.
 
@@ -227,7 +225,6 @@ Generally, `0`, `"N days"`, and `"N weeks"` will be used.
 
 * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
 * `"0"` to allow all packages
-
 
 ### Behavior
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -465,8 +465,6 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 ## Unresolved Questions
 [unresolved-questions]: #unresolved-questions
 
-* When a version requirement is incompatible with minimum-release age, should we pick the oldest or newest version?
-* Should we name this to also cover the [`cargo generate-lockfile --publish-time`](https://github.com/rust-lang/cargo/issues/16271) use case?
 * Would it be better to have `registry.min-publish-age` be the global setting, and `registries.crates-io.min-publish-age` be the setting for the crates.io registry?
   The current proposal is based on precedent of "credential-provider" and "global-credential-provider", but perhaps we shouldn't follow that precedent?
 * How do we make it clear when things are held back?
@@ -474,8 +472,8 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
   * We list MSRVs for unselected packages, should we also list publish times? I'm assuming that should be in local time
   * Locking message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) is in UTC time, see [Tracking Issue for _lockfile-publish-time_ #16271](https://github.com/rust-lang/cargo/issues/16271), when relative time differences likely make local time more relevant
 * Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
-* `fallback` precedence between this and `incompatible-rust-version`?
-  * Most likely, `incompatible-rust-version` should have higher precedence to increase the chance of builds succeeding.
+* `deny` precedence between this and `incompatible-rust-version`?
+  * Both produce errors, but `incompatible-rust-version` will likely be evaluated first to increase the chance of builds succeeding.
 * Can we, and should we make any guarantees about security when using this feature, such as "a release of a malicious version of a crate will not compromise the build
 
 ## Future Possibilities

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -50,50 +50,55 @@ Note that this is **not** a full solution to compromised dependencies. It can in
 [guide-level-explanation]: #guide-level-explanation
 
 The `registry.global-min-publish-age` [configuration option][1][^1] for Cargo can be used to specify a minimum age for published versions to use.
+When set, Cargo will select versions with a publish time ("pubtime") that is older than that duration,
+if possible.
 
-When set, it contains a duration specified as an integer followed by a unit of "seconds", "minutes", "days", or "weeks".
-If a new crate would be added with a command such as `cargo add` or `cargo update`, it will use a version with a publish
-time ("pubtime") before that is older than that duration, if possible. `cargo` may print a message in such a case.
+This is paired with `resolver.incompatible-publish-age` to control the behavior across all registries,
+whether to `allow` newer packages or only `fallback` to them when no others are available.
 
-For example with
+For example, in your `<repo>/.cargo/config.toml`, you may have:
 
 ```toml
 [registry]
 global-min-publish-age = "7 days"
 ```
 
-running a command like `cargo update`, `cargo add`, `cargo build`, etc. will prefer to use versions of required crates that were published
-at least 7 days ago.
-
-The time can be indicated as an integer followed by a time unit such as minutes, hours, days, etc. Note that it
-is best not to use a time longer than a couple of weeks.
-
-Crates that use path or git, rather than a registry will never trigger this check, as there isn't a relevant publish time to use. Also,
-this check won't be preformed for crates published on registries that don't publish the `pubtime` information (note that crates.io does
-include `pubtime`).
-
-The `resolver.incompatible-publish-age` configuration can also be used to control how `cargo` handles versions whose
-publish time is newer than the min-publish-age. By default, it will try to use an older version, unless none is available
-that also complies with the specified version constraint, or the `rust-version`. However by setting this to "allow"
-it is possible to disable the min-publish-age checking.
-
-If it isn't possible to satisfy a dependency with a version that meets the minimum release age requirement and
-`resolver.incompatible-publish-age` is set to "fallback", then Cargo will
-fall back to using the best version that matches. In this cases, a warning will be printed next to the message for adding the
-crate, similar to the warning for an incompatible rust version. It looks like:
-
-```
-Adding example v1.2.3 (published less than 2 days ago on 2026-03-07)
+Running `cargo update` will look something like:
+```console
+$ cargo update
+Updating index
+ Locking 1 package to recent Rust 1.60 compatible version
+  Adding example v1.2.3 (available: v1.6.0, published 2 days ago)
 ```
 
-Most likely, `resolver.incompatible-publish-age` will usually be left at its default of `fallback`, however it may occasionally
-be desirable to use it to temporarily turn off the minimum age check, especially if there are configurations for multiple
-registries. This would typically be done with a command line argument like `--config 'resolver.incompatible-publish-age="allow"'` or an
-environment variable like `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`.
+While a CI job runs:
+```
+env:
+  CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: allow
+  CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE: allow
+steps:
+  - uses: actions/checkout@v4
+  - run: rustup update stable && rustup default stable
+  - run: cargo update --verbose
+  - run: cargo build --verbose
+  - run: cargo test --verbose
+```
 
-It is also possible to configure the `min-publish-age` per cargo registry. `registries.<name>.min-publish-age` sets
-the minimum publish age for the `<name>` registry. And `registry.min-publish-age` sets it for the default registry
-crates.io registry.
+This will mean that:
+- Locally, `cargo add foo` will default the version requirement on `foo` to be low enough to support the 7 day old package
+- Locally, `cargo update` will update your `Cargo.lock` to versions within the minimum-release age
+- This CI job will verify the latest versions of your dependencies
+
+Note: this check does not apply to
+- path dependencies
+- git dependencies
+- registries that do not include `pubtime` (crates.io supports it)
+
+### Per-registry configuration
+
+It is also possible to configure the `min-publish-age` per cargo registry.
+`registries.<name>.min-publish-age` sets the minimum publish age for the `<name>` registry.
+And `registry.min-publish-age` sets it for crates.io.
 
 For example:
 ```toml
@@ -112,18 +117,27 @@ global-min-publish-age = "2 days"
 min-publish-age = "5 days"
 ```
 
-This will use a minimum publish age of 5 days for crates.io, 2 hours for crates.exalmple.com, no minimum for registry.local, and 2 days for any other registry.
+This will use a minimum publish age of
+- 5 days for crates.io
+- 2 hours for crates.exalmple.com
+- no minimum for registry.local
+- 2 days for any other registry.
 
 ### Using newer version
 
-In some cases, it may be desirable to use a version that is newer than the minimum publish age. For example, because a new
-version has a critical security fix, or because it is part of the same family of crates as the dependent crate, and they should
-be released together.
+In some cases, it may be desirable to use a version that is newer than the minimum publish age.
 
-If `resolver.incompatible-publish-age` is "fallback" (the default), it is possible to bypass the check by updating the version range to require
-the newer version in `Cargo.toml`, or with `cargo add`, or specify the exact version to use with `cargo update --precise`.
+Say `example` from the [guide section](#guide-level-explanation) has a fix for a vulnerability in v1.3.0, you could do one of:
+```console
+$ cargo update example --precise 1.3.0
+Updating index
+ Locking 1 package to recent Rust 1.60 compatible version
+  Adding example v1.2.3 (published 10 days ago, available: v1.6.0, published 2 days ago)
+$ # or ...
+$ cargo add example@1.3.0
+```
 
-In the future, additional controls may be provided (see [Future Possibilities](#future-possibilities)).
+This is due to the `resolver.incompatible-publish-age = "fallback"` default which preserves your `Cargo.lock` and respects too-high of version requirements despite your minimum-release age.
 
 [1]: https://doc.rust-lang.org/cargo/reference/config.html
 [^1]: As specified in `.cargo/config.toml` files
@@ -199,6 +213,7 @@ than allowed by the appropriate `min-publish-age` setting.
  * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
  * `"0"` to allow all packages
 
+Generally, `0`, `"N days"`, and `"N weeks"` will be used.
 
 #### `registry.global-min-publish-age`
 
@@ -236,6 +251,7 @@ In addition to what is specified above
       newer than the policy would otherwise allow (although in the future, there may be an option to deny that).
     * If the version of a crate in the lockfile is already newer than `min-publish-age`, then `cargo update` will not update that crate, nor will
       it downgrade to an older version. It will leave the version as it is.
+    * When locking to an older version, that will be included like with the MSRV-aware resolver
 * When a lockfile is generated, as with `cargo generate-lockfile` or other commands such as `cargo build` that can do so, then versions will be
   selected that comply with the `min-publish-age` policy, if possible.
 * If the only version of a crate that satisfies the `min-publish-age` constraint is a yanked version, it will behave as if no versions satisfied the

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -393,6 +393,11 @@ have any impact on local changes, like directly editing `Cargo.toml` causing an 
 ["Package Managers Need to Cool Down"](https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html) discusses several implementations of this in various
 package managers (including this RFC).
 
+["Dependency-cooldown discussions warm up"](https://lwn.net/Articles/1068692/)
+covers the broader ecosystem debate around dependency cooldowns,
+including an alternative "upload queue" approach
+where registries delay distribution rather than consumers delay adoption.
+
 ### Debian "testing"
 
 Debian's "testing" distribution consists of packages from unstable that have been in the "unstable" distribution for a certain minimum age (2-10 days depending on an `urgency` field in the package changelog), have been built for all previously supported targets, have their dependencies in testing, and don't have any new release-critical bugs.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -219,6 +219,12 @@ consistent with existing Cargo options, as described in [Related Options in Carg
 ## Prior Art
 [prior-art]: #prior-art
 
+### Debian "testing"
+
+Debian's "testing" distribution consists of packages from unstable that have been in the "unstable" distribution for a certain minimum age (2-10 days depending on an `urgency` field in the package changelog), have been built for all previously supported targets, have their dependencies in testing, and don't have any new release-critical bugs.
+
+Users of "unstable" include early adopters who don't mind being the canary when things break (and reporting the aforementioned bugs, release-critical or otherwise). Users of "testing" get slightly older packages and a reduced chance of release-critical bugs.
+
 ### pnpm
 
 `minimumReleaseAge` is a configuration option which takes a number of minutes as an argument. It then won't update or install releases that were released less than that many minutes ago. This also applies to transitive dependencies.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -274,6 +274,9 @@ consistent with existing Cargo options, as described in [Related Options in Carg
 The term "publish" was used rather than "package", "version", or "release" to make it
 clear that this only applies to crates that are published in a registry.
 
+`publish` is redundant with this being in the `registry` table.
+This helps with the above disambiguation and for clarity in discussing this as a shorthand.
+
 `cooldown` was avoided due to term generally referring to throttling while we are looking for a certain maturity.
 
 ### `fallback` and `deny`

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -267,20 +267,6 @@ time to realize their credentials have been compromised and yank the version bef
 ## Rationale and Alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-### Why not leave this to third party tools?
-
-There are already some third party tools that fulfill this functionality to some degree. For example, dependabot and renovate can
-be used for updating Cargo.toml and Cargo.lock, and both support some form of minimum publish age. And the cargo-cooldown project provides
-an alternative to `cargo update` that respects a minimum publish age.
-
-However, these tools only work for updating and adding dependencies outside of cargo itself, they do not
-have any impact on explicitly run built-in cargo commands such as `cargo update` and `cargo add`.
-Having built-in support makes it easier to enforce a minimum publish age policy.
-
-Furthermore, these tools depend on the existence of a `Cargo.lock` file to lock the versions. Or having
-strict version constraints in `Cargo.toml`. If a `Cargo.lock` file does not yet exist, commands such as `cargo build` won't
-be protected.
-
 ### Configuration Locations and Names
 
 The locations and names of the configuration options in this proposal were chosen to be
@@ -321,6 +307,15 @@ You can pin versions in your `Cargo.toml` but that is a manual process and doesn
 dependencies.
 
 Users can manage all of their direct and transitive dependencies in a `Cargo.lock` file but that is tedious and it is easy to overlook new entries on implicit lockfile changes.
+
+### Why not leave this to third party tools?
+
+There are already some third party tools that fulfill this functionality to some degree. For example, dependabot and renovate can
+be used for updating Cargo.toml and Cargo.lock, and both support some form of minimum publish age. And the cargo-cooldown project provides
+an alternative to `cargo update` that respects a minimum publish age.
+
+However, these tools only work for updating and adding dependencies outside of cargo itself, they do not
+have any impact on local changes, like directly editing `Cargo.toml` causing an implicit `Cargo.lock` update, `cargo update`, or `cargo add`.
 
 ## Prior Art
 [prior-art]: #prior-art

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -24,7 +24,8 @@ global-min-publish-age = "14 days"
 
 There are a couple of reasons why one may wish not to use the most recent version of a package.
 
-One such reason is to mitigate the risk of [supply chain attacks](https://en.wikipedia.org/wiki/Supply_chain_attack). Often, supply chain
+This reduces the risk of [supply chain attacks](https://en.wikipedia.org/wiki/Supply_chain_attack),
+particularly those found by automated scanners on newly published package versions.
 attacks are found fairly quickly after they are deployed. Thus, if the dependency isn't updated
 immediately after a release, you can have some protection against a new release of a dependency
 containing malicious code. In light of recent supply chain attacks on the NPM ecosystem,

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -81,7 +81,9 @@ If it isn't possible to satisfy a dependency with a version that meets the minim
 fall back to using the best version that matches. In this cases, a warning will be printed next to the message for adding the
 crate, similar to the warning for an incompatible rust version. It looks like:
 
-$${\color{green}Adding} example v1.2.3 {\color{red}(published less than 2 days ago on 2026-03-07)}$$
+```
+Adding example v1.2.3 (published less than 2 days ago on 2026-03-07)
+```
 
 Most likely, `resolver.incompatible-publish-age` will usually be left at its default of `fallback`, however it may occasionally
 be desirable to use it to temporarily turn off the minimum age check, especially if there are configurations for multiple

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -6,9 +6,11 @@
 ## Summary
 [summary]: #summary
 
-This proposal adds a new configuration option to cargo that specifies a minimum age for package
-updates. When adding or updating a dependency, cargo won't use a version of that crate that
-is newer than the minimum age when specified, with a way to override to get urgent security fixes.
+This proposal adds a new configuration option to cargo allowing users to specify a minimum age for dependency versions.
+When adding or updating a dependency, cargo will prefer versions of a registry crate that
+are older than the minimum age.
+`Cargo.lock`, version requirements, and `cargo update --precise` can bypass this, allowing
+for exceptions like for urgent security fixes.
 
 An example configuration would be:
 
@@ -16,8 +18,6 @@ An example configuration would be:
 [registry]
 global-min-publish-age = "14 days"
 ```
-
-Or it could be specified on the command line with `--config registry.global-min-publish-age '14 days'`.
 
 ## Motivation
 [motivation]: #motivation

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -294,6 +294,20 @@ it isn't as critical to have a way to list crates to exclude from the rule in co
 We anticipate that `fallback` will be sufficient for most use cases, but the possibility of a `deny` option
 can be revisited if necessary.
 
+### Exclude list
+
+Exclude lists tend to be used either for:
+- Forcing a specific newer version: we have this covered through the `fallback` mechanism
+- Marking a source as always trusted: we have this covered through per-registry configuration
+
+One problem with an exclude list is that they tend to be a static solution (all versions) for a transient problem (a subset of versions).
+
+An exclude list can always be added in the future if a strong enough use case presents itself.
+By delaying, we can also take into account any future changes.
+For example, if the focus is on different levels trust within the same registry,
+we could design a solution around [registry namespacing](https://internals.rust-lang.org/t/survey-of-organizational-ownership-and-registry-namespace-designs-for-cargo-and-crates-io/24027/4),
+assuming support is added.
+
 ### Per-registry configuration
 
 Allowing the minimum age to be configurable per registry provides a simple mechanism

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -32,7 +32,13 @@ For more background on version maturity requirements as a risk mitigation, see
 [We should all be using dependency cooldowns](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) and
 [Dependency cooldowns, redux](https://blog.yossarian.net/2025/12/13/cooldowns-redux).
 
-Another reason to wish to delay using a new release, is because new versions can introduce regressions. Different projects have different risks tolerances for regressions and by giving projects control over how mature their dependencies are, they can choose the level of risk they will accept.  This has the effect on the ecosystem of creating a gradual roll out for package versions where early adopters help to mature the package by the time it makes it to the more risk averse projects.  Granted, the fixes will have the same minimum age requirement but projects can choose to use newer versions to get the fixes relevant to them.
+There would be value in a gradual roll out scheme for the ecosystem.
+New versions can introduce inadvertent breaking changes, bugs, or security vulnerabilities.
+Having everyone discover these problems at once leads to a wider, costlier disruption to the ecosystem.
+Some maintainers are fine being on the bleeding edge, taking on those costs, and act as a canary for the ecosystem.
+Those who are more risk averse can choose how much stagnation they are willing to accept for others to discover these problems and get them worked out.
+Maintainers may even want to blend these in one project: keep risks down for local development while CI has a dependency version canary job to identify future problems and track their status.
+Granted, any fixes will also be subject to the minimum-release age but at least these will be available to upgrade to so long as there is an exception mechanism.
 
 As such, it would be useful to have an option to put a limit on commands that update the `Cargo.lock` file (not just  `cargo add` and `cargo update` but other commands after editing `Carg.toml` like `cargo check`, etc)
 so that they can only use package releases that are older than some threshold.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -481,15 +481,16 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 ## Future Possibilities
 [future-possibilities]: #future-possibilities
 
-- Support "deny" for `resolver.incompatible-publish-age`.
-  - This is initially excluded, because it isn't clear how this should behave with respect to versions already in Cargo.lock, or use with the `--precise` flag.
-  - What would an error look like?
-  - How would you be able to override this for specific crates for important security updates, or for related crates that should be released at the same time?
+- Support `fallback` for `resolver.incompatible-publish-age`.
+  - With `fallback`, too-new versions would be deprioritized but still allowed as a last resort.
+  - This was not included initially because of the yank attack vector:
+    a malicious actor could yank safe versions and force the resolver to fall back to a too-new malicious version.
+  - May be useful for risk-tolerant workflows that prefer a degraded resolve over an error
+    when with other tool/mechanism help validating too-new versions are safe to use.
 - Add a way to specify that the minimum age doesn't apply to certain packages. For example, by having an array of crates that should always use the newest version.
   - The use case is solved through other means and we'll need to get runtime and gather use cases before deciding how to further evolve this
-  - The "I need a security fix now" use case is handled by  bumping versions in `Cargo.toml` and/or `Cargo.lock`
+  - The "I need a security fix now" use case is handled by `cargo update --precise` and bumping versions in `Cargo.toml`
   - The "I have a trusted package source" is handled by the making this configurable per-registry
     - Note: an exclude list of just names is helpful for "I have a trusted package source" but an attack vector for "I need a security fix now" because it leaves it to the user to remove it once it is no longer needed
-  - This may be more important if support for "deny" is added to `resolver.incompatible-publish-age`.
 - Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
 - A `resolver.now` field for setting the time for which `min-publish-age` should be compared against

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -60,7 +60,7 @@ For example, in your `<repo>/.cargo/config.toml`, you may have:
 
 ```toml
 [registry]
-global-min-publish-age = "7 days"
+global-min-publish-age = "14 days"
 ```
 
 Running `cargo update` will look something like:
@@ -68,7 +68,7 @@ Running `cargo update` will look something like:
 $ cargo update
 Updating index
  Locking 1 package to recent Rust 1.60 compatible version
-  Adding example v1.2.3 (available: v1.6.0, published 2 days ago)
+  Adding some-package v1.2.3 (available: v1.6.0, published 2 days ago)
 ```
 
 While a CI job runs:
@@ -102,39 +102,34 @@ And `registry.min-publish-age` sets it for crates.io.
 
 For example:
 ```toml
-[registries.example]
-index = "https://crates.example.com"
-min-publish-age = "2 hours"
-
-[registry.local]
-index = "https://registry.local"
+[registry.my-org]
+index = "https://my.org"
 min-publish-age = 0 # this registry is fully trusted
 
 [registry]
 # Default for any registry without a specific value
-global-min-publish-age = "2 days"
+global-min-publish-age = "14 days"
 # Value to use for crates.io
 min-publish-age = "5 days"
 ```
 
 This will use a minimum publish age of
 - 5 days for crates.io
-- 2 hours for crates.example.com
-- no minimum for registry.local
-- 2 days for any other registry.
+- no minimum for `my-org`
+- 14 days for any other registry.
 
 ### Using newer version
 
 In some cases, it may be desirable to use a version that is newer than the minimum publish age.
 
-Say `example` from the [guide section](#guide-level-explanation) has a fix for a vulnerability in v1.3.0, you could do one of:
+Say `some-package` from [earlier](#guide-level-explanation) has a fix for a vulnerability in v1.3.0, you could do one of:
 ```console
-$ cargo update example --precise 1.3.0
+$ cargo update some-package --precise 1.3.0
 Updating index
  Locking 1 package to recent Rust 1.60 compatible version
-  Adding example v1.2.3 (published 10 days ago, available: v1.6.0, published 2 days ago)
+  Adding some-package v1.2.3 (published 10 days ago, available: v1.6.0, published 2 days ago)
 $ # or ...
-$ cargo add example@1.3.0
+$ cargo add some-package@1.3.0
 ```
 
 This is due to the `resolver.incompatible-publish-age = "fallback"` default which preserves your `Cargo.lock` and respects too-high of version requirements despite your minimum-release age.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -276,20 +276,20 @@ This helps with the above disambiguation and for clarity in discussing this as a
 
 `cooldown` was avoided due to term generally referring to throttling while we are looking for a certain maturity.
 
-### `fallback` and `deny`
+### Starting with `deny`
 
-`resolver.incompatible-publish-age` is starting with just support for `allow` and `fallback`, leaving `deny` for future consideration,
-because that allows users to easily override the minimum age for specific crates when necessary.
+`resolver.incompatible-publish-age` starts with `allow` and `deny`.
+The `fallback` option is deferred to future consideration.
 
-Specifically, with `fallback` it is possible to override the minimum age behavior for
-specific crates by specifying a more specific version in `Cargo.toml`, or using `cargo update --precise`.
+Starting with `deny` rather than `fallback` closes the yank attack vector:
+with `fallback`, a malicious actor with the right permissions could publish a malicious version
+and yank the safe versions, forcing the resolver to fall back to the malicious too-new version.
+`deny` prevents this by erroring instead of falling back.
 
-Furthermore, with `fallback`, and the ability to override versions as mentioned above,
-we can defer support for an exclusion list as well,
-simplifying the design work we need to do now and being able to gather more requirements in case it becomes worth addressing in the future.
-
-The one danger of `fallback` is that a malicious actor with the right permissions can publish a malicious version and yank the safe versions,
-bypassing the `min-publish-age`.
+Unlike `resolver.incompatible-rust-versions` which starts with `fallback`,
+`deny` is viable here because `pubtime` data is exhaustive.
+crates.io sets it for every version once backfilled,
+so there are no gaps that would cause spurious errors.
 
 ### Timestamp vs duration
 
@@ -321,7 +321,7 @@ for different packages.
 ### Exclude list
 
 Exclude lists tend to be used either for:
-- Forcing a specific newer version: we have this covered through the `fallback` mechanism
+- Forcing a specific newer version: we have this covered through `cargo update --precise`
 - Marking a source as always trusted: we have this covered through per-registry configuration
 
 One problem with an exclude list is that they tend to be a static solution (all versions) for a transient problem (a subset of versions).

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -279,17 +279,21 @@ This helps with the above disambiguation and for clarity in discussing this as a
 ### Starting with `deny`
 
 `resolver.incompatible-publish-age` starts with `allow` and `deny`.
-The `fallback` option is deferred to future consideration.
-
-Starting with `deny` rather than `fallback` closes the yank attack vector:
-with `fallback`, a malicious actor with the right permissions could publish a malicious version
-and yank the safe versions, forcing the resolver to fall back to the malicious too-new version.
-`deny` prevents this by erroring instead of falling back.
 
 Unlike `resolver.incompatible-rust-versions` which starts with `fallback`,
 `deny` is viable here because `pubtime` data is exhaustive.
 crates.io sets it for every version once backfilled,
 so there are no gaps that would cause spurious errors.
+
+A `fallback` option would deprioritize too-new versions but still allow them as a last resort.
+This is deferred because it opens the yank attack vector:
+a malicious actor with right permissions could publish a malicious version and yank the safe versions.
+It then forces the resolver to fall back to the malicious too-new version.
+`deny` prevents this by erroring instead of falling back.
+
+`fallback` may be useful in the future for risk-tolerant workflows
+that prefer a degraded resolve over an error,
+particularly when combined with other tools that validate pubtime-incompatible versions.
 
 ### Timestamp vs duration
 
@@ -483,12 +487,8 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 ## Future Possibilities
 [future-possibilities]: #future-possibilities
 
-- Support `fallback` for `resolver.incompatible-publish-age`.
-  - With `fallback`, too-new versions would be deprioritized but still allowed as a last resort.
-  - This was not included initially because of the yank attack vector:
-    a malicious actor could yank safe versions and force the resolver to fall back to a too-new malicious version.
-  - May be useful for risk-tolerant workflows that prefer a degraded resolve over an error
-    when with other tool/mechanism help validating too-new versions are safe to use.
+- Support `fallback` for `resolver.incompatible-publish-age`
+  (see [Starting with `deny`](#starting-with-deny) for why this is deferred).
 - Add an exclude list for `min-publish-age`
   (see [Exclude list](#exclude-list) for why this is deferred).
 - When all compatible older-than-min-age versions are yanked

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -104,7 +104,7 @@ For example:
 ```toml
 [registries.my-org]
 index = "https://my.org"
-min-publish-age = 0 # this registry is fully trusted
+min-publish-age = "0" # this registry is fully trusted
 
 [registry]
 # Default for any registry without a specific value
@@ -208,7 +208,7 @@ than allowed by the appropriate `min-publish-age` setting.
  * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
  * `"0"` to allow all packages
 
-Generally, `0`, `"N days"`, and `"N weeks"` will be used.
+Generally, `"0"`, `"N days"`, and `"N weeks"` will be used.
 
 #### `registry.global-min-publish-age`
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -277,6 +277,8 @@ consistent with existing Cargo options, as described in [Related Options in Carg
 The term "publish" was used rather than "package", "version", or "release" to make it
 clear that this only applies to crates that are published in a registry.
 
+`cooldown` was avoided due to term generally referring to throttling while we are looking for a certain maturity.
+
 ### fallback and deny
 
 We default `resolver.incompatible-publish-age` to "fallback" rather than deny

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -22,17 +22,15 @@ global-min-publish-age = "14 days"
 ## Motivation
 [motivation]: #motivation
 
-There are a couple of reasons why one may wish not to use the most recent version of a package.
+There are a couple of reasons why one may wish not to use the most recent version of a package:
 
-This reduces the risk of [supply chain attacks](https://en.wikipedia.org/wiki/Supply_chain_attack),
-particularly those found by automated scanners on newly published package versions.
-attacks are found fairly quickly after they are deployed. Thus, if the dependency isn't updated
-immediately after a release, you can have some protection against a new release of a dependency
-containing malicious code. In light of recent supply chain attacks on the NPM ecosystem,
-there has been an increased interest in using automated tools to ensure that packages used
-are older than some age. This creates a window of time between when a dependency is compromised
-and when that release is used by your project. See for example the blog post
-"[We should all be using dependency cooldowns](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns)".
+Some [supply chain attacks](https://en.wikipedia.org/wiki/Supply_chain_attack)
+are found by automated scanners on newly published package versions.
+Recent supply chain attacks on the NPM ecosystem have drawn attention to the value of waiting on these
+automated scanners.
+For more background on version maturity requirements as a risk mitigation, see
+[We should all be using dependency cooldowns](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) and
+[Dependency cooldowns, redux](https://blog.yossarian.net/2025/12/13/cooldowns-redux).
 
 Another reason to wish to delay using a new release, is because new versions can introduce regressions. Different projects have different risks tolerances for regressions and by giving projects control over how mature their dependencies are, they can choose the level of risk they will accept.  This has the effect on the ecosystem of creating a gradual roll out for package versions where early adopters help to mature the package by the time it makes it to the more risk averse projects.  Granted, the fixes will have the same minimum age requirement but projects can choose to use newer versions to get the fixes relevant to them.
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -156,7 +156,7 @@ This RFC adds a few new configuration options to [cargo configuration](https://d
 
 ```toml
 [resolver]
-incompatible-publish-age = "fallback" # Specifies how resolver reacts to these
+incompatible-publish-age = "deny" # Specifies how resolver reacts to these
 
 [registries.<name>]
 min-publish-age = "..."  # Override `registry.global-min-publish-age` for this registry
@@ -171,16 +171,13 @@ global-min-publish-age = "0"  # Minimum time span allowed for packages from this
 #### `resolver.incompatible-publish-age`
 
 * Type: String
-* Default: `"fallback"`
+* Default: `"deny"`
 * Environment: `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE`
 
 When resolving the version of a dependency, specify the behavior for versions with a `pubtime` (if present) that is incompatible with `registry.min-publish-age`. Values include:
 
 * `allow`: treat pubtime-incompatible versions like any other version
-* `fallback`: only consider pubtime-incompatible versions if no other version matched
-
-If the value is `fallback`, then cargo will print a warning if no suitable version can be found and the resolver is forced to select a version that is newer
-than allowed by the appropriate `min-publish-age` setting.
+* `deny`: treat pubtime-incompatible versions like yanked versions
 
  See the [resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#rust-version) chapter for more details.
 
@@ -235,23 +232,15 @@ Generally, `"0"`, `"N days"`, and `"N weeks"` will be used.
 
 In addition to what is specified above
 
-* `min-publish-age` only applies to dependencies fetched from a registry that publishes `pubtime`, such as crates.io.
+* Only applies to dependencies fetched from a registry that publishes `pubtime`, such as crates.io.
   * They do not apply to git or path dependencies, in
     part because there is not always an obvious publish time, or a way to find alternative versions.
   * They do not apply to registries that don't set `pubtime`, as there is no reliable way to know when the version was published.
-* If a specific version is explicitly specified in Cargo.toml, or on the command line, that has higher precedence than the publish time check,
-  and will be assumed to be valid.
-* `cargo add`
-  * If a version is not explicitly specified by the user and the package is fetched from a registry (not a path or git), the version requirement will default to one that includes a version compatible with `min-publish-age`
-* `cargo install`
-  * If a specific version is not specified by the user, respect `registries.min-publish-age` for the version of the crate itself,
-    as well as transitive dependencies when possible.
 * When resolving dependencies:
-  * Any crates updated from the registry will only consider versions published
-    before the time specified by the appropriate `min-publish-age` option.
-  * If the version of a crate in the lockfile is already newer than `min-publish-age`, then `cargo update` will not update that crate, nor will
-    it downgrade to an older version. It will leave the version as it is.
-  * Yanked status has higher precedence than `resolver.incompatible-publish-age`
+  * Pubtime-incompatible versions are not considered for new resolves,
+    but if already present in `Cargo.lock`, they are left in place.
+  * If no version satisfies both the version requirement and the minimum publish age,
+    the resolve will error.
   * Precedence with `resolver.incompatible-rust-version` is unspecified (but `resolver.incompatible-rust-version` will likely have higher precedence)
   * A status message will be printed when selecting a non-latest version as well for incompatible versions.
 * `cargo update` specifically:

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -36,6 +36,9 @@ using a version older than some age.
 As such, it would be useful to have an option to put a limit on commands like `cargo add` and `cargo update`
 so that they can only use package releases that are older than some threshold.
 
+Note that this is **not** a full solution to compromised dependencies. It can increase the protection against certain types of
+"supply chain" attacks, but not all of them. As such, using this feature should not be relied upon for security by itself.
+
 
 ## Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -54,6 +57,17 @@ it is possible to disable the min-publish-age checking.
 It is also possible to configure the `min-publish-age` per cargo registry. `registries.<name>.min-publish-age` sets
 the minimum publish age for the `<name>` registry. And `registry.min-publish-age` sets it for the default registry
 crates.io registry.
+
+### Using newer version
+
+In some cases, it may be desirable to use a version that is newer than the minimum publish age. For example, because a new
+version has a critical security fix, or because it is part of the same family of crates as the dependent crate, and they should
+be released together.
+
+If `resolver.incompatible-publish-age` is "fallback" (the default), it is possible to bypass the check by updating the version range to require
+the newer version in `Cargo.toml`, or with `cargo add`, or specify the exact version to use with `cargo update --precise`.
+
+In the future, additional controls may be provided (see [Future Possibilities](#future-possibilities)).
 
 [1]: https://doc.rust-lang.org/cargo/reference/config.html
 [^1]: As specified in `.cargo/config.toml` files
@@ -176,6 +190,10 @@ The biggest drawback is that if this is widely used, it could potentially lead t
 However, most likely, there will be a spread of values used, depending on risk tolerance, and hopefully the result is actually that there will be a more gradual rollout in most
 cases.
 
+Also, even if all users of a crate set a minimum publish age there is still value in a delay, because it provides time for automated security scanners, and human reviewers
+to review the changes before the new version is pulled in by updates. And in the case of a malicious release made using compromised credentials, it give the actual developer
+time to realize their credentials have been compromised and yank the version before it is widely used.
+
 ## Rationale and Alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
@@ -189,6 +207,9 @@ However, these tools only work for updating and adding dependencies outside of c
 have any impact on explicitly run built-in cargo commands such as `cargo update` and `cargo add`.
 Having built-in support makes it easier to enforce a minimum publish age policy.
 
+Furthermore, these tools depend on the existence of a `Cargo.lock` file to lock the versions. Or having
+strict version constraints in `Cargo.toml`. If a `Cargo.lock` file does not yet exist, commands such as `cargo build` won't
+be protected.
 
 ### Configuration Locations
 
@@ -307,8 +328,6 @@ There is an existing experimental third-party crate that provides a plugin for e
 ## Unresolved Questions
 [unresolved-questions]: #unresolved-questions
 
-* Should "deny" be an allowed value for `resolver.incompatible-publish-age`? And if so, how does that behave? What is the error message? Is it overridden
-  by a version specified in `Cargo.lock` or with the `--precise` flag?
 * Would it be better to have `registry.min-publish-age` be the global setting, and `registries.crates-io.min-publish-age` be the setting for the crates.io registry?
   The current proposal is based on precedent of "credential-provider" and "global-credential-provider", but perhaps we shouldn't follow that precedent?
 * How do we make it clear when things are held back?
@@ -323,5 +342,9 @@ There is an existing experimental third-party crate that provides a plugin for e
 
 - Support "deny" for `resolver.incompatible-publish-age`.
     - This is initially excluded, because it isn't clear how this should behave with respect to versions already in Cargo.lock, or use with the `--precise` flag.
-- Add a way to specify that the minimum age doesn't apply to certain packages
+    - What would an error look like?
+- Add a way to specify that the minimum age doesn't apply to certain packages. For example, by having an array of crates that should always use the newest version.
+    - I excluded this from the initial RFC, because implementing it adds significant complexity to the proposal, and it is relatively easy to work around by explicitly updating
+      those packages to newer versions in Cargo.toml and/or Cargo.lock.
+    - This may be more important if support for "deny" is added to `resolver.incompatible-publish-age`.
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -55,18 +55,61 @@ When set, it contains a duration specified as an integer followed by a unit of "
 If a new crate would be added with a command such as `cargo add` or `cargo update`, it will use a version with a publish
 time ("pubtime") before that is older than that duration, if possible. `cargo` may print a message in such a case.
 
+For example with
+
+```toml
+[registry]
+global-min-publish-age = "7 days"
+```
+
+running a command like `cargo update`, `cargo add`, `cargo build`, etc. will prefer to use versions of required crates that were published
+at least 7 days ago.
+
+The time can be indicated as an integer followed by a time unit such as minutes, hours, days, etc.
+
+Crates that use path or git, rather than a registry will never trigger this check, as there isn't a relevant publish time to use. Also,
+this check won't be preformed for crates published on registries that don't publish the `pubtime` information (note that crates.io does
+include `pubtime`).
+
 The `resolver.incompatible-publish-age` configuration can also be used to control how `cargo` handles versions whose
 publish time is newer than the min-publish-age. By default, it will try to use an older version, unless none is available
 that also complies with the specified version constraint, or the `rust-version`. However by setting this to "allow"
 it is possible to disable the min-publish-age checking.
 
+If it isn't possible to satisfy a dependency with a version that meets the minimum release age requirement and
+`resolver.incompatible-publish-age` is set to "fallback", then Cargo will
+fall back to using the best version that matches. In this cases, a warning will be printed next to the message for adding the
+crate, similar to the warning for an incompatible rust version. It looks like:
+
+$${\color{green}Adding} example v1.2.3 {\color{red}(published less than 2 days ago on 2026-03-07)}$$
+
 Most likely, `resolver.incompatible-publish-age` will usually be left at its default of `fallback`, however it may occasionally
 be desirable to use it to temporarily turn off the minimum age check, especially if there are configurations for multiple
-registries.
+registries. This would typically be done with a command line argument like `--config 'resolver.incompatible-publish-age="allow"'` or an
+environment variable like `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`.
 
 It is also possible to configure the `min-publish-age` per cargo registry. `registries.<name>.min-publish-age` sets
 the minimum publish age for the `<name>` registry. And `registry.min-publish-age` sets it for the default registry
 crates.io registry.
+
+For example:
+```toml
+[registries.example]
+index = "https://crates.example.com"
+min-publish-age = "2 hours"
+
+[registry.local]
+index = "https://registry.local"
+min-publish-age = 0 # this registry is fully trusted
+
+[registry]
+# Default for any registry without a specific value
+global-min-publish-age = "2 days"
+# Value to use for crates.io
+min-publish-age = "5 days"
+```
+
+This will use a minimum publish age of 5 days for crates.io, 2 hours for crates.exalmple.com, no minimum for registry.local, and 2 days for any other registry.
 
 ### Using newer version
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -303,6 +303,11 @@ It then forces the resolver to fall back to the malicious too-new version.
 `fallback` may be useful in the future for risk-tolerant workflows
 that prefer a degraded resolve over an error,
 particularly when combined with other tools that validate pubtime-incompatible versions.
+It would also help with `cargo update --precise` for packages with transitive dependencies.
+For example,
+`CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=fallback cargo update clap --precise 4.5.3`
+would pull in only the necessary too-new transitive dependencies
+rather than disabling the check entirely with `allow`.
 
 ### Timestamp vs duration
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -291,6 +291,22 @@ it isn't as critical to have a way to list crates to exclude from the rule in co
 We anticipate that `fallback` will be sufficient for most use cases, but the possibility of a `deny` option
 can be revisited if necessary.
 
+### Timestamp vs duration
+
+Some prior art
+- exclusively use a timestamp
+- allow either a timestamp or a relative time within the same field
+
+While a timestamp has its uses
+(see [`--publish-time`](https://doc.rust-lang.org/cargo/reference/unstable.html#lockfile-publish-time)),
+it wouldn't be as ergonomic for this use case.
+
+Designing the field to support both would create a trap for users trying to reproduce a problem from the past in that they are likely to set the timestamp but overlook that they need to take the existing duration into account.
+Even if they do remember to take the existing duration into account,
+it would be more convenient if they can be set separately.
+
+Setting the timestamp to resolve to is left as a future possibility
+
 ### Per-registry configuration
 
 Allowing the minimum age to be configurable per registry provides a simple mechanism
@@ -471,3 +487,4 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
     - Note: an exclude list of just names is helpful for "I have a trusted package source" but an attack vector for "I need a security fix now" because it leaves it to the user to remove it once it is no longer needed
   - This may be more important if support for "deny" is added to `resolver.incompatible-publish-age`.
 - Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
+- A `resolver.now` field for setting the time for which `min-publish-age` should be compared against

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -35,7 +35,7 @@ and when that release is used by your project. See for example the blog post
 
 Another reason to wish to delay using a new release, is because new versions can introduce regressions. Different projects have different risks tolerances for regressions and by giving projects control over how mature their dependencies are, they can choose the level of risk they will accept.  This has the effect on the ecosystem of creating a gradual roll out for package versions where early adopters help to mature the package by the time it makes it to the more risk averse projects.  Granted, the fixes will have the same minimum age requirement but projects can choose to use newer versions to get the fixes relevant to them.
 
-As such, it would be useful to have an option to put a limit on commands like `cargo add` and `cargo update`
+As such, it would be useful to have an option to put a limit on commands that update the `Cargo.lock` file (not just  `cargo add` and `cargo update` but other commands after editing `Carg.toml` like `cargo check`, etc)
 so that they can only use package releases that are older than some threshold.
 
 Note that this is **not** a full solution to compromised dependencies. It can increase the protection against certain types of

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -245,7 +245,6 @@ In addition to what is specified above
     but if already present in `Cargo.lock`, they are left in place.
   * If no version satisfies both the version requirement and the minimum publish age,
     the resolve will error.
-  * Precedence with `resolver.incompatible-rust-version` is unspecified (but `resolver.incompatible-rust-version` will likely have higher precedence)
   * A status message will be printed when selecting a non-latest version as well for incompatible versions.
 * `cargo update` specifically:
   * If `--precise` is used, that version will be used, even if it

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -8,7 +8,7 @@
 
 This proposal adds a new configuration option to cargo that specifies a minimum age for package
 updates. When adding or updating a dependency, cargo won't use a version of that crate that
-is newer than the minimum age, unless no possible version is older.
+is newer than the minimum age by default with a way to override to get urgent security fixes.
 
 ## Motivation
 [motivation]: #motivation

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -499,6 +499,14 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 ## Unresolved Questions
 [unresolved-questions]: #unresolved-questions
 
+### Before RFC acceptance
+
+* Can we, and should we, make any guarantees about security when using this feature,
+  such as "a malicious version of a crate will not compromise the build
+  if published within the minimum publish age window"?
+
+### Before stabilization
+
 * Would it be better to have `registry.min-publish-age` be the global setting, and `registries.crates-io.min-publish-age` be the setting for the crates.io registry?
   The current proposal is based on precedent of "credential-provider" and "global-credential-provider", but perhaps we shouldn't follow that precedent?
 * How do we make it clear when things are held back?
@@ -508,9 +516,6 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 * Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
 * `deny` precedence between this and `incompatible-rust-version`?
   * Both produce errors, but `incompatible-rust-version` will likely be evaluated first to increase the chance of builds succeeding.
-* Can we, and should we, make any guarantees about security when using this feature,
-  such as "a malicious version of a crate will not compromise the build
-  if published within the minimum publish age window"?
 
 ## Future Possibilities
 [future-possibilities]: #future-possibilities

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -281,16 +281,6 @@ Furthermore, these tools depend on the existence of a `Cargo.lock` file to lock 
 strict version constraints in `Cargo.toml`. If a `Cargo.lock` file does not yet exist, commands such as `cargo build` won't
 be protected.
 
-### Using Cargo.toml and Cargo.lock
-
-You can pin versions in your `Cargo.toml` but that is a manual process and doesn't cover transitive
-dependencies.
-
-`Cargo.lock` records versions but those are at the time of last change.
-Adding a new dependency can cause you to pull in transitive dependencies that are outside
-your desired minimum age. There isn't a manageable way to run `cargo update` and intentionally
-get versions that are inside of your desired minimum age.
-
 ### Configuration Locations and Names
 
 The locations and names of the configuration options in this proposal were chosen to be
@@ -325,6 +315,12 @@ This makes it less necessary to have more complicated configuration for rules fo
 and excluding sets of packages from the age policy, or setting different age policies
 for different packages.
 
+### Using Cargo.toml and Cargo.lock (i.e. "do nothing")
+
+You can pin versions in your `Cargo.toml` but that is a manual process and doesn't cover transitive
+dependencies.
+
+Users can manage all of their direct and transitive dependencies in a `Cargo.lock` file but that is tedious and it is easy to overlook new entries on implicit lockfile changes.
 
 ## Prior Art
 [prior-art]: #prior-art

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -236,6 +236,10 @@ In addition to what is specified above
   * They do not apply to git or path dependencies, in
     part because there is not always an obvious publish time, or a way to find alternative versions.
   * They do not apply to registries that don't set `pubtime`, as there is no reliable way to know when the version was published.
+  * For [source replacement],
+    registry mirrors are expected to preserve `pubtime` from the index to be applicable.
+    Local registries and directory (vendored) sources typically don't have `pubtime`,
+    so the check does not apply.
 * When resolving dependencies:
   * Pubtime-incompatible versions are not considered for new resolves,
     but if already present in `Cargo.lock`, they are left in place.
@@ -246,6 +250,8 @@ In addition to what is specified above
 * `cargo update` specifically:
   * If `--precise` is used, that version will be used, even if it
     newer than the policy would otherwise allow
+
+[source replacement]: https://doc.rust-lang.org/cargo/reference/source-replacement.html
 
 ## Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -162,7 +162,7 @@ incompatible-publish-age = "deny" # Specifies how resolver reacts to these
 min-publish-age = "..."  # Override `registry.global-min-publish-age` for this registry
 
 [registry]
-min-publish-age = "0"  # Override `registry.global-min-publish-age` for crates.io
+min-publish-age = "..."  # Override `registry.global-min-publish-age` for crates.io
 global-min-publish-age = "0"  # Minimum time span allowed for packages from this registry
  ```
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -250,6 +250,7 @@ In addition to what is specified above
     as well for incompatible versions.
   * [`cargo update --precise`] can override the policy,
     just as it can select a yanked version.
+  * `cargo install` skips pubtime-incompatible versions as well
 
 [source replacement]: https://doc.rust-lang.org/cargo/reference/source-replacement.html
 [yanked versions]: https://doc.rust-lang.org/cargo/reference/resolver.html#yanked-versions

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -200,7 +200,7 @@ See the resolver chapter for more details.
 
 * Type: String
 * Default: none
-* Environment: `CARGO_REGISTRY_<name>_MIN_PUBLISH_AGE`
+* Environment: `CARGO_REGISTRY_MIN_PUBLISH_AGE`
 
  Specifies the minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages from crates.io not set, `registry.global-min-publish-age` will be used.
 
@@ -215,7 +215,7 @@ Generally, `"0"`, `"N days"`, and `"N weeks"` will be used.
 
 * Type: String
 * Default: `"0"`
-* Environment: `CARGO_GLOBAL_REGISTRY_<name>_MIN_PUBLISH_AGE`
+* Environment: `CARGO_REGISTRY_GLOBAL_MIN_PUBLISH_AGE`
 
  Specifies the global minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages. If `min-publish-age` is not set for a specific registry using `registries.<name>.min-publish-age`, Cargo will use this minimum publish age.
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -150,15 +150,15 @@ This RFC adds a few new configuration options to [cargo configuration](https://d
 ### Added to [Configuration Format](https://doc.rust-lang.org/cargo/reference/config.html#configuration-format)
 
 ```toml
- [resolver]
- incompatible-publish-age = "fallback" # Specifies how resolver reacts to these
+[resolver]
+incompatible-publish-age = "fallback" # Specifies how resolver reacts to these
 
- [registries.<name>]
- min-publish-age = "..."  # Override `registry.global-min-publish-age` for this registry
+[registries.<name>]
+min-publish-age = "..."  # Override `registry.global-min-publish-age` for this registry
 
- [registry]
- min-publish-age = "0"  # Override `registry.global-min-publish-age` for crates.io
- global-min-publish-age = "0"  # Minimum time span allowed for packages from this registry
+[registry]
+min-publish-age = "0"  # Override `registry.global-min-publish-age` for crates.io
+global-min-publish-age = "0"  # Minimum time span allowed for packages from this registry
  ```
 
 ### Added to [`[resolver]`](https://doc.rust-lang.org/cargo/reference/config.html#resolver)

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -119,7 +119,7 @@ min-publish-age = "5 days"
 
 This will use a minimum publish age of
 - 5 days for crates.io
-- 2 hours for crates.exalmple.com
+- 2 hours for crates.example.com
 - no minimum for registry.local
 - 2 days for any other registry.
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -257,7 +257,8 @@ The minimum publish age check applies to the following dependency sources:
   registry mirrors are expected to preserve `pubtime` from the index to be applicable.
   Local registries and directory (vendored) sources typically don't have `pubtime`,
   so the check does not apply.
-* `cargo install` also skips pubtime-incompatible versions.
+* `cargo install` also skips pubtime-incompatible versions
+  as the `[resolver]` table is documented as not applying to `cargo install`.
 
 [source replacement]: https://doc.rust-lang.org/cargo/reference/source-replacement.html
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -10,6 +10,15 @@ This proposal adds a new configuration option to cargo that specifies a minimum 
 updates. When adding or updating a dependency, cargo won't use a version of that crate that
 is newer than the minimum age by default with a way to override to get urgent security fixes.
 
+An example configuration would be:
+
+```toml
+[registry]
+global-min-publish-age = "14 days"
+```
+
+Or it could be specified on the command line with `--config registry.global-min-publish-age '14 days'`.
+
 ## Motivation
 [motivation]: #motivation
 
@@ -26,12 +35,9 @@ and when that release is used by your project. See for example the blog post
 
 Another reason to wish to delay using a new release, is because new versions can introduce new bugs. By only
 using versions that have had some time to "mature", you can mitigate the risk of encountering those bugs a little.
-Hopefully the bugs will be found before you start using the new version and thus could update to a version that fixes those bugs,
-or lock your version, so you don't get the buggy version, if the bugs apply to you.
-
-Although cargo, of course, allows you to specify exact versions in `Cargo.toml` and has a lock file that can freeze the versions used,
-that requires manually inspecting each version of each transitive dependency to confirm it complies with a policy of
-using a version older than some age.
+Different people (or groups of people) have different tolerance for risk, and this provides
+a mechanism whereby new versions can roll out gradually to users depending on the tolerance
+for risk of those users.
 
 As such, it would be useful to have an option to put a limit on commands like `cargo add` and `cargo update`
 so that they can only use package releases that are older than some threshold.
@@ -53,6 +59,10 @@ The `resolver.incompatible-publish-age` configuration can also be used to contro
 publish time is newer than the min-publish-age. By default, it will try to use an older version, unless none is available
 that also complies with the specified version constraint, or the `rust-version`. However by setting this to "allow"
 it is possible to disable the min-publish-age checking.
+
+Most likely, `resolver.incompatible-publish-age` will usually be left at its default of `fallback`, however it may occasionally
+be desirable to use it to temporarily turn off the minimum age check, especially if there are configurations for multiple
+registries.
 
 It is also possible to configure the `min-publish-age` per cargo registry. `registries.<name>.min-publish-age` sets
 the minimum publish age for the `<name>` registry. And `registry.min-publish-age` sets it for the default registry
@@ -162,8 +172,10 @@ than allowed by the appropriate `min-publish-age` setting.
 
 In addition to what is specified above
 
-* `min-publish-age` only apply to dependencies fetched from a registry, such as crates.io. They do not apply to git or path dependencies, in
+* `min-publish-age` only apply to dependencies fetched from a registry that publishes `pubtime`, such as crates.io. They do not apply to git or path dependencies, in
   part because there is not always an obvious publish time, or a way to find alternative versions.
+  They do not apply to registries that don't set `pubtime`, as there is no reliable way to know when the version
+  was published.
 * At this time, if a specific version is explicitly specified in Cargo.toml, or on the command line, that has higher precedence than the publish time check,
   and will be assumed to be valid. In the future it may be possible to change this behavior.
 * `cargo add`
@@ -210,6 +222,16 @@ Having built-in support makes it easier to enforce a minimum publish age policy.
 Furthermore, these tools depend on the existence of a `Cargo.lock` file to lock the versions. Or having
 strict version constraints in `Cargo.toml`. If a `Cargo.lock` file does not yet exist, commands such as `cargo build` won't
 be protected.
+
+### Using Cargo.toml and Cargo.lock
+
+You can pin versions in your `Cargo.toml` but that is a manual process and doesn't cover transitive
+dependencies.
+
+`Cargo.lock` records versions but those are at the time of last change.
+Adding a new dependency can cause you to pull in transitive dependencies that are outside
+your desired minimum age. There isn't a manageable way to run `cargo update` and intentionally
+get versions that are inside of your desired minimum age.
 
 ### Configuration Locations
 
@@ -342,6 +364,7 @@ There is an existing experimental third-party crate that provides a plugin for e
     * Locking message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) is in UTC time, see [Tracking Issue for _lockfile-publish-time_ #16271](https://github.com/rust-lang/cargo/issues/16271), when relative time differences likely make local time more relevant
 * Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
 * `fallback` precedence between this and `incompatible-rust-version`?
+* Can we, and should we make any guarantees about security when using this feature, such as "a release of a malicious version of a crate will not compromise the build
 
 ## Future Possibilities
 [future-possibilities]: #future-possibilities
@@ -349,8 +372,11 @@ There is an existing experimental third-party crate that provides a plugin for e
 - Support "deny" for `resolver.incompatible-publish-age`.
     - This is initially excluded, because it isn't clear how this should behave with respect to versions already in Cargo.lock, or use with the `--precise` flag.
     - What would an error look like?
+    - How would you be able to override this for specific crates for important security updates, or for related crates that should be released at the same time?
 - Add a way to specify that the minimum age doesn't apply to certain packages. For example, by having an array of crates that should always use the newest version.
     - I excluded this from the initial RFC, because implementing it adds significant complexity to the proposal, and it is relatively easy to work around by explicitly updating
       those packages to newer versions in Cargo.toml and/or Cargo.lock.
     - This may be more important if support for "deny" is added to `resolver.incompatible-publish-age`.
-
+- Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
+- Provide a mechanism to compare the publish time against a time other than the current system time. For example, comparing to the time of some snapshot, or the timestamp
+  of a local cache.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -1,6 +1,6 @@
 - Feature Name: cargo_min_publish_age
 - Start Date: 2026-01-21
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3923](https://github.com/rust-lang/rfcs/pull/3923)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 ## Summary

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -132,6 +132,8 @@ $ # or ...
 $ cargo add some-package@1.3.0
 ```
 
+`cargo update` won't preserve the use of the new version after a `cargo generate-lockfile` while `cargo add` will.
+
 This is due to the `resolver.incompatible-publish-age = "fallback"` default which preserves your `Cargo.lock` and respects too-high of version requirements despite your minimum-release age.
 
 [1]: https://doc.rust-lang.org/cargo/reference/config.html

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -240,17 +240,20 @@ In addition to what is specified above
     registry mirrors are expected to preserve `pubtime` from the index to be applicable.
     Local registries and directory (vendored) sources typically don't have `pubtime`,
     so the check does not apply.
-* When resolving dependencies:
-  * Pubtime-incompatible versions are not considered for new resolves,
+* When resolving dependencies,
+  pubtime-incompatible versions follow the same rules as [yanked versions]:
+  * They are not considered for new resolves,
     but if already present in `Cargo.lock`, they are left in place.
   * If no version satisfies both the version requirement and the minimum publish age,
     the resolve will error.
-  * A status message will be printed when selecting a non-latest version as well for incompatible versions.
-* `cargo update` specifically:
-  * If `--precise` is used, that version will be used, even if it
-    newer than the policy would otherwise allow
+  * A status message will be printed when selecting a non-latest version
+    as well for incompatible versions.
+  * [`cargo update --precise`] can override the policy,
+    just as it can select a yanked version.
 
 [source replacement]: https://doc.rust-lang.org/cargo/reference/source-replacement.html
+[yanked versions]: https://doc.rust-lang.org/cargo/reference/resolver.html#yanked-versions
+[`cargo update --precise`]: https://doc.rust-lang.org/cargo/commands/cargo-update.html#option-cargo-update---precise
 
 ## Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -444,8 +444,6 @@ Some precedents in Cargo
 
 pre-release: requires opt-in through version requirement. Unstable support to force it with `--precise` but that doesn't apply recursively.
 
- We use the term `publish` and not `release`
-
 ## Unresolved Questions
 [unresolved-questions]: #unresolved-questions
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -489,12 +489,6 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
   * We list MSRVs for unselected packages, should we also list publish times? I'm assuming that should be in local time
   * Locking message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) is in UTC time, see [Tracking Issue for _lockfile-publish-time_ #16271](https://github.com/rust-lang/cargo/issues/16271), when relative time differences likely make local time more relevant
 * Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
-* Is `resolver.incompatible-publish-age` needed at all?
-  Setting `registry.global-min-publish-age = "0"` achieves the same as `resolver.incompatible-publish-age = "allow"`.
-  The resolver setting provides a clearer intent for transient overrides
-  and a path to `fallback` in the future, but adds configuration complexity,
-  especially if we never expand the values beyond "allow" and "deny".
-  The resolver setting also doesn't support per-registry config.
 * `deny` precedence between this and `incompatible-rust-version`?
   * Both produce errors, but `incompatible-rust-version` will likely be evaluated first to increase the chance of builds succeeding.
 * Can we, and should we make any guarantees about security when using this feature, such as "a release of a malicious version of a crate will not compromise the build

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -328,6 +328,11 @@ Exclude lists tend to be used either for:
 - Marking a source as always trusted: we have this covered through per-registry configuration
 
 One problem with an exclude list is that they tend to be a static solution (all versions) for a transient problem (a subset of versions).
+This can lead people open to an attack after a high-value upgrade.
+We could make the exclude list use the [Package ID Spec](https://doc.rust-lang.org/cargo/reference/pkgid-spec.html) format and even require a full version to be specified.
+
+Users likely will need to exclude transitive dependencies as well.
+For instance, to use a too-new version of `clap`, you may also need to exclude `clap_builder`, `clap_derive`, and `clap_lex`.
 
 An exclude list can always be added in the future if a strong enough use case presents itself.
 By delaying, we can also take into account any future changes.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -279,19 +279,19 @@ clear that this only applies to crates that are published in a registry.
 
 `cooldown` was avoided due to term generally referring to throttling while we are looking for a certain maturity.
 
-### fallback and deny
+### `fallback` and `deny`
 
-We default `resolver.incompatible-publish-age` to "fallback" rather than deny
-and defer support for "deny" to future possibilities, because that allows user to allow
+We default `resolver.incompatible-publish-age` to `fallback` rather than `deny`
+and defer support for `deny` to future possibilities, because that allows
 users to easily override the minimum age for specific crates when necessary.
 
-Specifically, with "fallback" it is possible to override the minimum age behavior for
-specific crates by specifying a more specific version in Cargo.toml, or using `cargo update --precise`.
+Specifically, with `fallback` it is possible to override the minimum age behavior for
+specific crates by specifying a more specific version in `Cargo.toml`, or using `cargo update --precise`.
 
-Furthermore, with "fallback", and the ability to override versions as mentioned above,
+Furthermore, with `fallback`, and the ability to override versions as mentioned above,
 it isn't as critical to have a way to list crates to exclude from the rule in configuration.
 
-We anticipate that "fallback" will be sufficient for most use cases, but the possibility of a  "deny" option
+We anticipate that `fallback` will be sufficient for most use cases, but the possibility of a `deny` option
 can be revisited if necessary.
 
 ### Per-registry configuration

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -447,6 +447,8 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 ## Unresolved Questions
 [unresolved-questions]: #unresolved-questions
 
+* When a version requirement is incompatible with minimum-release age, should we pick the oldest or newest version?
+* Should we name this to also cover the [`cargo generate-lockfile --publish-time`](https://github.com/rust-lang/cargo/issues/16271) use case?
 * Would it be better to have `registry.min-publish-age` be the global setting, and `registries.crates-io.min-publish-age` be the setting for the crates.io registry?
   The current proposal is based on precedent of "credential-provider" and "global-credential-provider", but perhaps we shouldn't follow that precedent?
 * How do we make it clear when things are held back?
@@ -472,6 +474,3 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
     - Note: an exclude list of just names is helpful for "I have a trusted package source" but an attack vector for "I need a security fix now" because it leaves it to the user to remove it once it is no longer needed
   - This may be more important if support for "deny" is added to `resolver.incompatible-publish-age`.
 - Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
-- Provide a mechanism to compare the publish time against a time other than the current system time. For example, comparing to the time of some snapshot, or the timestamp
-  of a local cache.
-- Allow specifying a timestamp for the `min-publish-age`.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -230,29 +230,28 @@ Generally, `0`, `"N days"`, and `"N weeks"` will be used.
 
 In addition to what is specified above
 
-* `min-publish-age` only apply to dependencies fetched from a registry that publishes `pubtime`, such as crates.io. They do not apply to git or path dependencies, in
-  part because there is not always an obvious publish time, or a way to find alternative versions.
-  They do not apply to registries that don't set `pubtime`, as there is no reliable way to know when the version
-  was published.
-* At this time, if a specific version is explicitly specified in Cargo.toml, or on the command line, that has higher precedence than the publish time check,
-  and will be assumed to be valid. In the future it may be possible to change this behavior.
+* `min-publish-age` only apply to dependencies fetched from a registry that publishes `pubtime`, such as crates.io.
+  * They do not apply to git or path dependencies, in
+    part because there is not always an obvious publish time, or a way to find alternative versions.
+  * They do not apply to registries that don't set `pubtime`, as there is no reliable way to know when the version was published.
+* If a specific version is explicitly specified in Cargo.toml, or on the command line, that has higher precedence than the publish time check,
+  and will be assumed to be valid.
 * `cargo add`
-    * If a version is not explicitly specified by the user and the package is fetched from a registry (not a path or git), `min-publish-age` options
-      will be respected.
+    * If a version is not explicitly specified by the user and the package is fetched from a registry (not a path or git), the version requirement will default to one that includes a version compatible with `min-publish-age`
 * `cargo install`
     * If a specific version is not specified by the user, respect `registries.min-publish-age` for the version of the crate itself,
       as well as transitive dependencies when possible.
-* `cargo update`
-    * Unless `--precise` is used to specify a specific version, any crates updated from the registry will only consider versions published
-      before the time specified by the appropriate `min-publish-age` option. If `--precise` is used, that version will be used, even if it
-      newer than the policy would otherwise allow (although in the future, there may be an option to deny that).
+* When resolving dependencies:
+    * Any crates updated from the registry will only consider versions published
+      before the time specified by the appropriate `min-publish-age` option.
     * If the version of a crate in the lockfile is already newer than `min-publish-age`, then `cargo update` will not update that crate, nor will
       it downgrade to an older version. It will leave the version as it is.
-    * When locking to an older version, that will be included like with the MSRV-aware resolver
-* When a lockfile is generated, as with `cargo generate-lockfile` or other commands such as `cargo build` that can do so, then versions will be
-  selected that comply with the `min-publish-age` policy, if possible.
-* If the only version of a crate that satisfies the `min-publish-age` constraint is a yanked version, it will behave as if no versions satisfied the
-  `min-publish-age` constraint. In other words, yanked versions has higher priority than the `min-publish-age` configuration.
+    * Yanked status has higher precedence than `resolver.incompatible-publish-age`
+    * Precedence with `resolver.incompatible-rust-version` is unspecified (but `resolver.incompatible-rust-version` will likely have higher precedence)
+    * A status message will be printed when selecting a non-latest version as well for incompatible versions.
+* `cargo update` specifically:
+    * If `--precise` is used, that version will be used, even if it
+      newer than the policy would otherwise allow
 
 ## Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -294,6 +294,17 @@ it isn't as critical to have a way to list crates to exclude from the rule in co
 We anticipate that `fallback` will be sufficient for most use cases, but the possibility of a `deny` option
 can be revisited if necessary.
 
+### Per-registry configuration
+
+Allowing the minimum age to be configurable per registry provides a simple mechanism
+to use different minimum ages for different sets of packages, including possibly no
+minimum in common situations such as using an internal registry where the crates
+are completely trusted.
+
+This makes it less necessary to have more complicated configuration for rules for including
+and excluding sets of packages from the age policy, or setting different age policies
+for different packages.
+
 ### Exclude list
 
 Exclude lists tend to be used either for:
@@ -307,17 +318,6 @@ By delaying, we can also take into account any future changes.
 For example, if the focus is on different levels trust within the same registry,
 we could design a solution around [registry namespacing](https://internals.rust-lang.org/t/survey-of-organizational-ownership-and-registry-namespace-designs-for-cargo-and-crates-io/24027/4),
 assuming support is added.
-
-### Per-registry configuration
-
-Allowing the minimum age to be configurable per registry provides a simple mechanism
-to use different minimum ages for different sets of packages, including possibly no
-minimum in common situations such as using an internal registry where the crates
-are completely trusted.
-
-This makes it less necessary to have more complicated configuration for rules for including
-and excluding sets of packages from the age policy, or setting different age policies
-for different packages.
 
 ### Using Cargo.toml and Cargo.lock (i.e. "do nothing")
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -281,18 +281,18 @@ This helps with the above disambiguation and for clarity in discussing this as a
 
 ### `fallback` and `deny`
 
-We default `resolver.incompatible-publish-age` to `fallback` rather than `deny`
-and defer support for `deny` to future possibilities, because that allows
-users to easily override the minimum age for specific crates when necessary.
+`resolver.incompatible-publish-age` is starting with just support for `allow` and `fallback`, leaving `deny` for future consideration,
+because that allows users to easily override the minimum age for specific crates when necessary.
 
 Specifically, with `fallback` it is possible to override the minimum age behavior for
 specific crates by specifying a more specific version in `Cargo.toml`, or using `cargo update --precise`.
 
 Furthermore, with `fallback`, and the ability to override versions as mentioned above,
-it isn't as critical to have a way to list crates to exclude from the rule in configuration.
+we can defer support for an exclusion list as well,
+simplifying the design work we need to do now and being able to gather more requirements in case it becomes worth addressing in the future.
 
-We anticipate that `fallback` will be sufficient for most use cases, but the possibility of a `deny` option
-can be revisited if necessary.
+The one danger of `fallback` is that a malicious actor with the right permissions can publish a malicious version and yank the safe versions,
+bypassing the `min-publish-age`.
 
 ### Timestamp vs duration
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -38,10 +38,9 @@ Having everyone discover these problems at once leads to a wider, costlier disru
 Some maintainers are fine being on the bleeding edge, taking on those costs, and act as a canary for the ecosystem.
 Those who are more risk averse can choose how much stagnation they are willing to accept for others to discover these problems and get them worked out.
 Maintainers may even want to blend these in one project: keep risks down for local development while CI has a dependency version canary job to identify future problems and track their status.
-Granted, any fixes will also be subject to the minimum-release age but at least these will be available to upgrade to so long as there is an exception mechanism.
+Granted, this only helps if the problems are discovered by yourself or others.  Any fixes will also be subject to the minimum-release age but at least these will be available to upgrade to so long as there is an exception mechanism.
 
-As such, it would be useful to have an option to put a limit on commands that update the `Cargo.lock` file (not just  `cargo add` and `cargo update` but other commands after editing `Carg.toml` like `cargo check`, etc)
-so that they can only use package releases that are older than some threshold.
+Allowing maintainers to encourage a certain degree of maturity for dependency versions can help these use cases.
 
 Note that this is **not** a full solution to compromised dependencies. It can increase the protection against certain types of
 "supply chain" attacks, but not all of them. As such, using this feature should not be relied upon for security by itself.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -128,19 +128,8 @@ error: failed to select a version for the requirement `some-package = "^1.3"`
 In some cases, it may be desirable to use a version that is newer than the minimum publish age.
 For example, `some-package` from [earlier](#guide-level-explanation) has a fix for a vulnerability in v1.3.0.
 
-Since too-new versions follow yanked semantics,
-the same override mechanisms apply:
-
-```console
-$ cargo update some-package --precise 1.3.0
-warning: selected package `some-package@1.3.0` is too new
-  = note: published 2 days ago, minimum age 14 days
-    Updating some-package v1.2.3 -> v1.3.0
-```
-
-A limitation of `cargo update --precise` is that you can only force the use of that one package
-but it may have dependencies on new versions as well.
-You can temporarily disable the check to accomplish this:
+The `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` environment variable
+can temporarily disable the check:
 
 ```console
 $ CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow cargo update clap --precise 4.5.3
@@ -149,8 +138,7 @@ Updating clap_derive 4.3.0 -> 4.5.3 (published 2 days ago, minimum age 14 days)
 Updating clap_builder 4.3.0 -> 4.5.3 (published 2 days ago, minimum age 14 days)
 ```
 
-For a broader override, the `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` environment variable
-disables the check entirely.
+Once the versions are recorded in `Cargo.lock`, subsequent resolves will keep them.
 
 [1]: https://doc.rust-lang.org/cargo/reference/config.html
 [^1]: As specified in `.cargo/config.toml` files
@@ -356,7 +344,7 @@ for different packages.
 ### Exclude list
 
 Exclude lists tend to be used either for:
-- Forcing a specific newer version: we have this covered through `cargo update --precise`
+- Forcing a specific newer version: we have this covered through `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` combined with `cargo update --precise`
 - Marking a source as always trusted: we have this covered through per-registry configuration
 
 One problem with an exclude list is that they tend to be a static solution (all versions) for a transient problem (a subset of versions).

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -7,10 +7,9 @@
 [summary]: #summary
 
 This proposal adds a new configuration option to cargo allowing users to specify a minimum age for dependency versions.
-When adding or updating a dependency, cargo will prefer versions of a registry crate that
-are older than the minimum age.
-`Cargo.lock`, version requirements, and `cargo update --precise` can bypass this, allowing
-for exceptions like for urgent security fixes.
+When specified, Cargo won't use a version of a registry crate
+that is newer than the minimum age,
+with a way to override for exceptions like urgent security fixes.
 
 An example configuration would be:
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -407,6 +407,7 @@ There is an existing experimental third-party crate that provides a plugin for e
     * Locking message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) is in UTC time, see [Tracking Issue for _lockfile-publish-time_ #16271](https://github.com/rust-lang/cargo/issues/16271), when relative time differences likely make local time more relevant
 * Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
 * `fallback` precedence between this and `incompatible-rust-version`?
+    * Most likely, `incompatible-rust-version` should have higher precedence to increase the chance of builds succeeding.
 * Can we, and should we make any guarantees about security when using this feature, such as "a release of a malicious version of a crate will not compromise the build
 
 ## Future Possibilities
@@ -423,3 +424,4 @@ There is an existing experimental third-party crate that provides a plugin for e
 - Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
 - Provide a mechanism to compare the publish time against a time other than the current system time. For example, comparing to the time of some snapshot, or the timestamp
   of a local cache.
+- Allow specifying a timestamp for the `min-publish-age`.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -34,10 +34,10 @@ For more background on version maturity requirements as a risk mitigation, see
 There would be value in a gradual roll out scheme for the ecosystem.
 New versions can introduce inadvertent breaking changes, bugs, or security vulnerabilities.
 Having everyone discover these problems at once leads to a wider, costlier disruption to the ecosystem.
-Some maintainers are fine being on the bleeding edge, taking on those costs, and act as a canary for the ecosystem.
+Some maintainers are fine being on the bleeding edge, taking on those costs, and acting as a canary for the ecosystem.
 Those who are more risk averse can choose how much stagnation they are willing to accept for others to discover these problems and get them worked out.
 Maintainers may even want to blend these in one project: keep risks down for local development while CI has a dependency version canary job to identify future problems and track their status.
-Granted, this only helps if the problems are discovered by yourself or others.  Any fixes will also be subject to the minimum-release age but at least these will be available to upgrade to so long as there is an exception mechanism.
+Granted, this only helps if the problems are discovered by yourself or others. Any fixes will also be subject to the minimum-release age but at least these will be available to upgrade to so long as there is an exception mechanism.
 
 Allowing maintainers to encourage a certain degree of maturity for dependency versions can help these use cases.
 
@@ -202,7 +202,7 @@ See the resolver chapter for more details.
 * Default: none
 * Environment: `CARGO_REGISTRY_MIN_PUBLISH_AGE`
 
- Specifies the minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages from crates.io not set, `registry.global-min-publish-age` will be used.
+ Specifies the minimum timespan since a version's `pubtime` that it may be considered for `resolver.incompatible-publish-age` for packages from crates.io. If not set, `registry.global-min-publish-age` will be used.
 
  It supports the following values:
 
@@ -233,7 +233,7 @@ are considered pubtime-incompatible.
 When [`resolver.incompatible-publish-age`] is set to `deny`,
 the resolver will ignore these versions
 unless they already exist in the `Cargo.lock` file.
-Setting the config to `allow` would disables the check,
+Setting the config to `allow` would disable the check,
 which if combined with `cargo update --precise`,
 cargo would pull in a specific version and its transitive dependencies.
 
@@ -269,7 +269,7 @@ However, most likely, there will be a spread of values used, depending on risk t
 cases.
 
 Also, even if all users of a crate set a minimum publish age there is still value in a delay, because it provides time for automated security scanners, and human reviewers
-to review the changes before the new version is pulled in by updates. And in the case of a malicious release made using compromised credentials, it give the actual developer
+to review the changes before the new version is pulled in by updates. And in the case of a malicious release made using compromised credentials, it gives the actual developer
 time to realize their credentials have been compromised and yank the version before it is widely used.
 
 ### Disjoint resolver config values
@@ -295,7 +295,7 @@ clear that this only applies to crates that are published in a registry.
 `publish` is redundant with this being in the `registry` table.
 This helps with the above disambiguation and for clarity in discussing this as a shorthand.
 
-`cooldown` was avoided due to term generally referring to throttling while we are looking for a certain maturity.
+`cooldown` was avoided due to the term generally referring to throttling while we are looking for a certain maturity.
 
 ### Starting with `deny`
 
@@ -308,7 +308,7 @@ so there are no gaps that would cause spurious errors.
 
 A `fallback` option would deprioritize too-new versions but still allow them as a last resort.
 This is deferred because it opens the yank attack vector:
-a malicious actor with right permissions could publish a malicious version and yank the safe versions.
+a malicious actor with the right permissions could publish a malicious version and yank the safe versions.
 It then forces the resolver to fall back to the malicious too-new version.
 `deny` prevents this by erroring instead of falling back.
 
@@ -323,7 +323,7 @@ rather than disabling the check entirely with `allow`.
 
 ### Timestamp vs duration
 
-Some prior art
+Some prior art:
 - exclusively use a timestamp
 - allow either a timestamp or a relative time within the same field
 
@@ -335,7 +335,7 @@ Designing the field to support both would create a trap for users trying to repr
 Even if they do remember to take the existing duration into account,
 it would be more convenient if they can be set separately.
 
-Setting the timestamp to resolve to is left as a future possibility
+Setting the timestamp to resolve to is left as a future possibility.
 
 ### Per-registry configuration
 
@@ -355,7 +355,7 @@ Exclude lists tend to be used either for:
 - Marking a source as always trusted: we have this covered through per-registry configuration
 
 One problem with an exclude list is that they tend to be a static solution (all versions) for a transient problem (a subset of versions).
-This can lead people open to an attack after a high-value upgrade.
+This can leave people open to an attack after a high-value upgrade.
 An exclude list of just names is helpful for "I have a trusted package source" scenario,
 but less so for "I need a security fix now".
 The user must remember to remove the exclusion once it is no longer needed,
@@ -367,7 +367,7 @@ For instance, to use a too-new version of `clap`, you may also need to exclude `
 
 An exclude list can always be added in the future if a strong enough use case presents itself.
 By delaying, we can also take into account any future changes.
-For example, if the focus is on different levels trust within the same registry,
+For example, if the focus is on different levels of trust within the same registry,
 we could design a solution around [registry namespacing](https://internals.rust-lang.org/t/survey-of-organizational-ownership-and-registry-namespace-designs-for-cargo-and-crates-io/24027/4),
 assuming support is added.
 
@@ -430,7 +430,7 @@ environment variable.
 The `cooldown` option provides a number of settings, including:
 
 - `default-days` – Default minimum age of release, in days
-- `semver-major-days`, `semver-minor-days`, `smever-patch-days` -- Override the cooldown/minimum-release-age based on what kind of release it is.
+- `semver-major-days`, `semver-minor-days`, `semver-patch-days` -- Override the cooldown/minimum-release-age based on what kind of release it is.
 - `include` / `exclude` – a list of packages to include/exclude in the "cooldown". Supports wildcards. `exclude` has higher priority than `include`.
 
 "Security" updates bypass the `cooldown` settings.
@@ -445,7 +445,7 @@ The options below can be provided in global, or project-specific configuration f
 
 `minimumReleaseAge` specifies a duration which all updates must be older than for renovate to create an update. It looks like the duration specification uses units (ex. "3 days"), however, again I can't find a precise specification for the syntax.
 
-It is possible to create separate rules with different `minimumReleaseAge` configurations, on per-package basis, or across groups of packages/registries.
+It is possible to create separate rules with different `minimumReleaseAge` configurations, on a per-package basis, or across groups of packages/registries.
 
 "Security" updates bypass the minimum release age checks.
 
@@ -508,7 +508,9 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 * Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
 * `deny` precedence between this and `incompatible-rust-version`?
   * Both produce errors, but `incompatible-rust-version` will likely be evaluated first to increase the chance of builds succeeding.
-* Can we, and should we make any guarantees about security when using this feature, such as "a release of a malicious version of a crate will not compromise the build
+* Can we, and should we, make any guarantees about security when using this feature,
+  such as "a malicious version of a crate will not compromise the build
+  if published within the minimum publish age window"?
 
 ## Future Possibilities
 [future-possibilities]: #future-possibilities

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -138,8 +138,16 @@ warning: selected package `some-package@1.3.0` is too new
     Updating some-package v1.2.3 -> v1.3.0
 ```
 
-To record the intent more permanently,
-bump the version requirement in `Cargo.toml`.
+A limitation of `cargo update --precise` is that you can only force the use of that one package
+but it may have dependencies on new versions as well.
+You can temporarily disable the check to accomplish this:
+
+```console
+$ CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow cargo update clap --precise 4.5.3
+Updating clap 4.3.0 -> 4.5.3 (published 2 days ago, minimum age 14 days)
+Updating clap_derive 4.3.0 -> 4.5.3 (published 2 days ago, minimum age 14 days)
+Updating clap_builder 4.3.0 -> 4.5.3 (published 2 days ago, minimum age 14 days)
+```
 
 For a broader override, the `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` environment variable
 disables the check entirely.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -33,11 +33,7 @@ are older than some age. This creates a window of time between when a dependency
 and when that release is used by your project. See for example the blog post
 "[We should all be using dependency cooldowns](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns)".
 
-Another reason to wish to delay using a new release, is because new versions can introduce new bugs. By only
-using versions that have had some time to "mature", you can mitigate the risk of encountering those bugs a little.
-Different people (or groups of people) have different tolerance for risk, and this provides
-a mechanism whereby new versions can roll out gradually to users depending on the tolerance
-for risk of those users.
+Another reason to wish to delay using a new release, is because new versions can introduce regressions. Different projects have different risks tolerances for regressions and by giving projects control over how mature their dependencies are, they can choose the level of risk they will accept.  This has the effect on the ecosystem of creating a gradual roll out for package versions where early adopters help to mature the package by the time it makes it to the more risk averse projects.  Granted, the fixes will have the same minimum age requirement but projects can choose to use newer versions to get the fixes relevant to them.
 
 As such, it would be useful to have an option to put a limit on commands like `cargo add` and `cargo update`
 so that they can only use package releases that are older than some threshold.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -267,6 +267,8 @@ In addition to what is specified above
 ## Drawbacks
 [drawbacks]: #drawbacks
 
+### Slower problem discovery
+
 The biggest drawback is that if this is widely used, it could potentially lead to it taking longer for problems to be discovered after a version is published.
 However, most likely, there will be a spread of values used, depending on risk tolerance, and hopefully the result is actually that there will be a more gradual rollout in most
 cases.
@@ -274,6 +276,13 @@ cases.
 Also, even if all users of a crate set a minimum publish age there is still value in a delay, because it provides time for automated security scanners, and human reviewers
 to review the changes before the new version is pulled in by updates. And in the case of a malicious release made using compromised credentials, it give the actual developer
 time to realize their credentials have been compromised and yank the version before it is widely used.
+
+### Disjoint resolver config values
+
+`resolver.incompatible-publish-age` supports `allow`/`deny`
+while `resolver.incompatible-rust-versions` supports `allow`/`fallback`,
+which may be confusing.
+See [Starting with `deny`](#starting-with-deny) for why the value sets differ.
 
 ## Rationale and Alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -47,7 +47,7 @@ The `registry.global-min-publish-age` [configuration option][1][^1] for Cargo ca
 
 When set, it contains a duration specified as an integer followed by a unit of "seconds", "minutes", "days", or "weeks".
 If a new crate would be added with a command such as `cargo add` or `cargo update`, it will use a version with a publish
-time ("pubtime") before that is older than that duration, if possible.
+time ("pubtime") before that is older than that duration, if possible. `cargo` may print a message in such a case.
 
 The `resolver.incompatible-publish-age` configuration can also be used to control how `cargo` handles versions whose
 publish time is newer than the min-publish-age. By default, it will try to use an older version, unless none is available

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -397,7 +397,7 @@ There is an existing experimental third-party crate that provides a plugin for e
 
  [`resolver.incompatible-rust-versions`](https://doc.rust-lang.org/cargo/reference/config.html#resolverincompatible-rust-versions)
 
-     * Controls behavior in relation to your [`package.rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) and those set by potential dependendencies
+     * Controls behavior in relation to your [`package.rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) and those set by potential dependencies
 
      * Values:
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -367,7 +367,7 @@ The options below can be provided in global, or project-specific configuration f
 
 `minimumReleaseAge` specifies a duration which all updates must be older than for renovate to create an update. It looks like the duration specification uses units (ex. "3 days"), however, again I can't find a precise specification for the syntax.
 
-I think it is possible to create separate rules with different `minimumReleaseAge` configurations.
+It is possible to create separate rules with different `minimumReleaseAge` configurations, on per-package basis, or across groups of packages/registries.
 
 "Security" updates bypass the minimum release age checks.
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -121,6 +121,8 @@ the resolve will error, similar to when all matching versions are yanked:
 $ cargo update
 error: failed to select a version for the requirement `some-package = "^1.3"`
   version 1.3.0 is too new (published 2 days ago, minimum age 14 days)
+help: to preserve the min-publish-age, downgrade the version requirement to `"1.1"`
+help: to use `"1.3"` anyways, re-resolve with `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`
 ```
 
 ### Using newer versions

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -267,10 +267,12 @@ time to realize their credentials have been compromised and yank the version bef
 ## Rationale and Alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-### Configuration Locations and Names
+### Configuration Locations
 
 The locations and names of the configuration options in this proposal were chosen to be
 consistent with existing Cargo options, as described in [Related Options in Cargo](#related-options).
+
+### Configuration Names
 
 The term "publish" was used rather than "package", "version", or "release" to make it
 clear that this only applies to crates that are published in a registry.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -449,8 +449,10 @@ There is an existing experimental third-party crate that provides a plugin for e
     - What would an error look like?
     - How would you be able to override this for specific crates for important security updates, or for related crates that should be released at the same time?
 - Add a way to specify that the minimum age doesn't apply to certain packages. For example, by having an array of crates that should always use the newest version.
-    - I excluded this from the initial RFC, because implementing it adds significant complexity to the proposal, and it is relatively easy to work around by explicitly updating
-      those packages to newer versions in Cargo.toml and/or Cargo.lock.
+    - The use case is solved through other means and we'll need to get runtime and gather use cases before deciding how to further evolve this
+    - The "I need a security fix now" use case is handled by  bumping versions in `Cargo.toml` and/or `Cargo.lock`
+    - The "I have a trusted package source" is handled by the making this configurable per-registry
+      - Note: an exclude list of just names is helpful for "I have a trusted package source" but an attack vector for "I need a security fix now" because it leaves it to the user to remove it once it is no longer needed
     - This may be more important if support for "deny" is added to `resolver.incompatible-publish-age`.
 - Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
 - Provide a mechanism to compare the publish time against a time other than the current system time. For example, comparing to the time of some snapshot, or the timestamp

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -49,11 +49,9 @@ Note that this is **not** a full solution to compromised dependencies. It can in
 [guide-level-explanation]: #guide-level-explanation
 
 The `registry.global-min-publish-age` [configuration option][1][^1] for Cargo can be used to specify a minimum age for published versions to use.
-When set, Cargo will select versions with a publish time ("pubtime") that is older than that duration,
-if possible.
-
-This is paired with `resolver.incompatible-publish-age` to control the behavior across all registries,
-whether to `allow` newer packages or only `fallback` to them when no others are available.
+When set, Cargo treats versions with a publish time ("pubtime") newer than that duration like yanked versions:
+Cargo will not use a too-new version unless it is already recorded in `Cargo.lock`,
+and will generate an error if there are no longer any compatible versions.
 
 For example, in your `<repo>/.cargo/config.toml`, you may have:
 
@@ -67,7 +65,7 @@ Running `cargo update` will look something like:
 $ cargo update
 Updating index
  Locking 1 package to recent Rust 1.60 compatible version
-  Adding some-package v1.2.3 (available: v1.6.0, published 2 days ago)
+  Adding some-package v1.2.3 (available: v1.3.0, published 2 days ago)
 ```
 
 While a CI job runs:
@@ -84,14 +82,11 @@ steps:
 ```
 
 This will mean that:
-- Locally, `cargo add foo` will default the version requirement on `foo` to be low enough to support the 7 day old package
-- Locally, `cargo update` will update your `Cargo.lock` to versions within the minimum-release age
-- This CI job will verify the latest versions of your dependencies
 
-Note: this check does not apply to
-- path dependencies
-- git dependencies
-- registries that do not include `pubtime` (crates.io supports it)
+- Locally, `cargo update` will only select versions older than the minimum publish age,
+  e.g., `some-package@1.2.3`
+- This CI job will verify the latest versions of your dependencies,
+  e.g., `some-package@1.3.0`
 
 ### Per-registry configuration
 
@@ -117,23 +112,37 @@ This will use a minimum publish age of
 - no minimum for `my-org`
 - 14 days for any other registry.
 
-### Using newer version
+### When no version matches
 
-In some cases, it may be desirable to use a version that is newer than the minimum publish age.
+If no version of a dependency satisfies both the version requirement and the minimum publish age,
+the resolve will error, similar to when all matching versions are yanked:
 
-Say `some-package` from [earlier](#guide-level-explanation) has a fix for a vulnerability in v1.3.0, you could do one of:
 ```console
-$ cargo update some-package --precise 1.3.0
-Updating index
- Locking 1 package to recent Rust 1.60 compatible version
-  Adding some-package v1.2.3 (published 10 days ago, available: v1.6.0, published 2 days ago)
-$ # or ...
-$ cargo add some-package@1.3.0
+$ cargo update
+error: failed to select a version for the requirement `some-package = "^1.3"`
+  version 1.3.0 is too new (published 2 days ago, minimum age 14 days)
 ```
 
-`cargo update` won't preserve the use of the new version after a `cargo generate-lockfile` while `cargo add` will.
+### Using newer versions
 
-This is due to the `resolver.incompatible-publish-age = "fallback"` default which preserves your `Cargo.lock` and respects too-high of version requirements despite your minimum-release age.
+In some cases, it may be desirable to use a version that is newer than the minimum publish age.
+For example, `some-package` from [earlier](#guide-level-explanation) has a fix for a vulnerability in v1.3.0.
+
+Since too-new versions follow yanked semantics,
+the same override mechanisms apply:
+
+```console
+$ cargo update some-package --precise 1.3.0
+warning: selected package `some-package@1.3.0` is too new
+  = note: published 2 days ago, minimum age 14 days
+    Updating some-package v1.2.3 -> v1.3.0
+```
+
+To record the intent more permanently,
+bump the version requirement in `Cargo.toml`.
+
+For a broader override, the `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` environment variable
+disables the check entirely.
 
 [1]: https://doc.rust-lang.org/cargo/reference/config.html
 [^1]: As specified in `.cargo/config.toml` files

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -230,7 +230,7 @@ Generally, `0`, `"N days"`, and `"N weeks"` will be used.
 
 In addition to what is specified above
 
-* `min-publish-age` only apply to dependencies fetched from a registry that publishes `pubtime`, such as crates.io.
+* `min-publish-age` only applies to dependencies fetched from a registry that publishes `pubtime`, such as crates.io.
   * They do not apply to git or path dependencies, in
     part because there is not always an obvious publish time, or a way to find alternative versions.
   * They do not apply to registries that don't set `pubtime`, as there is no reliable way to know when the version was published.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -494,4 +494,6 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
   and a newer non-yanked version exists,
   Cargo could alert the user that they may want to override with `--precise`.
 - Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
-- A `resolver.now` field for setting the time for which `min-publish-age` should be compared against
+- A `resolver.now` field for setting the reference time that `min-publish-age` is compared against.
+  This could be useful for offline workflows where wall-clock time keeps advancing
+  but the registry index may be stale.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -45,7 +45,7 @@ Note that this is **not** a full solution to compromised dependencies. It can in
 
 The `registry.global-min-publish-age` [configuration option][1][^1] for Cargo can be used to specify a minimum age for published versions to use.
 
-When set, it contains a duration specified as an integer followed by a unit of "seconds", "minutes", "days", "weeks", or "months".
+When set, it contains a duration specified as an integer followed by a unit of "seconds", "minutes", "days", or "weeks".
 If a new crate would be added with a command such as `cargo add` or `cargo update`, it will use a version with a publish
 time ("pubtime") before that is older than that duration, if possible.
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -102,7 +102,7 @@ And `registry.min-publish-age` sets it for crates.io.
 
 For example:
 ```toml
-[registry.my-org]
+[registries.my-org]
 index = "https://my.org"
 min-publish-age = 0 # this registry is fully trusted
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -490,5 +490,8 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
   - The "I need a security fix now" use case is handled by `cargo update --precise` and bumping versions in `Cargo.toml`
   - The "I have a trusted package source" is handled by the making this configurable per-registry
     - Note: an exclude list of just names is helpful for "I have a trusted package source" but an attack vector for "I need a security fix now" because it leaves it to the user to remove it once it is no longer needed
+- When all compatible older-than-min-age versions are yanked
+  and a newer non-yanked version exists,
+  Cargo could alert the user that they may want to override with `--precise`.
 - Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
 - A `resolver.now` field for setting the time for which `min-publish-age` should be compared against

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -237,21 +237,21 @@ In addition to what is specified above
 * If a specific version is explicitly specified in Cargo.toml, or on the command line, that has higher precedence than the publish time check,
   and will be assumed to be valid.
 * `cargo add`
-    * If a version is not explicitly specified by the user and the package is fetched from a registry (not a path or git), the version requirement will default to one that includes a version compatible with `min-publish-age`
+  * If a version is not explicitly specified by the user and the package is fetched from a registry (not a path or git), the version requirement will default to one that includes a version compatible with `min-publish-age`
 * `cargo install`
-    * If a specific version is not specified by the user, respect `registries.min-publish-age` for the version of the crate itself,
-      as well as transitive dependencies when possible.
+  * If a specific version is not specified by the user, respect `registries.min-publish-age` for the version of the crate itself,
+    as well as transitive dependencies when possible.
 * When resolving dependencies:
-    * Any crates updated from the registry will only consider versions published
-      before the time specified by the appropriate `min-publish-age` option.
-    * If the version of a crate in the lockfile is already newer than `min-publish-age`, then `cargo update` will not update that crate, nor will
-      it downgrade to an older version. It will leave the version as it is.
-    * Yanked status has higher precedence than `resolver.incompatible-publish-age`
-    * Precedence with `resolver.incompatible-rust-version` is unspecified (but `resolver.incompatible-rust-version` will likely have higher precedence)
-    * A status message will be printed when selecting a non-latest version as well for incompatible versions.
+  * Any crates updated from the registry will only consider versions published
+    before the time specified by the appropriate `min-publish-age` option.
+  * If the version of a crate in the lockfile is already newer than `min-publish-age`, then `cargo update` will not update that crate, nor will
+    it downgrade to an older version. It will leave the version as it is.
+  * Yanked status has higher precedence than `resolver.incompatible-publish-age`
+  * Precedence with `resolver.incompatible-rust-version` is unspecified (but `resolver.incompatible-rust-version` will likely have higher precedence)
+  * A status message will be printed when selecting a non-latest version as well for incompatible versions.
 * `cargo update` specifically:
-    * If `--precise` is used, that version will be used, even if it
-      newer than the policy would otherwise allow
+  * If `--precise` is used, that version will be used, even if it
+    newer than the policy would otherwise allow
 
 ## Drawbacks
 [drawbacks]: #drawbacks
@@ -409,49 +409,42 @@ There is an existing experimental third-party crate that provides a plugin for e
 ### Related Options in Cargo
 [related-options]: #related-options-in-cargo
 
- Some precedents in Cargo
+Some precedents in Cargo
 
- [`cache.auto-clean-frequency`](https://doc.rust-lang.org/cargo/reference/config.html#cacheauto-clean-frequency)
+[`cache.auto-clean-frequency`](https://doc.rust-lang.org/cargo/reference/config.html#cacheauto-clean-frequency)
 
-     * "never" — Never deletes old files.
-
-     * "always" — Checks to delete old files every time Cargo runs.
-
-     * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
+> * "never" — Never deletes old files.
+> * "always" — Checks to delete old files every time Cargo runs.
+> * An integer followed by “seconds”, “minutes”, “hours”, “days”, “weeks”, or “months”
 
 
- [`resolver.incompatible-rust-versions`](https://doc.rust-lang.org/cargo/reference/config.html#resolverincompatible-rust-versions)
+[`resolver.incompatible-rust-versions`](https://doc.rust-lang.org/cargo/reference/config.html#resolverincompatible-rust-versions)
 
-     * Controls behavior in relation to your [`package.rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) and those set by potential dependencies
-
-     * Values:
-
-       * allow: treat rust-version-incompatible versions like any other version
-       * fallback: only consider rust-version-incompatible versions if no other version matched
-
-
- [`package.resolver`](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) is only a version number. When adding `incompatible-rust-version`, we intentionally deferred anything being done in manifests.
-
- [`[registry]`](https://doc.rust-lang.org/cargo/reference/config.html#registry)
-
-     * Set default registry
-
-     * Sets credential providers for all registries
-
-     * Sets crates.io values
+> * Controls behavior in relation to your [`package.rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) and those set by potential dependencies
+>
+> * Values:
+>
+> * allow: treat rust-version-incompatible versions like any other version
+> * fallback: only consider rust-version-incompatible versions if no other version matched
 
 
- [`[registries]`](https://doc.rust-lang.org/cargo/reference/config.html#registries)
+[`package.resolver`](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) is only a version number. When adding `incompatible-rust-version`, we intentionally deferred anything being done in manifests.
 
-     * Sets registry specific values
+[`[registry]`](https://doc.rust-lang.org/cargo/reference/config.html#registry)
 
+> * Set default registry
+> * Sets credential providers for all registries
+> * Sets crates.io values
 
- `yanked`: can't do new resolves to it but left in if already there. Unstable support to force it with `--precise` but that doesn't apply recursively.
+[`[registries]`](https://doc.rust-lang.org/cargo/reference/config.html#registries)
 
- pre-release: requires opt-in through version requirement. Unstable support to force it with `--precise` but that doesn't apply recursively.
+> * Sets registry specific values
+
+`yanked`: can't do new resolves to it but left in if already there. Unstable support to force it with `--precise` but that doesn't apply recursively.
+
+pre-release: requires opt-in through version requirement. Unstable support to force it with `--precise` but that doesn't apply recursively.
 
  We use the term `publish` and not `release`
-
 
 ## Unresolved Questions
 [unresolved-questions]: #unresolved-questions
@@ -459,27 +452,27 @@ There is an existing experimental third-party crate that provides a plugin for e
 * Would it be better to have `registry.min-publish-age` be the global setting, and `registries.crates-io.min-publish-age` be the setting for the crates.io registry?
   The current proposal is based on precedent of "credential-provider" and "global-credential-provider", but perhaps we shouldn't follow that precedent?
 * How do we make it clear when things are held back?
-    * The "locking" message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) lists one time but the time here is dependent on where any given package is from
-    * We list MSRVs for unselected packages, should we also list publish times? I'm assuming that should be in local time
-    * Locking message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) is in UTC time, see [Tracking Issue for _lockfile-publish-time_ #16271](https://github.com/rust-lang/cargo/issues/16271), when relative time differences likely make local time more relevant
+  * The "locking" message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) lists one time but the time here is dependent on where any given package is from
+  * We list MSRVs for unselected packages, should we also list publish times? I'm assuming that should be in local time
+  * Locking message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) is in UTC time, see [Tracking Issue for _lockfile-publish-time_ #16271](https://github.com/rust-lang/cargo/issues/16271), when relative time differences likely make local time more relevant
 * Implementation wise, will there be much complexity in getting per registry information into `VersionPreferences` and using it?
 * `fallback` precedence between this and `incompatible-rust-version`?
-    * Most likely, `incompatible-rust-version` should have higher precedence to increase the chance of builds succeeding.
+  * Most likely, `incompatible-rust-version` should have higher precedence to increase the chance of builds succeeding.
 * Can we, and should we make any guarantees about security when using this feature, such as "a release of a malicious version of a crate will not compromise the build
 
 ## Future Possibilities
 [future-possibilities]: #future-possibilities
 
 - Support "deny" for `resolver.incompatible-publish-age`.
-    - This is initially excluded, because it isn't clear how this should behave with respect to versions already in Cargo.lock, or use with the `--precise` flag.
-    - What would an error look like?
-    - How would you be able to override this for specific crates for important security updates, or for related crates that should be released at the same time?
+  - This is initially excluded, because it isn't clear how this should behave with respect to versions already in Cargo.lock, or use with the `--precise` flag.
+  - What would an error look like?
+  - How would you be able to override this for specific crates for important security updates, or for related crates that should be released at the same time?
 - Add a way to specify that the minimum age doesn't apply to certain packages. For example, by having an array of crates that should always use the newest version.
-    - The use case is solved through other means and we'll need to get runtime and gather use cases before deciding how to further evolve this
-    - The "I need a security fix now" use case is handled by  bumping versions in `Cargo.toml` and/or `Cargo.lock`
-    - The "I have a trusted package source" is handled by the making this configurable per-registry
-      - Note: an exclude list of just names is helpful for "I have a trusted package source" but an attack vector for "I need a security fix now" because it leaves it to the user to remove it once it is no longer needed
-    - This may be more important if support for "deny" is added to `resolver.incompatible-publish-age`.
+  - The use case is solved through other means and we'll need to get runtime and gather use cases before deciding how to further evolve this
+  - The "I need a security fix now" use case is handled by  bumping versions in `Cargo.toml` and/or `Cargo.lock`
+  - The "I have a trusted package source" is handled by the making this configurable per-registry
+    - Note: an exclude list of just names is helpful for "I have a trusted package source" but an attack vector for "I need a security fix now" because it leaves it to the user to remove it once it is no longer needed
+  - This may be more important if support for "deny" is added to `resolver.incompatible-publish-age`.
 - Potentially support other source of publish time besides the `pubtime` field from a cargo registry.
 - Provide a mechanism to compare the publish time against a time other than the current system time. For example, comparing to the time of some snapshot, or the timestamp
   of a local cache.

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -514,14 +514,9 @@ pre-release: requires opt-in through version requirement. Unstable support to fo
 ## Unresolved Questions
 [unresolved-questions]: #unresolved-questions
 
-### Before RFC acceptance
-
 * Can we, and should we, make any guarantees about security when using this feature,
   such as "a malicious version of a crate will not compromise the build
   if published within the minimum publish age window"?
-
-### Before stabilization
-
 * How do we make it clear when things are held back?
   * The "locking" message for [Cargo time machine (generate lock files based on old registry state) #5221](https://github.com/rust-lang/cargo/issues/5221) lists one time but the time here is dependent on where any given package is from
   * We list MSRVs for unselected packages, should we also list publish times? I'm assuming that should be in local time

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -1,7 +1,7 @@
 - Feature Name: cargo_min_publish_age
 - Start Date: 2026-02-23
 - RFC PR: [rust-lang/rfcs#3923](https://github.com/rust-lang/rfcs/pull/3923)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- Tracking Issue: [rust-lang/cargo#17009](https://github.com/rust-lang/cargo/issues/17009)
 
 ## Summary
 [summary]: #summary

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -257,8 +257,8 @@ The minimum publish age check applies to the following dependency sources:
   registry mirrors are expected to preserve `pubtime` from the index to be applicable.
   Local registries and directory (vendored) sources typically don't have `pubtime`,
   so the check does not apply.
-* `cargo install` also skips pubtime-incompatible versions
-  as the `[resolver]` table is documented as not applying to `cargo install`.
+* `cargo install` is subject to `min-publish-age` and will not select pubtime-incompatible versions.
+  `resolver.incompatible-publish-age` cannot override this as the `[resolver]` table does not apply to `cargo install`.
 
 [source replacement]: https://doc.rust-lang.org/cargo/reference/source-replacement.html
 

--- a/text/3923-cargo-min-publish-age.md
+++ b/text/3923-cargo-min-publish-age.md
@@ -275,6 +275,13 @@ Also, even if all users of a crate set a minimum publish age there is still valu
 to review the changes before the new version is pulled in by updates. And in the case of a malicious release made using compromised credentials, it gives the actual developer
 time to realize their credentials have been compromised and yank the version before it is widely used.
 
+On a related note,
+delayed discovery might make authors feel it is "too late" to yank
+because wall-clock time has passed.
+However, the minimum publish age also means most consumers haven't resolved the new version yet,
+so a yank remains low-disruption for longer than elapsed time alone would suggest.
+The practical yank window is shaped more by adoption than by the calendar.
+
 ### Disjoint resolver config values
 
 `resolver.incompatible-publish-age` supports `allow`/`deny`


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3923)*



<!-- Thank you for trying to improve Rust through the RFC process! -->
<!-- Please add a short summary of your RFC below -->

> [!IMPORTANT]  
> When responding to RFCs, try to use inline review comments (it is possible to leave an inline review comment for the entire file at the top) instead of direct comments for normal comments and keep normal comments for procedural matters like starting FCPs.
>
> This keeps the discussion more organized.

## Summary


This RFC proposes adding options to Cargo that allow specifying a minimum age for published versions to use.

See https://github.com/rust-lang/cargo/issues/15973

[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/3923-cargo-min-publish-age.md)

### [--> FCP <--](https://github.com/rust-lang/rfcs/pull/3923#issuecomment-4346452551)