### PR TITLE
Add *be present* contribution policy

### DIFF
--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -24,7 +24,7 @@ Maintainers and moderators are **not** required to put effort into explaining re
 
 - Fully AI-generated and not carefully self-reviewed contributions are *low-effort*.
   - These are informally known as "slop" or as "vibecoding".
-  - These include those produced by [OpenClaw](https://openclaw.ai/) or similar tools.
+  - These include those produced by [OpenClaw](https://en.wikipedia.org/wiki/OpenClaw) or similar tools.
   - Code, PR descriptions, bug reports, proposals, and comments are all low-effort if fully-generated and not carefully self-reviewed.
 - Feeding maintainer questions into AI tools and then proxying the output directly back to the reviewer is *low-effort* and lacks *compassion*.
 

--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -8,6 +8,19 @@
 
 We adopt a *be present* contribution policy for the Rust Project.
 
+## Design axioms
+
+The policy rests on four principles — four *beliefs* about how to approach drafting a successful policy.
+
+- **Let's start from common ground.**
+  - I.e., people have diverse views; let's start with those that we share.
+- **What matters is what's in front of us.**
+  - I.e., what comes over the wall is what defines our experience; we can tell when a PR is well reviewed and when a contributor understands it.
+- **Policy defines the unacceptable, not the disappointing.**
+  - I.e., policy needs to err on the side of avoiding false positives because we'll put moral weight behind these determinations.  Well-meaning people acting reasonably will still sometimes disappoint us, and that's not what we're trying to catch.
+- **Contributing requires being present.**
+  - I.e., we expect the person coming to us to be engaged in the work and with us.  This is true whether the person is using tools or whether the person is bringing to us the work of an internal team.
+
 ## Contribution policy
 
 Contributing to the Rust Project requires *being present* — present for the work and present when working with maintainers.

--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -6,26 +6,28 @@
 ## Summary
 [summary]: #summary
 
-We adopt a *no low-effort contributions* policy for the Rust Project.
+We adopt a *be present* contribution policy for the Rust Project.
 
 ## Contribution policy
 
-*Contributions* refer to pull requests, issues, proposals, and comments.
+Contributing to the Rust Project requires *being present* — present for the work and present when working with maintainers.
 
-- **Effort**: If you're not putting in the same level of effort a maintainer will have to put in to review it, then you're not adding value.  This level varies by the task and by the cost of review, but it's never less than being careful and thoughtful.
-- **Accountability**: We hold you responsible for everything you send to us.  We expect you to understand it and be able to explain it.  We expect you to check it carefully.  Respect our time.
-- **Compassion**: In taking the time to answer your questions and review what you've proposed, we're making an investment in you and in the open source community.  Keep that in mind when we're offering feedback.  Listen carefully.  Reflect on it.  Reply to us compassionately.  We're trying to help; making our maintainers feel bad about that leads to burnout.
+- **Effort**: Being present means pulling your weight — putting in the same level of effort a maintainer will have to put in to review it.  This level varies by the task and by the cost of review, but it's never less than being careful and thoughtful.
+- **Accountability**: Being present means being responsible for everything you send us.  We expect you to be involved with the work, to understand it, to be able to explain it, to check it carefully, and to respect our time.
+- **Compassion**: Being present means engaging respectfully with reviewers.  In taking the time to answer your questions and review what you've proposed, we're making an investment in you and in the open source community.  Keep that in mind when we're offering feedback — listen carefully, reflect on it, and reply to us compassionately.  We're trying to help; making our maintainers feel bad about that leads to burnout.
 
-Contributions that fail to satisfy these criteria are *low-effort contributions*.
+When these criteria are not satisfied, we say that the contributor is *not present*.
 
-Maintainers and moderators are **not** required to put effort into explaining rejection of low-effort contributions.
+Maintainers and moderators are **not** required to put effort into explaining rejection of contributions where the contributor is not present.
 
-## Examples of low-effort contributions
+*Contributions* include pull requests, issues, proposals, and comments.
 
-- Fully AI-generated and not carefully self-reviewed contributions are *low-effort*.
-  - These are informally known as "slop" or as "vibecoding".
-  - These include those produced by [OpenClaw](https://en.wikipedia.org/wiki/OpenClaw) and similar tools.
-  - Code, PR descriptions, bug reports, proposals, and comments are all low-effort if fully-generated and not carefully self-reviewed.
-- Feeding maintainer questions into AI tools and then proxying the output directly back to the reviewer is *low-effort* and lacks *compassion*.
+### Examples of failing to be present
+
+- If the contribution is fully AI-generated and the contributor was not in-the-loop, did not carefully review the result, or does not understand it, then the contributor is *not present*.
+  - These contributions are informally known as "slop" and this behavior is informally known as "vibecoding".
+  - Use of tools such as [OpenClaw](https://en.wikipedia.org/wiki/OpenClaw) presents a high risk of producing these contributions and this behavior.
+- Contributors must be present not just when submitting code, but when writing PR descriptions, bug reports, proposals, and comments.
+- If one feeds maintainer questions into AI tools and then proxies the output directly back to the reviewer, one is not present, and this behavior lacks *compassion*.
 
 This list is nonexhaustive.

--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -24,7 +24,7 @@ Maintainers and moderators are **not** required to put effort into explaining re
 
 - Fully AI-generated and not carefully self-reviewed contributions are *low-effort*.
   - These are informally known as "slop" or as "vibecoding".
-  - These include those produced by [OpenClaw](https://en.wikipedia.org/wiki/OpenClaw) or similar tools.
+  - These include those produced by [OpenClaw](https://en.wikipedia.org/wiki/OpenClaw) and similar tools.
   - Code, PR descriptions, bug reports, proposals, and comments are all low-effort if fully-generated and not carefully self-reviewed.
 - Feeding maintainer questions into AI tools and then proxying the output directly back to the reviewer is *low-effort* and lacks *compassion*.
 

--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -43,4 +43,4 @@ These illustrate how to apply the policy.  The list is not exhaustive.
 - Feeding reviewer questions into an AI tool and proxying the output directly back fails *compassion*.  The reviewer is investing in you; that investment requires your presence.
 - Submitting work — whether AI-generated, written by others (and used with permission), or written by hand — without exercising care and attention proportional to what you're asking of reviewers fails *effort*.  Presence is incompatible with carelessness and inattention.
 
-Informally, contributions that fall short may be called "slop" and the behavior "vibecoding".  Use of tools such as [OpenClaw](https://en.wikipedia.org/wiki/OpenClaw) presents a high risk of producing these contributions and this behavior.  Extreme care is needed if using these tools.
+Informally, contributions that fall short may be called "slop" and the behavior "vibecoding".

--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -27,7 +27,7 @@ Contributing to the Rust Project requires *being present* — present for the wo
 
 - **Effort**: Being present means pulling your weight — putting in the same level of effort a maintainer will have to put in to review it.  This level varies by the task and by the cost of review, but it's never less than being careful and thoughtful.
 - **Accountability**: Being present means being responsible for everything you send us.  We expect you to be involved with the work, to understand it, to be able to explain it, to check it carefully, and to respect our time.
-- **Compassion**: Being present means engaging respectfully with reviewers.  In taking the time to answer your questions and review what you've proposed, we're making an investment in you and in the open source community.  Keep that in mind when we're offering feedback — listen carefully, reflect on it, and reply to us compassionately.  We're trying to help; making our maintainers feel bad about that leads to burnout.
+- **Compassion**: Being present means engaging with reviewers as collaborators.  Reviewers take your work seriously and use care and kindness in interactions.  Help them help everyone by listening carefully, reflecting, and replying compassionately.
 
 When these criteria are not satisfied, we say that the contributor is *not present*.
 

--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -37,10 +37,10 @@ Maintainers and moderators are **not** required to put effort into explaining re
 
 ### Examples of failing to be present
 
-- If the contribution is fully AI-generated and the contributor was not in-the-loop, did not carefully review the result, or does not understand it, then the contributor is *not present*.
-  - These contributions are informally known as "slop" and this behavior is informally known as "vibecoding".
-  - Use of tools such as [OpenClaw](https://en.wikipedia.org/wiki/OpenClaw) presents a high risk of producing these contributions and this behavior.
-- Contributors must be present not just when submitting code, but when writing PR descriptions, bug reports, proposals, and comments.
-- If one feeds maintainer questions into AI tools and then proxies the output directly back to the reviewer, one is not present, and this behavior lacks *compassion*.
+These illustrate how to apply the policy.  The list is not exhaustive.
 
-This list is nonexhaustive.
+- Submitting AI-generated work when you weren't in-the-loop, when you haven't checked it with care, when you don't understand it, or when you can't explain it to a reviewer fails *accountability*.  If you haven't engaged with the work and can't engage with review questions about it, you aren't being present as its contributor.
+- Feeding reviewer questions into an AI tool and proxying the output directly back fails *compassion*.  The reviewer is investing in you; that investment requires your presence.
+- Submitting work — whether AI-generated, written by others (and used with permission), or written by hand — without exercising care and attention proportional to what you're asking of reviewers fails *effort*.  Presence is incompatible with carelessness and inattention.
+
+Informally, contributions that fall short may be called "slop" and the behavior "vibecoding".  Use of tools such as [OpenClaw](https://en.wikipedia.org/wiki/OpenClaw) presents a high risk of producing these contributions and this behavior.  Extreme care is needed if using these tools.

--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -1,0 +1,31 @@
+- Feature Name: N/A
+- Start Date: 2026-03-13
+- RFC PR: [rust-lang/rfcs#3936](https://github.com/rust-lang/rfcs/pull/3936)
+- Issue: [rust-lang/leadership-council#273](https://github.com/rust-lang/leadership-council/issues/273)
+
+## Summary
+[summary]: #summary
+
+We adopt a *no low-effort contributions* policy for the Rust Project.
+
+## Contribution policy
+
+*Contributions* refer to pull requests, issues, proposals, and comments.
+
+- **Effort**: If you're not putting in the same level of effort a maintainer will have to put in to review it, then you're not adding value.  This level varies by the task and by the cost of review, but it's never less than being careful and thoughtful.
+- **Accountability**: We hold you responsible for everything you send to us.  We expect you to understand it and be able to explain it.  We expect you to check it carefully.  Respect our time.
+- **Compassion**: In taking the time to answer your questions and review what you've proposed, we're making an investment in you.  We want to make you better able to help us.  Keep that in mind when we're offering feedback.  Listen carefully.  Reflect on it.  Reply to us compassionately.  We're trying to help; making our maintainers feel bad about that leads to burnout.
+
+Contributions that fail to satisfy these criteria are *low-effort contributions*.
+
+Maintainers and moderators are **not** required to put effort into explaining rejection of low-effort contributions.
+
+## Examples of low-effort contributions
+
+- Fully AI-generated and not carefully self-reviewed contributions are *low-effort*.
+  - These are informally known as "slop" or as "vibecoding".
+  - These include those produced by [OpenClaw](https://openclaw.ai/) or similar tools.
+  - Code, PR descriptions, bug reports, proposals, and comments are all low-effort if fully-generated and not carefully self-reviewed.
+- Feeding maintainer questions into AI tools and then proxying the output directly back to the reviewer is *low-effort* and lacks *compassion*.
+
+This list is nonexhaustive.

--- a/text/3936-contribution-policy.md
+++ b/text/3936-contribution-policy.md
@@ -14,7 +14,7 @@ We adopt a *no low-effort contributions* policy for the Rust Project.
 
 - **Effort**: If you're not putting in the same level of effort a maintainer will have to put in to review it, then you're not adding value.  This level varies by the task and by the cost of review, but it's never less than being careful and thoughtful.
 - **Accountability**: We hold you responsible for everything you send to us.  We expect you to understand it and be able to explain it.  We expect you to check it carefully.  Respect our time.
-- **Compassion**: In taking the time to answer your questions and review what you've proposed, we're making an investment in you.  We want to make you better able to help us.  Keep that in mind when we're offering feedback.  Listen carefully.  Reflect on it.  Reply to us compassionately.  We're trying to help; making our maintainers feel bad about that leads to burnout.
+- **Compassion**: In taking the time to answer your questions and review what you've proposed, we're making an investment in you and in the open source community.  Keep that in mind when we're offering feedback.  Listen carefully.  Reflect on it.  Reply to us compassionately.  We're trying to help; making our maintainers feel bad about that leads to burnout.
 
 Contributions that fail to satisfy these criteria are *low-effort contributions*.
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3936)*

*Update*: I'm working on expanding this to a full RFC.  See https://github.com/rust-lang/rfcs/pull/3936#issuecomment-4148914115.

*Update*: I've renamed and reframed this proposal around the idea of *being present* and have added the guiding design axioms.  See https://github.com/rust-lang/rfcs/pull/3936#issuecomment-4152375187.

---

Original description:

Previously I had proposed a *no low-effort contributions* policy in https://github.com/rust-lang/leadership-council/issues/273#issuecomment-4060269094, where it had gone into FCP.  In this commit, I add the text of that proposed policy in RFC format.

Later, I may add other sections -- e.g., motivation, rationale, unresolved questions, etc.  In the interest of expediency, I'm starting with just the policy itself and the associated examples.

cc @rust-lang/leadership-council

> [!IMPORTANT]
> This is a difficult issue.  Remember that we're all colleagues trying to do the best for Rust and that we all need to continue to work together.  Please keep in mind that people have many different experiences and earnestly hold many different views.  Please focus on assuming good intent, being curious, and acting compassionately.

> [!NOTE]
> Keep in mind, too, that on this one, we *mostly* are interested in hearing from members of the Project.  If you're not a member of the Project and have valuable information or a unique and relevant experience to share, e.g., about your experience contributing, then we're probably interested in hearing that.  Otherwise, you may want to sit back a bit on this one.  See https://github.com/rust-lang/rfcs/pull/3936#issuecomment-4130327905.

<!-- Thank you for trying to improve Rust through the RFC process! -->
<!-- Please add a short summary of your RFC below -->

> [!IMPORTANT]  
> When responding to RFCs, try to use inline review comments (it is possible to leave an inline review comment for the entire file at the top) instead of direct comments for normal comments and keep normal comments for procedural matters like starting FCPs.
>
> This keeps the discussion more organized.


[Rendered](https://github.com/rust-lang/rfcs/blob/b89bb8ae1dfdae5fa1d9569000590e62d2f13eaf/text/3936-contribution-policy.md)