### PR TITLE
Crate deletion allowances

### DIFF
--- a/text/0000-crate-deletion-allowances.md
+++ b/text/0000-crate-deletion-allowances.md
@@ -35,7 +35,7 @@ The additions from this RFC are directly inspired by these two examples, althoug
 
 The crate deletion criteria receives the following change, specifically regarding reverse dependencies which are considered by the deletion criteria:
 
-* Yanked versions which are over a year old are not considered as valid reverse dependencies. If the depended crate passes the deletion criteria and gets deleted, these yanked versions may also get deleted.
+* Yanked versions which are over a year old are not considered as valid reverse dependencies. If the depended crate passes the deletion criteria and gets deleted, this still won't delete those yanked versions; they'll just have an invalid dependency.
 * If a version of a crate has been failing to compile on the latest stable for over 4 years (~1 edition cycle), it may be yanked without the approval of the crate author. Since these versions are necessarily at least four years old, they also satisfy the requirements for the above criteria.
 
 The full deletion criteria becomes:


### PR DESCRIPTION
This RFC proposes adding a number of "reasonable changes" to the current crates.io deletion policy that will allow the deletion of several "reasonable to delete" crates which currently do not qualify.

They are definitely, directly, shamelessly motivated by the personal experience of the RFC author. Please let them know if anything was poorly or hastily worded.

> [!IMPORTANT]  
> When responding to RFCs, try to use inline review comments (it is possible to leave an inline review comment for the entire file at the top) instead of direct comments for normal comments and keep normal comments for procedural matters like starting FCPs.
>
> This keeps the discussion more organized.


[Rendered](https://github.com/clarfonthey/rust-rfcs/blob/deletion-allowances/text/0000-crate-deletion-allowances.md)