### PR TITLE
RFC: Associated traits

### DIFF
--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -1,6 +1,6 @@
 - Feature Name: `associated_traits`
-- Start Date: 2026-03-21
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Start Date: 2026-03-28
+- RFC PR: [rust-lang/rfcs#3938](https://github.com/rust-lang/rfcs/pull/3938)
 - Rust Issue: [rust-lang/rfcs#2190](https://github.com/rust-lang/rfcs/issues/2190)
 
 ## Summary

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -1,0 +1,489 @@
+- Feature Name: `associated_traits`
+- Start Date: 2026-03-21
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rfcs#2190](https://github.com/rust-lang/rfcs/issues/2190)
+
+## Summary
+[summary]: #summary
+
+Allow traits to declare **associated traits** — named trait constraints that are defined abstractly in a trait and given concrete values in implementations. Just as associated types let a trait abstract over *which type* is used, associated traits let a trait abstract over *which constraints* are imposed. This is the trait-level analog of associated types and the Rust equivalent of Haskell's `ConstraintKinds`.
+
+```rust
+trait Container {
+    trait Elem;
+    fn process<T: Self::Elem>(&self, item: T);
+}
+
+impl Container for MyContainer {
+    trait Elem = Send + Clone;
+    fn process<T: Self::Elem>(&self, item: T) { /* ... */ }
+}
+```
+
+## Motivation
+[motivation]: #motivation
+
+### The problem
+
+Rust programmers frequently need to write traits that are *generic over constraints*. Today, the only way to parameterize a trait over which bounds should apply to some type is to fix them at the trait definition site, or to duplicate the entire trait hierarchy for each set of constraints.
+
+Consider a plugin framework:
+
+```rust
+// Without associated traits — constraints are baked in.
+trait Plugin {
+    fn run<T: Send + 'static>(&self, task: T);
+}
+```
+
+Every implementor must accept `Send + 'static`, even if some plugin systems (e.g., single-threaded ones) don't need `Send`. The only workaround today is to duplicate the trait:
+
+```rust
+trait SendPlugin {
+    fn run<T: Send + 'static>(&self, task: T);
+}
+
+trait LocalPlugin {
+    fn run<T: 'static>(&self, task: T);
+}
+```
+
+This duplication cascades through every consumer of the trait, every generic function, and every downstream crate.
+
+### Use cases from the community
+
+[rust-lang/rfcs#2190](https://github.com/rust-lang/rfcs/issues/2190) (76 👍, 12 👀) has collected real-world use cases since 2017. The most prominent:
+
+**Async runtime agnosticism.** A runtime trait can abstract over whether futures must be `Send`:
+
+```rust
+trait Runtime {
+    trait FutureConstraint;
+    fn spawn<F: Future<Output = ()> + Self::FutureConstraint>(f: F);
+}
+
+impl Runtime for TokioRuntime {
+    trait FutureConstraint = Send + 'static;
+    // ...
+}
+
+impl Runtime for LocalRuntime {
+    trait FutureConstraint = 'static;
+    // ...
+}
+```
+
+Today, the async ecosystem is split between `Send` and `!Send` runtimes, requiring parallel trait hierarchies and duplicated generic code.
+
+**Type constructor families (higher-kinded types lite).** `PointerFamily` abstracts over `Arc` vs. `Rc` by parameterizing the element constraints:
+
+```rust
+trait PointerFamily {
+    trait Bounds;
+    type Pointer<T>;
+}
+
+impl PointerFamily for ArcFamily {
+    trait Bounds = Send + Sync;
+    type Pointer<T> = Arc<T>;
+}
+
+impl PointerFamily for RcFamily {
+    trait Bounds = Clone;
+    type Pointer<T> = Rc<T>;
+}
+```
+
+**UI component frameworks.** An `Events` associated trait lets different component types declare which event traits are valid:
+
+```rust
+trait Component {
+    type Props: Clone + 'static;
+    trait Events;
+    fn new(props: Self::Props) -> Self;
+}
+```
+
+**Monitor/capability patterns.** A data structure constrains which kinds of monitors it accepts:
+
+```rust
+trait DataStructure {
+    trait Mon: Monitor;
+}
+```
+
+### Summary of benefits
+
+- Eliminates trait duplication when constraints vary per implementation.
+- Composes naturally with existing features: associated types, GATs, trait inheritance, `impl Trait`, UFCS.
+- Provides Rust's answer to Haskell's `ConstraintKinds` in an idiomatic, Rust-native way.
+- Directly addresses a long-standing community request (2017–present, 76+ upvotes).
+
+## Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+### Declaring an associated trait
+
+Inside a trait body, you can declare an associated trait using the `trait` keyword, mirroring how `type` declares an associated type:
+
+```rust
+trait Container {
+    trait Elem;
+}
+```
+
+This says: "every implementation of `Container` must specify what `Elem` means as a trait bound."
+
+### Providing a value in an impl
+
+In an `impl` block, you provide the associated trait's value using `trait Name = TraitBound;`:
+
+```rust
+impl Container for MyVec {
+    trait Elem = Send + Clone;
+}
+```
+
+The value can be any valid trait bound: a single trait, a compound bound (`Send + Clone`), a trait with associated type constraints (`IntoIterator<Item = i32>`), a lifetime bound (`'static`), or `?Sized`.
+
+### Using an associated trait as a bound
+
+Once declared, an associated trait can be used anywhere a regular trait bound is expected:
+
+```rust
+fn process<C: Container, T: C::Elem>(container: &C, item: T) {
+    // T satisfies whatever Elem resolves to for this C.
+}
+```
+
+This is the *primary use*: the caller sees `T: C::Elem`, and the trait solver resolves `C::Elem` to the concrete bounds from the impl (e.g., `Send + Clone` for `MyVec`).
+
+### Declaration bounds (supertraits)
+
+You can require that every implementation's value satisfies certain minimum bounds:
+
+```rust
+trait Processor {
+    trait Constraint: Clone;  // Every impl's value must include Clone
+}
+
+impl Processor for MyProc {
+    trait Constraint = Clone + Send;  // OK: Clone is satisfied
+}
+
+impl Processor for BadProc {
+    trait Constraint = Send;  // ERROR: does not satisfy Clone
+}
+```
+
+### Defaults
+
+Associated traits can have defaults, just like associated types:
+
+```rust
+trait Serializable {
+    trait Format = serde::Serialize;  // Default; impls can override
+}
+```
+
+### Generic associated traits
+
+Associated traits can have their own generic parameters, analogous to GATs:
+
+```rust
+trait Transform {
+    trait Constraint<T: Clone>;
+}
+
+impl Transform for MyTransform {
+    trait Constraint<T: Clone> = PartialEq<T>;
+}
+```
+
+Where clauses are also supported:
+
+```rust
+trait Codec {
+    trait Decode<T> where T: Send;
+}
+```
+
+### UFCS disambiguation
+
+When a type parameter is bounded by multiple traits that each define an associated trait with the same name, you can use fully-qualified syntax to disambiguate:
+
+```rust
+trait Readable { trait Constraint; }
+trait Writable { trait Constraint; }
+
+fn transfer<T: Readable + Writable, R: <T as Readable>::Constraint>(data: R) {}
+```
+
+### `impl Trait` syntax
+
+Associated traits work with `impl Trait` in argument position:
+
+```rust
+trait Handler {
+    trait Arg;
+    fn handle(&self, arg: impl Self::Arg);
+}
+```
+
+### Where associated traits *cannot* appear
+
+- **Type position**: `let x: T::Elem = ...` is an error — associated traits are constraints, not types.
+- **`dyn` position**: `dyn T::Elem` is an error — there is no type to make into a trait object.
+- **Inherent impls**: `impl MyStruct { trait Foo = Send; }` is an error — associated traits only make sense in trait impls.
+
+### Error messages
+
+When the feature gate is absent:
+
+```
+error[E0658]: associated traits are experimental
+  --> src/lib.rs:3:5
+   |
+3  |     trait Elem;
+   |     ^^^^^^^^^^
+   |
+   = note: see issue #99999 for more information
+   = help: add `#![feature(associated_traits)]` to the crate attributes
+```
+
+When an associated trait is used in type position:
+
+```
+error: expected type, found trait `Container::Elem`
+  --> src/lib.rs:10:14
+   |
+10 |     let _x: T::Elem = todo!();
+   |             ^^^^^^^ not a type; `Elem` is an associated trait
+```
+
+## Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+### Syntax
+
+**Declaration** (in trait body):
+
+```
+trait Ident ;
+trait Ident : Bounds ;
+trait Ident = DefaultBounds ;
+trait Ident : Bounds = DefaultBounds ;
+trait Ident < GenericParams > ;
+trait Ident < GenericParams > where WhereClauses ;
+```
+
+**Implementation** (in impl body):
+
+```
+trait Ident = Bounds ;
+trait Ident < GenericParams > = Bounds ;
+```
+
+**Usage** (in bound position):
+
+```
+T: Container::Elem
+T: <C as Container>::Elem
+T: C::Elem<i32>
+```
+
+### AST representation
+
+A new variant `AssocItemKind::Trait` is added to the AST, containing:
+- `ident`: the name
+- `generics`: generic parameters and where clauses
+- `bounds`: declaration bounds (supertraits)
+- `value`: the default or impl value (a list of `GenericBound`)
+- `has_value`: whether a `= ...` value is present
+
+### HIR representation
+
+Two new variants:
+- `TraitItemKind::Trait(GenericBounds)` — in trait definitions
+- `ImplItemKind::Trait(GenericBounds)` — in trait implementations
+
+A new HIR bound variant:
+- `GenericBound::AssocTraitBound(&Ty, &PathSegment, Span, Option<DefId>)` — represents `B: C::Elem` in bound position, where the optional `DefId` carries UFCS trait disambiguation.
+
+### DefKind and middle representation
+
+- `DefKind::AssocTrait` — a new `DefKind` variant, distinct from `AssocTy`.
+- `AssocKind::Trait { name: Symbol }` — a new `AssocKind` variant at the `ty` level.
+- `AssocTag::Trait` — used to probe for associated trait items specifically.
+
+### Predicate
+
+A new clause kind is added:
+
+```rust
+ClauseKind::AssocTraitBound(AssocTraitBoundPredicate {
+    self_ty: Ty,      // The bounded type (B)
+    projection: AliasTerm,  // The projection (<C as Container>::Elem)
+})
+```
+
+### Name resolution
+
+The resolver accepts partial resolutions (paths with unresolved trailing segments) in `PathSource::Trait(AliasPossibility::Maybe)` when the base is a type parameter, `Self` type param, or `Self` type alias. This allows `C::Elem` in bound position to resolve `C` as a type parameter and leave `Elem` as an unresolved associated item.
+
+For UFCS paths (`<T as Trait>::Elem`), the resolver handles fully-qualified paths through `PathSource::TraitItem`, now extended to accept `DefKind::AssocTrait`.
+
+### Type checking
+
+**Projection**: Associated traits do *not* participate in type projection. `project()` returns `NoProgress` for `AssocTrait` projections. `type_of()` is unreachable (`span_bug!`) for associated traits.
+
+**Bound enforcement**: When `B: C::Elem` appears as a bound, the HIR type lowering emits a `ClauseKind::AssocTraitBound` predicate. The trait solver resolves this by:
+
+1. Using `selcx.select()` to find the impl for the container trait bound.
+2. Using `assoc_def()` to locate the associated trait item in the impl.
+3. Reading `explicit_item_bounds()` to get the concrete trait values.
+4. Emitting `ClauseKind::Trait(B: ConcreteTraitValue)` obligations for each value trait.
+
+This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
+
+**Declaration bounds**: When a declaration has bounds (`trait Elem: Clone;`), `compare_impl_item` checks that the impl's value satisfies those supertraits.
+
+**UFCS disambiguation**: When the optional `constraint_trait` is present in `AssocTraitBound`, the bound resolution filters candidates to only the specified trait, correctly disambiguating `<T as Readable>::Constraint` from `<T as Writable>::Constraint`.
+
+### Interaction with other features
+
+**Associated types**: Associated traits and associated types coexist in the same trait body. They cannot share the same name (`E0325`). A trait can have both `type Item` and `trait Constraint`. An associated type can be bounded by an associated trait: `type Item: Self::Constraint;`.
+
+**GATs**: Associated traits can be declared alongside GATs and used to constrain GAT parameters at the use site, as in the `PointerFamily` pattern.
+
+**Trait inheritance**: Associated traits are inherited through supertraits. If `trait Base { trait Elem; }` and `trait Extended: Base { ... }`, then `Extended` inheritors can use `Self::Elem`.
+
+**`impl Trait`**: `impl C::Elem` in return position or argument position works through opaque type lowering, creating an opaque type bounded by the associated trait.
+
+**Cross-crate**: Associated trait declarations and values are available across crate boundaries. The metadata encodes `DefKind::AssocTrait` and `explicit_item_bounds` for associated trait items.
+
+**`dyn Trait`**: Associated traits are **not** object-safe. Using `dyn T::Elem` produces a specific error: "associated traits cannot be used with dyn".
+
+### Comparison with associated types
+
+| Aspect | Associated Type | Associated Trait |
+|--------|----------------|-----------------|
+| Declaration | `type Foo;` | `trait Foo;` |
+| Value | `type Foo = i32;` | `trait Foo = Send;` |
+| Position | Type position | Bound position |
+| `type_of` | Returns the type | Unreachable (`span_bug!`) |
+| Projection | Yes (`T::Foo` is a type) | No (`T::Foo` is a constraint) |
+| DefKind | `AssocTy` | `AssocTrait` |
+| Generics | Yes (GATs) | Yes (generic associated traits) |
+| Defaults | Yes | Yes |
+| UFCS | `<T as Trait>::Foo` | `<T as Trait>::Foo` |
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+- **Language complexity**: This adds a new kind of associated item. Rust already has associated types, associated constants, and associated functions. A fourth category increases the surface area that all users, tools, and documentation must understand.
+
+- **Partial overlap with where clauses**: Some simple cases that associated traits address can be handled today via additional trait parameters or where clauses, though less ergonomically and without the ability to vary per implementation.
+
+- **Solver complexity**: The `AssocTraitBound` predicate adds a new resolution pathway in both the old and new trait solvers, which must be maintained alongside existing projection and trait obligation machinery.
+
+- **Bound expansion in method bodies**: Within an impl's method body, `T: Self::Arg` does not currently expand to the concrete bounds for the purposes of using methods from those bounds. The caller-side resolution works correctly, but within the impl body, users must add explicit bounds to use the expanded capabilities. This is a limitation that may be addressed in future work.
+
+## Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+### Why not reuse associated types?
+
+One might consider representing associated traits as associated types that happen to be traits (e.g., `type Elem: ?Sized = dyn Send;`). This was rejected for several reasons:
+
+1. **Semantic distinction**: Types and constraints are fundamentally different concepts. An associated type has a `type_of`, participates in type projection, and can appear in type position. An associated trait does none of these. Conflating them would require special-casing at every level.
+
+2. **Projection confusion**: `T::Elem` for an associated type returns a *type*. For an associated trait, it returns a *constraint*. Reusing the same mechanism would create ambiguity in the type system.
+
+3. **Proper infrastructure**: By giving associated traits their own `DefKind::AssocTrait`, `TraitItemKind::Trait`, and `ClauseKind::AssocTraitBound`, each compiler pass can handle them explicitly rather than routing through type machinery and failing at runtime.
+
+### Why not trait aliases?
+
+[Trait aliases](https://github.com/rust-lang/rfcs/pull/1733) (e.g., `trait SendClone = Send + Clone;`) are fixed at definition time. They cannot vary per implementation of an enclosing trait. Associated traits are the "associated" analog — they provide the same expressiveness that associated types provide over type aliases.
+
+### Why not additional generic parameters?
+
+Instead of `trait Container { trait Elem; }`, one could write `trait Container<Elem: ?Sized> { ... }`. This makes `Elem` a *generic parameter*, not an *associated item*. The tradeoffs mirror those of generic parameters vs. associated types:
+
+- Generic parameters allow multiple implementations for the same type (e.g., `impl Container<Send> for Vec` and `impl Container<Clone> for Vec`), which is usually not desired.
+- Associated items enforce that each impl provides exactly one value, which is the common case.
+- Associated items don't appear in the type signature at every use site.
+
+### Impact of not doing this
+
+Without associated traits, the Rust ecosystem will continue to duplicate trait hierarchies when constraints need to vary (as seen with async runtimes, serialization frameworks, and plugin systems). This duplication is a persistent source of boilerplate and a barrier to writing truly generic code.
+
+## Prior art
+[prior-art]: #prior-art
+
+### Haskell: ConstraintKinds
+
+GHC's [`ConstraintKinds`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/constraint_kind.html) extension allows constraints to be used as first-class kinds. A type family can return a constraint:
+
+```haskell
+type family ElemConstraint (c :: * -> *) :: Constraint
+type instance ElemConstraint MyVec = (Send, Clone)
+```
+
+This is more general than associated traits (constraints can appear in more positions), but Rust's associated traits achieve the most commonly needed subset — parameterizing traits over constraints — in a way that fits Rust's existing associated item pattern.
+
+### Haskell: RMonad
+
+The [`rmonad`](https://hackage.haskell.org/package/rmonad) library uses `ConstraintKinds` to define restricted monads, enabling data structures like `Set` (which requires `Ord`) to be monads. Associated traits in Rust would enable similar patterns: a `Family` trait with `trait Bounds` can restrict what types a type constructor accepts.
+
+### Scala: Abstract type members
+
+Scala's abstract type members serve a similar role to Rust's associated types, and Scala's type bounds can express constraint parameterization. However, Scala does not have a direct analog to "associated trait constraints" as a named, implementor-chosen bound.
+
+### Swift: Associated type constraints
+
+Swift's protocol associated types can have constraints (`associatedtype Element: Sendable`), but these are fixed at the protocol level — implementors cannot choose different constraints. Rust's associated traits go further by making the constraint itself the associated item.
+
+## Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+### Before merging this RFC
+
+- **Bound expansion in method bodies**: Currently, within an impl method body, `T: Self::Arg` does not expand to allow calling methods from the concrete associated trait value. For example, if `trait Arg = IntoIterator<Item = i32>`, a method body with `T: Self::Arg` cannot call `for x in arg` without an additional explicit `T: IntoIterator` bound. The bounds are correctly enforced at the *caller* side, but the impl body does not see the expanded constraints. Should this be considered a blocker, or is it acceptable as a known limitation for the initial feature?
+
+- **`impl Self::AssocTrait` in method arguments**: The OP's example includes `fn handle(&self, arg: impl Self::Arg)`. This works syntactically, but the impl body's view of `arg`'s capabilities is limited (see above). What user expectations should we set?
+
+- **Trait generic parameters**: The OP also proposes `fn foo<Impl, trait Trait> where Impl: Trait { … }` — allowing trait-level generic parameters (not associated traits, but standalone trait parameters). This is a separate, more general feature. Should it be explicitly deferred, or should this RFC leave room for it?
+
+- **`where T::AssocTrait: OtherTrait` form**: Currently, `where T::Elem: Clone` is syntactically valid but semantically vacuous for associated traits (there is no type to bind `Clone` to). Should this be an error, a warning, or silently accepted?
+
+### Before stabilization
+
+- **Error codes**: Several associated-trait-specific error messages currently use ad-hoc `span_err` rather than dedicated error codes. Proper `EXXXX` codes should be assigned.
+
+- **Diagnostic quality**: Suggestions for common mistakes (e.g., using an associated trait in type position, forgetting to provide a value in an impl) should be polished.
+
+- **Incremental compilation**: Dedicated testing of incremental compilation scenarios with associated traits.
+
+- **New trait solver**: The implementation includes support in both the old and new trait solvers. The new solver support should be validated under `-Znext-solver`.
+
+### Out of scope for this RFC
+
+- **Negative associated trait bounds**: e.g., `trait Elem = !Send;`. This intersects with negative impls and is deferred.
+- **`dyn`-compatible associated traits**: Making traits with associated traits object-safe. This requires significant design work around dynamic dispatch and is deferred.
+- **Trait-level generic parameters**: `fn foo<trait T>()` is a distinct and more general feature.
+
+## Future possibilities
+[future-possibilities]: #future-possibilities
+
+- **Bound expansion in impl bodies**: A future enhancement could allow the compiler to automatically expand associated trait bounds within impl method bodies, so that `T: Self::Arg` where `Arg = IntoIterator` allows calling `IntoIterator` methods on `T` without an additional explicit bound.
+
+- **`where T::AssocTrait: OtherTrait`**: If the trait solver were extended to support "projection-level constraints on associated trait values," one could write `where T::Elem: Debug` to require that whatever `T::Elem` resolves to must include `Debug`.
+
+- **Trait-level generic parameters**: As proposed in the original issue, allowing `fn foo<trait Trait>()` where `Trait` is a first-class trait parameter. This is the natural dual: associated traits are to trait aliases as associated types are to type aliases; trait parameters would be to generic type parameters as associated traits are to associated types.
+
+- **Higher-kinded types interaction**: As noted by several commenters on the original issue, associated traits compose well with HKT-like patterns. A `Family` trait with `trait Bounds` and `type Of<T: Self::Bounds>` is a step toward restricted monads / restricted functors, similar to Haskell's `rmonad`.
+
+- **Non-lifetime HRTBs**: Combined with [non-lifetime higher-ranked trait bounds](https://github.com/rust-lang/rust/issues/108185) (`for<T: Foo> Bar<T>: Baz<T>`), associated traits would enable significantly more expressive generic constraint patterns.
+
+- **Const associated traits**: By analogy with const generics, one could imagine associated traits that are const-evaluable, though the motivation for this is unclear.

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -6,19 +6,33 @@
 ## Summary
 [summary]: #summary
 
-Allow traits to declare **associated traits** — named trait constraints that are defined abstractly in a trait and given concrete values in implementations. Just as associated types let a trait abstract over *which type* is used, associated traits let a trait abstract over *which constraints* are imposed. This is the trait-level analog of associated types and the Rust equivalent of Haskell's `ConstraintKinds`.
+Allow traits to declare **associated traits** — named trait constraints that are defined abstractly in a trait and given concrete values in implementations. Just as associated types let a trait abstract over *which type* is used, associated traits let a trait abstract over *which constraints* are imposed. This is the trait-level analog of associated types.
 
 ```rust
 #![feature(associated_traits)]
 
+// 1. Declare an associated trait in a trait definition.
 trait Container {
     trait Elem;
     fn process<T: Self::Elem>(&self, item: T);
 }
 
+// 2. Each impl chooses the concrete constraints.
 impl Container for MyContainer {
     trait Elem = Send + Clone;
     fn process<T: Self::Elem>(&self, item: T) { /* ... */ }
+}
+
+// 3. Generic code outside the impl uses `C::Elem` as a bound.
+//    This is the primary use case: the caller is generic over
+//    the constraints without knowing what they are.
+fn process_item<C: Container, T: C::Elem>(container: &C, item: T) {
+    container.process(item);
+}
+
+// 4. Fully-qualified syntax also works.
+fn process_qualified<C: Container, T: <C as Container>::Elem>(container: &C, item: T) {
+    container.process(item);
 }
 ```
 
@@ -117,8 +131,7 @@ trait DataStructure {
 ### Summary of benefits
 
 - Eliminates trait duplication when constraints vary per implementation.
-- Composes naturally with existing features: associated types, GATs, trait inheritance, `impl Trait`, UFCS.
-- Provides Rust's answer to Haskell's `ConstraintKinds` in an idiomatic, Rust-native way.
+- Composes naturally with existing features: associated types, generic associated types, trait inheritance, `impl Trait`, UFCS.
 - Directly addresses a long-standing community request (2017–present, 76+ upvotes).
 
 ## Guide-level explanation
@@ -183,14 +196,26 @@ impl Processor for BadProc {
 Associated traits can have defaults, just like associated types:
 
 ```rust
-trait Serializable {
-    trait Format = serde::Serialize;  // Default; impls can override
+trait Runtime {
+    trait FutureConstraint = Send;  // Default; most runtimes want Send
+    fn spawn<F: Future<Output = ()> + Self::FutureConstraint>(f: F);
+}
+
+// TokioRuntime is happy with the default (Send).
+impl Runtime for TokioRuntime {
+    fn spawn<F: Future<Output = ()> + Self::FutureConstraint>(f: F) { /* ... */ }
+}
+
+// A single-threaded runtime overrides the default.
+impl Runtime for LocalRuntime {
+    trait FutureConstraint = 'static;  // No Send requirement
+    fn spawn<F: Future<Output = ()> + Self::FutureConstraint>(f: F) { /* ... */ }
 }
 ```
 
 ### Generic associated traits
 
-Associated traits can have their own generic parameters, analogous to GATs:
+Associated traits can have their own generic parameters, analogous to generic associated types:
 
 ```rust
 trait Transform {
@@ -376,7 +401,7 @@ This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 
 **Associated types**: Associated traits and associated types coexist in the same trait body. They cannot share the same name (`E0325`). A trait can have both `type Item` and `trait Constraint`. An associated type can be bounded by an associated trait: `type Item: Self::Constraint;`.
 
-**GATs**: Associated traits can be declared alongside GATs and used to constrain GAT parameters at the use site, as in the `PointerFamily` pattern.
+**Generic associated types**: Associated traits can be declared alongside generic associated types and used to constrain their parameters at the use site, as in the `PointerFamily` pattern.
 
 **Trait inheritance**: Associated traits are inherited through supertraits. If `trait Base { trait Elem; }` and `trait Extended: Base { ... }`, then `Extended` inheritors can use `Self::Elem`.
 
@@ -396,7 +421,7 @@ This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 | `type_of` | Returns the type | Unreachable (`span_bug!`) |
 | Projection | Yes (`T::Foo` is a type) | No (`T::Foo` is a constraint) |
 | DefKind | `AssocTy` | `AssocTrait` |
-| Generics | Yes (GATs) | Yes (generic associated traits) |
+| Generics | Yes (generic associated types) | Yes (generic associated traits) |
 | Defaults | Yes | Yes |
 | UFCS | `<T as Trait>::Foo` | `<T as Trait>::Foo` |
 
@@ -411,16 +436,6 @@ This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 
 ## Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
-
-### Why not reuse associated types?
-
-One might consider representing associated traits as associated types that happen to be traits (e.g., `type Elem: ?Sized = dyn Send;`). This was rejected for several reasons:
-
-1. **Semantic distinction**: Types and constraints are fundamentally different concepts. An associated type has a `type_of`, participates in type projection, and can appear in type position. An associated trait does none of these. Conflating them would require special-casing at every level.
-
-2. **Projection confusion**: `T::Elem` for an associated type returns a *type*. For an associated trait, it returns a *constraint*. Reusing the same mechanism would create ambiguity in the type system.
-
-3. **Proper infrastructure**: By giving associated traits their own `DefKind::AssocTrait`, `TraitItemKind::Trait`, and `ClauseKind::AssocTraitBound`, each compiler pass can handle them explicitly rather than routing through type machinery and failing at runtime.
 
 ### Why not trait aliases?
 
@@ -464,33 +479,22 @@ Scala's abstract type members serve a similar role to Rust's associated types, a
 
 Swift's protocol associated types can have constraints (`associatedtype Element: Sendable`), but these are fixed at the protocol level — implementors cannot choose different constraints. Rust's associated traits go further by making the constraint itself the associated item.
 
-## Unresolved questions
-[unresolved-questions]: #unresolved-questions
-
-### Before merging this RFC
-
-- **Trait generic parameters**: The OP also proposes `fn foo<Impl, trait Trait> where Impl: Trait { … }` — allowing trait-level generic parameters (not associated traits, but standalone trait parameters). This is a separate, more general feature. Should it be explicitly deferred, or should this RFC leave room for it?
-
-### Before stabilization
-
-- **Error codes**: Several associated-trait-specific error messages currently use ad-hoc `span_err` rather than dedicated error codes. Proper `EXXXX` codes should be assigned.
-
-- **Diagnostic quality**: Suggestions for common mistakes (e.g., using an associated trait in type position, forgetting to provide a value in an impl) should be polished.
-
-- **Incremental compilation**: Dedicated testing of incremental compilation scenarios with associated traits.
-
-- **Solver validation**: Both the old and new solver implementations should be validated across a broad range of patterns, including cross-crate scenarios, before stabilization.
-
-### Out of scope for this RFC
+## Out of scope
+[out-of-scope]: #out-of-scope
 
 - **Negative associated trait bounds**: e.g., `trait Elem = !Send;`. This intersects with negative impls and is deferred.
 - **`dyn` with associated traits**: `dyn T::Elem` is not supported because Rust's type system requires dyn vtable layouts to be known at type-checking time, before monomorphization resolves `T`. This is the same constraint that prevents `dyn T` for type parameters. A trait with associated traits can still be used as `dyn Trait`; only the associated trait itself cannot appear as a dyn bound.
-- **Trait-level generic parameters**: `fn foo<trait T>()` is a distinct and more general feature.
+- **Trait-level generic parameters**: `fn foo<trait T>()` — allowing traits as first-class generic parameters — is a distinct and more general feature. It is the natural dual: associated traits are to trait aliases as associated types are to type aliases; trait parameters would be to generic type parameters as associated traits are to associated types.
+
+## Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+None at this time.
 
 ## Future possibilities
 [future-possibilities]: #future-possibilities
 
-- **Trait-level generic parameters**: As proposed in the original issue, allowing `fn foo<trait Trait>()` where `Trait` is a first-class trait parameter. This is the natural dual: associated traits are to trait aliases as associated types are to type aliases; trait parameters would be to generic type parameters as associated traits are to associated types.
+- **Trait-level generic parameters**: As proposed in the original issue, allowing `fn foo<trait Trait>()` where `Trait` is a first-class generic parameter (see [Out of scope](#out-of-scope)). This would complement associated traits by enabling fully generic constraint parameterization at call sites.
 
 - **Higher-kinded types interaction**: As noted by several commenters on the original issue, associated traits compose well with HKT-like patterns. A `Family` trait with `trait Bounds` and `type Of<T: Self::Bounds>` is a step toward restricted monads / restricted functors, similar to Haskell's `rmonad`.
 

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -10,7 +10,6 @@ Allow traits to declare **associated traits** — named trait constraints that a
 
 ```rust
 #![feature(associated_traits)]
-#![allow(incomplete_features)]
 
 trait Container {
     trait Elem;
@@ -340,7 +339,7 @@ For UFCS paths (`<T as Trait>::Elem`), the resolver handles fully-qualified path
 
 **Projection**: Associated traits do *not* participate in type projection. `project()` returns `NoProgress` for `AssocTrait` projections. `type_of()` is unreachable (`span_bug!`) for associated traits.
 
-**Solver support**: Associated traits are supported by both the old and new trait solvers. The old solver resolves `AssocTraitBound` predicates through its fulfillment engine (selecting the impl, extracting value bounds, emitting concrete trait obligations) and its evaluation path (mirroring the fulfillment logic for speculative queries). The new solver handles them via a dedicated `compute_assoc_trait_bound_goal` function. The feature is gated as `incomplete`, requiring both `#![feature(associated_traits)]` and `#![allow(incomplete_features)]`.
+**Solver support**: Associated traits are supported by both the old and new trait solvers. The old solver resolves `AssocTraitBound` predicates through its fulfillment engine (selecting the impl, extracting value bounds, emitting concrete trait obligations) and its evaluation path (mirroring the fulfillment logic for speculative queries). The new solver handles them via a dedicated `compute_assoc_trait_bound_goal` function. The feature is gated as `unstable`, requiring `#![feature(associated_traits)]`.
 
 **Bound enforcement**: When `B: C::Elem` appears as a bound, the HIR type lowering emits a `ClauseKind::AssocTraitBound` predicate. Both solver resolve this as follows:
 
@@ -394,8 +393,6 @@ This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 - **Partial overlap with where clauses**: Some simple cases that associated traits address can be handled today via additional trait parameters or where clauses, though less ergonomically and without the ability to vary per implementation.
 
 - **Solver complexity**: The `AssocTraitBound` predicate adds a new resolution pathway in both the old and new trait solvers — the old solver through its fulfillment engine and evaluation path, the new solver via a dedicated `compute_assoc_trait_bound_goal` function. Both pathways must be maintained alongside existing projection and trait obligation machinery.
-
-- **Incomplete feature status**: The feature is gated as `incomplete` rather than merely `unstable`, meaning the compiler emits a warning even when the feature is enabled. Users must also write `#![allow(incomplete_features)]` to suppress this warning.
 
 ## Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -232,6 +232,21 @@ trait Handler {
 }
 ```
 
+### Call-site value constraints
+
+You can constrain an associated trait's value at the call site using `where` clause syntax:
+
+```rust
+fn print_element<C: Container, T: C::Elem>(x: T)
+where
+    C::Elem: Debug,  // The impl's value for Elem must include Debug
+{
+    println!("{:?}", x);
+}
+```
+
+This is different from `T: C::Elem + Debug` (which constrains `T` independently). The value constraint `C::Elem: Debug` constrains the *Container's impl* — if the impl provides `trait Elem = Send` (no Debug), the call is rejected even if `T` happens to implement Debug.
+
 ### Where associated traits *cannot* appear
 
 - **Type position**: `let x: T::Elem = ...` is an error — associated traits are constraints, not types.
@@ -456,8 +471,6 @@ Swift's protocol associated types can have constraints (`associatedtype Element:
 
 - **Trait generic parameters**: The OP also proposes `fn foo<Impl, trait Trait> where Impl: Trait { … }` — allowing trait-level generic parameters (not associated traits, but standalone trait parameters). This is a separate, more general feature. Should it be explicitly deferred, or should this RFC leave room for it?
 
-- **`where T::AssocTrait: OtherTrait` form**: Currently, `where T::Elem: Clone` is syntactically valid but semantically vacuous for associated traits (there is no type to bind `Clone` to). Should this be an error, a warning, or silently accepted?
-
 ### Before stabilization
 
 - **Error codes**: Several associated-trait-specific error messages currently use ad-hoc `span_err` rather than dedicated error codes. Proper `EXXXX` codes should be assigned.
@@ -476,8 +489,6 @@ Swift's protocol associated types can have constraints (`associatedtype Element:
 
 ## Future possibilities
 [future-possibilities]: #future-possibilities
-
-- **`where T::AssocTrait: OtherTrait`**: If the trait solver were extended to support "projection-level constraints on associated trait values," one could write `where T::Elem: Debug` to require that whatever `T::Elem` resolves to must include `Debug`.
 
 - **Trait-level generic parameters**: As proposed in the original issue, allowing `fn foo<trait Trait>()` where `Trait` is a first-class trait parameter. This is the natural dual: associated traits are to trait aliases as associated types are to type aliases; trait parameters would be to generic type parameters as associated traits are to associated types.
 

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -454,10 +454,6 @@ Swift's protocol associated types can have constraints (`associatedtype Element:
 
 ### Before merging this RFC
 
-- **Bound expansion in method bodies**: ~~Currently, within an impl method body, `T: Self::Arg` does not expand to allow calling methods from the concrete associated trait value.~~ This has been implemented. When an impl provides `trait Arg = IntoIterator<Item = i32>`, a method body with `T: Self::Arg` can now call `for x in arg` directly. The compiler expands `AssocTraitBound` predicates into concrete trait predicates in the method's parameter environment.
-
-- **`impl Self::AssocTrait` in method arguments**: `fn handle(&self, arg: impl Self::Arg)` works correctly — the impl body can use the expanded capabilities of the associated trait value.
-
 - **Trait generic parameters**: The OP also proposes `fn foo<Impl, trait Trait> where Impl: Trait { … }` — allowing trait-level generic parameters (not associated traits, but standalone trait parameters). This is a separate, more general feature. Should it be explicitly deferred, or should this RFC leave room for it?
 
 - **`where T::AssocTrait: OtherTrait` form**: Currently, `where T::Elem: Clone` is syntactically valid but semantically vacuous for associated traits (there is no type to bind `Clone` to). Should this be an error, a warning, or silently accepted?

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -9,6 +9,9 @@
 Allow traits to declare **associated traits** — named trait constraints that are defined abstractly in a trait and given concrete values in implementations. Just as associated types let a trait abstract over *which type* is used, associated traits let a trait abstract over *which constraints* are imposed. This is the trait-level analog of associated types and the Rust equivalent of Haskell's `ConstraintKinds`.
 
 ```rust
+#![feature(associated_traits)]
+#![allow(incomplete_features)]
+
 trait Container {
     trait Elem;
     fn process<T: Self::Elem>(&self, item: T);
@@ -233,7 +236,7 @@ trait Handler {
 ### Where associated traits *cannot* appear
 
 - **Type position**: `let x: T::Elem = ...` is an error — associated traits are constraints, not types.
-- **`dyn` position**: `dyn T::Elem` is an error — there is no type to make into a trait object.
+- **`dyn` position**: `dyn T::Elem` is an error. Rust type-checks generic function bodies once, before monomorphization, so the set of traits behind `T::Elem` is not yet known. Since `dyn` types require a compile-time-known vtable layout, `dyn` with an associated trait that depends on a type parameter is fundamentally incompatible with Rust's generics model. This is the same reason `dyn T` where `T` is a type parameter is rejected.
 - **Inherent impls**: `impl MyStruct { trait Foo = Send; }` is an error — associated traits only make sense in trait impls.
 
 ### Error messages
@@ -337,12 +340,17 @@ For UFCS paths (`<T as Trait>::Elem`), the resolver handles fully-qualified path
 
 **Projection**: Associated traits do *not* participate in type projection. `project()` returns `NoProgress` for `AssocTrait` projections. `type_of()` is unreachable (`span_bug!`) for associated traits.
 
-**Bound enforcement**: When `B: C::Elem` appears as a bound, the HIR type lowering emits a `ClauseKind::AssocTraitBound` predicate. The trait solver resolves this by:
+**Solver support**: Associated traits are supported by both the old and new trait solvers. The old solver resolves `AssocTraitBound` predicates through its fulfillment engine (selecting the impl, extracting value bounds, emitting concrete trait obligations) and its evaluation path (mirroring the fulfillment logic for speculative queries). The new solver handles them via a dedicated `compute_assoc_trait_bound_goal` function. The feature is gated as `incomplete`, requiring both `#![feature(associated_traits)]` and `#![allow(incomplete_features)]`.
 
-1. Using `selcx.select()` to find the impl for the container trait bound.
-2. Using `assoc_def()` to locate the associated trait item in the impl.
-3. Reading `explicit_item_bounds()` to get the concrete trait values.
-4. Emitting `ClauseKind::Trait(B: ConcreteTraitValue)` obligations for each value trait.
+**Bound enforcement**: When `B: C::Elem` appears as a bound, the HIR type lowering emits a `ClauseKind::AssocTraitBound` predicate. Both solver resolve this as follows:
+
+1. **Structurally normalize** the self-type of the projection's trait reference to determine whether the concrete impl is known.
+2. **For abstract types** (type parameters, aliases, placeholders): add only the parent trait obligation (e.g., `C: Container`) and return success. The concrete value bounds cannot be resolved yet because the impl is unknown; declaration bounds are separately validated by `compare_impl_assoc_trait` at the impl site.
+3. **For concrete types**: iterate over relevant impls matching the trait reference. For each candidate impl:
+   a. Probe the impl and unify the goal trait reference with the impl's trait reference.
+   b. Fetch the eligible associated trait item from the impl via `fetch_eligible_assoc_item`.
+   c. Read `item_bounds()` on the impl item to extract the concrete value traits.
+   d. For each value trait, emit a new `TraitPredicate` goal with the original self-type (e.g., `B: Send` if `Elem = Send`).
 
 This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 
@@ -362,7 +370,7 @@ This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 
 **Cross-crate**: Associated trait declarations and values are available across crate boundaries. The metadata encodes `DefKind::AssocTrait` and `explicit_item_bounds` for associated trait items.
 
-**`dyn Trait`**: Associated traits are **not** object-safe. Using `dyn T::Elem` produces a specific error: "associated traits cannot be used with dyn".
+**`dyn Trait`**: Using an associated trait as a dyn bound (`dyn T::Elem`) is rejected because Rust type-checks generic bodies before monomorphization — the concrete trait set behind `T::Elem` is not yet known, and `dyn` requires a compile-time-known vtable layout. This is the same fundamental constraint that prevents `dyn T` where `T` is a type parameter. A trait that merely *has* associated traits can still be used as `dyn Trait` — the associated trait is simply unused in the dyn context.
 
 ### Comparison with associated types
 
@@ -385,9 +393,9 @@ This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 
 - **Partial overlap with where clauses**: Some simple cases that associated traits address can be handled today via additional trait parameters or where clauses, though less ergonomically and without the ability to vary per implementation.
 
-- **Solver complexity**: The `AssocTraitBound` predicate adds a new resolution pathway in both the old and new trait solvers, which must be maintained alongside existing projection and trait obligation machinery.
+- **Solver complexity**: The `AssocTraitBound` predicate adds a new resolution pathway in both the old and new trait solvers — the old solver through its fulfillment engine and evaluation path, the new solver via a dedicated `compute_assoc_trait_bound_goal` function. Both pathways must be maintained alongside existing projection and trait obligation machinery.
 
-- **Bound expansion in method bodies**: Within an impl's method body, `T: Self::Arg` does not currently expand to the concrete bounds for the purposes of using methods from those bounds. The caller-side resolution works correctly, but within the impl body, users must add explicit bounds to use the expanded capabilities. This is a limitation that may be addressed in future work.
+- **Incomplete feature status**: The feature is gated as `incomplete` rather than merely `unstable`, meaning the compiler emits a warning even when the feature is enabled. Users must also write `#![allow(incomplete_features)]` to suppress this warning.
 
 ## Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -449,9 +457,9 @@ Swift's protocol associated types can have constraints (`associatedtype Element:
 
 ### Before merging this RFC
 
-- **Bound expansion in method bodies**: Currently, within an impl method body, `T: Self::Arg` does not expand to allow calling methods from the concrete associated trait value. For example, if `trait Arg = IntoIterator<Item = i32>`, a method body with `T: Self::Arg` cannot call `for x in arg` without an additional explicit `T: IntoIterator` bound. The bounds are correctly enforced at the *caller* side, but the impl body does not see the expanded constraints. Should this be considered a blocker, or is it acceptable as a known limitation for the initial feature?
+- **Bound expansion in method bodies**: ~~Currently, within an impl method body, `T: Self::Arg` does not expand to allow calling methods from the concrete associated trait value.~~ This has been implemented. When an impl provides `trait Arg = IntoIterator<Item = i32>`, a method body with `T: Self::Arg` can now call `for x in arg` directly. The compiler expands `AssocTraitBound` predicates into concrete trait predicates in the method's parameter environment.
 
-- **`impl Self::AssocTrait` in method arguments**: The OP's example includes `fn handle(&self, arg: impl Self::Arg)`. This works syntactically, but the impl body's view of `arg`'s capabilities is limited (see above). What user expectations should we set?
+- **`impl Self::AssocTrait` in method arguments**: `fn handle(&self, arg: impl Self::Arg)` works correctly — the impl body can use the expanded capabilities of the associated trait value.
 
 - **Trait generic parameters**: The OP also proposes `fn foo<Impl, trait Trait> where Impl: Trait { … }` — allowing trait-level generic parameters (not associated traits, but standalone trait parameters). This is a separate, more general feature. Should it be explicitly deferred, or should this RFC leave room for it?
 
@@ -465,18 +473,16 @@ Swift's protocol associated types can have constraints (`associatedtype Element:
 
 - **Incremental compilation**: Dedicated testing of incremental compilation scenarios with associated traits.
 
-- **New trait solver**: The implementation includes support in both the old and new trait solvers. The new solver support should be validated under `-Znext-solver`.
+- **Solver validation**: Both the old and new solver implementations should be validated across a broad range of patterns, including cross-crate scenarios, before stabilization.
 
 ### Out of scope for this RFC
 
 - **Negative associated trait bounds**: e.g., `trait Elem = !Send;`. This intersects with negative impls and is deferred.
-- **`dyn`-compatible associated traits**: Making traits with associated traits object-safe. This requires significant design work around dynamic dispatch and is deferred.
+- **`dyn` with associated traits**: `dyn T::Elem` is not supported because Rust's type system requires dyn vtable layouts to be known at type-checking time, before monomorphization resolves `T`. This is the same constraint that prevents `dyn T` for type parameters. A trait with associated traits can still be used as `dyn Trait`; only the associated trait itself cannot appear as a dyn bound.
 - **Trait-level generic parameters**: `fn foo<trait T>()` is a distinct and more general feature.
 
 ## Future possibilities
 [future-possibilities]: #future-possibilities
-
-- **Bound expansion in impl bodies**: A future enhancement could allow the compiler to automatically expand associated trait bounds within impl method bodies, so that `T: Self::Arg` where `Arg = IntoIterator` allows calling `IntoIterator` methods on `T` without an additional explicit bound.
 
 - **`where T::AssocTrait: OtherTrait`**: If the trait solver were extended to support "projection-level constraints on associated trait values," one could write `where T::Elem: Debug` to require that whatever `T::Elem` resolves to must include `Debug`.
 

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -1,7 +1,7 @@
 - Feature Name: `associated_traits`
 - Start Date: 2026-03-28
 - RFC PR: [rust-lang/rfcs#3938](https://github.com/rust-lang/rfcs/pull/3938)
-- Rust Issue: [rust-lang/rfcs#2190](https://github.com/rust-lang/rfcs/issues/2190)
+- Rust Issue: None
 
 ## Summary
 [summary]: #summary

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -306,110 +306,227 @@ error: expected type, found trait `Container::Elem`
 ## Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-### Syntax
+### Associated trait declarations
 
-**Declaration** (in trait body):
+A trait definition may contain **associated trait declarations**, introduced with the `trait` keyword. An associated trait declaration names a trait constraint whose concrete value is provided by each impl.
 
-```
-trait Ident ;
-trait Ident : Bounds ;
-trait Ident = DefaultBounds ;
-trait Ident : Bounds = DefaultBounds ;
-trait Ident < GenericParams > ;
-trait Ident < GenericParams > where WhereClauses ;
-```
-
-**Implementation** (in impl body):
+**Grammar** (in trait body):
 
 ```
-trait Ident = Bounds ;
-trait Ident < GenericParams > = Bounds ;
+AssocTraitDecl =
+    "trait" IDENT ";"
+  | "trait" IDENT ":" Bounds ";"
+  | "trait" IDENT "=" Bounds ";"
+  | "trait" IDENT ":" Bounds "=" Bounds ";"
+  | "trait" IDENT GenericParams ";"
+  | "trait" IDENT GenericParams WhereClause ";"
+  | "trait" IDENT GenericParams ":" Bounds ";"
+  | "trait" IDENT GenericParams WhereClause ":" Bounds "=" Bounds ";"
 ```
 
-**Usage** (in bound position):
-
-```
-T: Container::Elem
-T: <C as Container>::Elem
-T: C::Elem<i32>
-```
-
-### AST representation
-
-A new variant `AssocItemKind::Trait` is added to the AST, containing:
-- `ident`: the name
-- `generics`: generic parameters and where clauses
-- `bounds`: declaration bounds (supertraits)
-- `value`: the default or impl value (a list of `GenericBound`)
-- `has_value`: whether a `= ...` value is present
-
-### HIR representation
-
-Two new variants:
-- `TraitItemKind::Trait(GenericBounds)` — in trait definitions
-- `ImplItemKind::Trait(GenericBounds)` — in trait implementations
-
-A new HIR bound variant:
-- `GenericBound::AssocTraitBound(&Ty, &PathSegment, Span, Option<DefId>)` — represents `B: C::Elem` in bound position, where the optional `DefId` carries UFCS trait disambiguation.
-
-### DefKind and middle representation
-
-- `DefKind::AssocTrait` — a new `DefKind` variant, distinct from `AssocTy`.
-- `AssocKind::Trait { name: Symbol }` — a new `AssocKind` variant at the `ty` level.
-- `AssocTag::Trait` — used to probe for associated trait items specifically.
-
-### Predicate
-
-A new clause kind is added:
+Examples:
 
 ```rust
-ClauseKind::AssocTraitBound(AssocTraitBoundPredicate {
-    self_ty: Ty,      // The bounded type (B)
-    projection: AliasTerm,  // The projection (<C as Container>::Elem)
-})
+trait Container {
+    trait Elem;                         // bare declaration
+    trait Constraint: Clone;            // with supertrait bound
+    trait Format = Send;                // with default value
+    trait Handler<T>: Debug;            // generic
+    trait Codec<T> where T: Send;       // generic with where clause
+}
 ```
 
-### Name resolution
+**Declaration bounds** (the part after `:`) are *requirements* on every impl's value. If `trait Elem: Clone;`, then every impl must provide a value that implies `Clone`. These bounds are also available to callers: a function with `T: C::Elem` may assume `T: Clone` when the declaration includes `: Clone`.
 
-The resolver accepts partial resolutions (paths with unresolved trailing segments) in `PathSource::Trait(AliasPossibility::Maybe)` when the base is a type parameter, `Self` type param, or `Self` type alias. This allows `C::Elem` in bound position to resolve `C` as a type parameter and leave `Elem` as an unresolved associated item.
+**Defaults** (the part after `=`) provide a value that impls may omit, analogous to default associated types. If an impl omits the associated trait, the default is used.
 
-For UFCS paths (`<T as Trait>::Elem`), the resolver handles fully-qualified paths through `PathSource::TraitItem`, now extended to accept `DefKind::AssocTrait`.
+### Associated trait implementations
 
-### Type checking
+In a trait impl, the associated trait's value is provided with `trait Name = Bounds;`:
 
-**Projection**: Associated traits do *not* participate in type projection. `project()` returns `NoProgress` for `AssocTrait` projections. `type_of()` is unreachable (`span_bug!`) for associated traits.
+```rust
+impl Container for MyVec {
+    trait Elem = Send + Clone;
+}
+```
 
-**Solver support**: Associated traits are supported by both the old and new trait solvers. The old solver resolves `AssocTraitBound` predicates through its fulfillment engine (selecting the impl, extracting value bounds, emitting concrete trait obligations) and its evaluation path (mirroring the fulfillment logic for speculative queries). The new solver handles them via a dedicated `compute_assoc_trait_bound_goal` function. The feature is gated as `unstable`, requiring `#![feature(associated_traits)]`.
+The value may be:
+- One or more trait bounds: `Send`, `Clone + Debug`
+- Trait bounds with associated type constraints: `IntoIterator<Item = i32>`
+- Lifetime bounds: `'static`, `Send + 'static`
+- Relaxed bounds: `?Sized`, `Send + ?Sized`
+- Any combination of the above: `Debug + Send + 'static`
 
-**Bound enforcement**: When `B: C::Elem` appears as a bound, the HIR type lowering emits a `ClauseKind::AssocTraitBound` predicate. Both solver resolve this as follows:
+**Validation**: The compiler checks that the impl's value satisfies the declaration's supertrait bounds. If the declaration says `trait Elem: Clone;`, the impl value must include `Clone` (or a subtrait of `Clone`).
 
-1. **Structurally normalize** the self-type of the projection's trait reference to determine whether the concrete impl is known.
-2. **For abstract types** (type parameters, aliases, placeholders): add only the parent trait obligation (e.g., `C: Container`) and return success. The concrete value bounds cannot be resolved yet because the impl is unknown; declaration bounds are separately validated by `compare_impl_assoc_trait` at the impl site.
-3. **For concrete types**: iterate over relevant impls matching the trait reference. For each candidate impl:
-   a. Probe the impl and unify the goal trait reference with the impl's trait reference.
-   b. Fetch the eligible associated trait item from the impl via `fetch_eligible_assoc_item`.
-   c. Read `item_bounds()` on the impl item to extract the concrete value traits.
-   d. For each value trait, emit a new `TraitPredicate` goal with the original self-type (e.g., `B: Send` if `Elem = Send`).
+Associated traits are **not permitted in inherent impls** — only in trait impls:
 
-This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
+```rust
+impl MyStruct {
+    trait Foo = Send;  // ERROR: not allowed in inherent impls
+}
+```
 
-**Declaration bounds**: When a declaration has bounds (`trait Elem: Clone;`), `compare_impl_item` checks that the impl's value satisfies those supertraits.
+### Using associated traits as bounds
 
-**UFCS disambiguation**: When the optional `constraint_trait` is present in `AssocTraitBound`, the bound resolution filters candidates to only the specified trait, correctly disambiguating `<T as Readable>::Constraint` from `<T as Writable>::Constraint`.
+An associated trait may appear anywhere a trait bound is expected, using the path syntax `C::Elem`:
 
-### Interaction with other features
+```rust
+fn process<C: Container, T: C::Elem>(item: T) { ... }
+```
 
-**Associated types**: Associated traits and associated types coexist in the same trait body. They cannot share the same name (`E0325`). A trait can have both `type Item` and `trait Constraint`. An associated type can be bounded by an associated trait: `type Item: Self::Constraint;`.
+This means: "`T` must satisfy whatever constraint `C::Elem` resolves to." In a generic context, the concrete value is not yet known, but any declaration bounds (supertraits) are available:
 
-**Generic associated types**: Associated traits can be declared alongside generic associated types and used to constrain their parameters at the use site, as in the `PointerFamily` pattern.
+```rust
+trait Container {
+    trait Elem: Debug + 'static;
+}
 
-**Trait inheritance**: Associated traits are inherited through supertraits. If `trait Base { trait Elem; }` and `trait Extended: Base { ... }`, then `Extended` inheritors can use `Self::Elem`.
+// T: Debug and T: 'static are available here from the declaration
+fn to_debug<C: Container, T: C::Elem>(item: T) -> Box<dyn Debug> {
+    Box::new(item)  // OK: T: Debug + 'static from declaration bounds
+}
+```
 
-**`impl Trait`**: `impl C::Elem` in return position or argument position works through opaque type lowering, creating an opaque type bounded by the associated trait.
+At a concrete call site (e.g., `process::<MyVec, i32>(42)`), the solver resolves `MyVec`'s impl of `Container`, extracts `Elem = Send + Clone`, and verifies `i32: Send + Clone`.
 
-**Cross-crate**: Associated trait declarations and values are available across crate boundaries. The metadata encodes `DefKind::AssocTrait` and `explicit_item_bounds` for associated trait items.
+Associated traits may also appear in:
 
-**`dyn Trait`**: Using an associated trait as a dyn bound (`dyn T::Elem`) is rejected because Rust type-checks generic bodies before monomorphization — the concrete trait set behind `T::Elem` is not yet known, and `dyn` requires a compile-time-known vtable layout. This is the same fundamental constraint that prevents `dyn T` where `T` is a type parameter. A trait that merely *has* associated traits can still be used as `dyn Trait` — the associated trait is simply unused in the dyn context.
+- **Where clauses**: `where T: C::Elem`
+- **Inline bounds**: `fn foo<T: C::Elem>()`
+- **`impl Trait`**: `fn foo(arg: impl C::Elem)` and `fn foo() -> impl C::Elem`
+- **Combined with other bounds**: `T: C::Elem + PartialEq`
+
+### Fully-qualified (UFCS) syntax
+
+When a type parameter is bounded by multiple traits that each declare an associated trait with the same name, the shorthand `T::Elem` is ambiguous. Fully-qualified syntax resolves the ambiguity:
+
+```rust
+trait Readable { trait Constraint; }
+trait Writable { trait Constraint; }
+
+fn transfer<T: Readable + Writable,
+            R: <T as Readable>::Constraint,
+            W: <T as Writable>::Constraint>(r: R, w: W) { ... }
+```
+
+The syntax `<T as Trait>::AssocTrait` mirrors the existing UFCS syntax for associated types (`<T as Trait>::AssocType`).
+
+### Positions where associated traits are rejected
+
+Associated traits are constraints, not types. They are rejected in positions that expect a type:
+
+- **Type position**: `let x: T::Elem = ...;` → error: "expected type, found trait"
+- **Return type**: `fn foo() -> T::Elem` → error (unless `impl T::Elem`)
+- **Struct fields**: `struct S { field: T::Elem }` → error
+- **`dyn` position**: `dyn T::Elem` → error: "associated traits cannot be used with dyn"
+
+The `dyn` restriction exists because `dyn` requires a compile-time-known vtable layout, and in a generic context the set of traits behind `T::Elem` is not yet known. This is the same fundamental constraint that prevents `dyn T` where `T` is a type parameter.
+
+A trait that *has* associated traits can still be used as `dyn Trait` — the associated trait is simply inaccessible in the dyn context.
+
+### Generic associated traits
+
+Associated traits may have their own generic parameters, analogous to generic associated types (GATs):
+
+```rust
+trait Transform {
+    trait Constraint<T: Clone>;
+}
+
+impl Transform for MyTransform {
+    trait Constraint<T: Clone> = PartialEq<T> + Debug;
+}
+```
+
+Generic parameters may include types, lifetimes, and bounds. Where clauses are also supported:
+
+```rust
+trait Codec {
+    trait Decode<'a, T> where T: Send;
+}
+```
+
+Usage includes the generic arguments:
+
+```rust
+fn decode<C: Codec, T: C::Decode<'static, u8>>() { ... }
+```
+
+### Interaction with associated types
+
+Associated traits and associated types may coexist in the same trait. They occupy the same name namespace — a trait cannot have both `type Foo` and `trait Foo` with the same name.
+
+An associated type may be bounded by an associated trait from the same trait:
+
+```rust
+trait Container {
+    trait ElemConstraint;
+    type Elem: Self::ElemConstraint;
+}
+```
+
+### Interaction with generic associated types
+
+Associated traits compose with GATs. An associated trait can constrain the parameters of a GAT at the use site:
+
+```rust
+trait PointerFamily {
+    trait Bounds;
+    type Pointer<T>;
+}
+
+fn wrap<F: PointerFamily, T: F::Bounds>(val: T) -> F::Pointer<T> { ... }
+```
+
+GAT parameters may also be directly bounded by associated traits:
+
+```rust
+trait Universe {
+    trait BoundsIn;
+    trait BoundsOut;
+    type Ref<T: Self::BoundsOut>: RefLike<T>;
+    type Cell<T: Self::BoundsIn>: CellLike<T>;
+}
+```
+
+When a GAT parameter is bounded by `Self::Bounds` and used in an impl, the compiler substitutes the concrete associated trait value to check that the impl's GAT definition satisfies its requirements. No additional `where` clauses are required on downstream types that use the GAT — bounds on GAT parameters are checked at instantiation.
+
+### Interaction with trait inheritance
+
+Associated traits are inherited through supertraits:
+
+```rust
+trait Base { trait Elem; }
+trait Extended: Base { trait Extra; }
+
+fn use_both<T: Extended, E: T::Elem + T::Extra>() { ... }
+```
+
+UFCS can disambiguate inherited associated traits:
+
+```rust
+fn use_base<T: Extended, E: <T as Base>::Elem>() { ... }
+```
+
+### Interaction with `impl Trait`
+
+`impl C::Elem` works in both argument and return position, creating an opaque type bounded by the associated trait:
+
+```rust
+trait Handler {
+    trait Arg;
+    fn handle(&self, arg: impl Self::Arg);
+}
+```
+
+### Cross-crate usage
+
+Associated trait declarations and their values are visible across crate boundaries. A crate can define a trait with associated traits, and downstream crates can implement and use them.
+
+### Auto-trait interaction
+
+The concrete types used with associated traits participate in auto-trait inference normally. For example, if `Universe::Ref<T>` is `Arc<T>`, then a struct containing `U::Ref<U::Cell<State>>` is `Send + Sync` when `U` is `Shared` (with `Arc<Mutex<State>>`), and `!Send` when `U` is `Isolated` (with `Rc<RefCell<State>>`).
 
 ### Comparison with associated types
 
@@ -417,13 +534,11 @@ This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 |--------|----------------|-----------------|
 | Declaration | `type Foo;` | `trait Foo;` |
 | Value | `type Foo = i32;` | `trait Foo = Send;` |
-| Position | Type position | Bound position |
-| `type_of` | Returns the type | Unreachable (`span_bug!`) |
-| Projection | Yes (`T::Foo` is a type) | No (`T::Foo` is a constraint) |
-| DefKind | `AssocTy` | `AssocTrait` |
-| Generics | Yes (generic associated types) | Yes (generic associated traits) |
+| Valid positions | Type position | Bound position |
+| Generics | Yes (GATs) | Yes (generic associated traits) |
 | Defaults | Yes | Yes |
 | UFCS | `<T as Trait>::Foo` | `<T as Trait>::Foo` |
+| `dyn` compatible | Yes (with limitations) | No |
 
 ## Drawbacks
 [drawbacks]: #drawbacks
@@ -432,7 +547,7 @@ This means `Rc<i32>: C::Elem` is correctly rejected when `Elem = Send`.
 
 - **Partial overlap with where clauses**: Some simple cases that associated traits address can be handled today via additional trait parameters or where clauses, though less ergonomically and without the ability to vary per implementation.
 
-- **Solver complexity**: The `AssocTraitBound` predicate adds a new resolution pathway in both the old and new trait solvers — the old solver through its fulfillment engine and evaluation path, the new solver via a dedicated `compute_assoc_trait_bound_goal` function. Both pathways must be maintained alongside existing projection and trait obligation machinery.
+- **Solver complexity**: Associated traits introduce a new kind of predicate that both the old and new trait solvers must handle, adding to the compiler's internal complexity. However, the resolution logic follows established patterns from associated type projection.
 
 ## Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/0000-associated-traits.md
+++ b/text/0000-associated-traits.md
@@ -206,12 +206,20 @@ impl Runtime for TokioRuntime {
     fn spawn<F: Future<Output = ()> + Self::FutureConstraint>(f: F) { /* ... */ }
 }
 
-// A single-threaded runtime overrides the default.
+// A single-threaded runtime overrides the default with a different value.
 impl Runtime for LocalRuntime {
     trait FutureConstraint = 'static;  // No Send requirement
     fn spawn<F: Future<Output = ()> + Self::FutureConstraint>(f: F) { /* ... */ }
 }
+
+// Another single-threaded runtime overrides with *no* additional bounds.
+impl Runtime for BareRuntime {
+    trait FutureConstraint;  // Explicit empty value — also overrides the default
+    fn spawn<F: Future<Output = ()> + Self::FutureConstraint>(f: F) { /* ... */ }
+}
 ```
+
+**Omission and the explicit empty value are not the same thing.** Omitting the `trait FutureConstraint` line (as in `TokioRuntime`) means "use the default from the declaration." Writing `trait FutureConstraint;` (as in `BareRuntime`) is an explicit value — it just happens to be empty — and *overrides* the default. See [Associated trait implementations](#associated-trait-implementations) for the precise rules.
 
 ### Generic associated traits
 
@@ -271,6 +279,10 @@ where
 ```
 
 This is different from `T: C::Elem + Debug` (which constrains `T` independently). The value constraint `C::Elem: Debug` constrains the *Container's impl* — if the impl provides `trait Elem = Send` (no Debug), the call is rejected even if `T` happens to implement Debug.
+
+Specifically, `C::Elem: Bound` is satisfied when `Bound` is one of the impl's chosen traits or a transitive supertrait of one of them (e.g. an impl with `trait Elem = MyTrait;` with `trait MyTrait: Debug { … }` still satisfies `C::Elem: Debug` because `Debug` is a supertrait of `MyTrait`).
+
+The check considers only the impl's declared bounds list and any transitive supertraits; it does **not** consult blanket impls. For example, a hypothetical `impl<T: Foo> Debug for T` does *not* make `C::Elem: Debug` hold for an impl that chose `trait Elem = Foo;`, even though every concrete `T` that satisfies the bound would also implement `Debug`.
 
 ### Where associated traits *cannot* appear
 
@@ -350,16 +362,66 @@ impl Container for MyVec {
 }
 ```
 
+**Grammar** (in trait impl body):
+
+```
+AssocTraitImpl =
+    "trait" IDENT ("=" Bounds?)? ";"
+  | "trait" IDENT GenericParams ("=" Bounds?)? ";"
+  | "trait" IDENT GenericParams WhereClause ("=" Bounds?)? ";"
+```
+
+The `= Bounds` portion is optional, and `Bounds` itself is also optional. The bare form `trait Elem;` is preferred for readability; the longer form `trait Elem = ;` is also accepted and has identical meaning (it mirrors Rust's existing [`WhereClause`](https://doc.rust-lang.org/reference/items/generics.html#grammar-WhereClause) grammar, which permits empty bound lists like `where T:`).
+
+#### Omission vs. explicit empty value
+
+There are three syntactically distinct cases, with three distinct meanings. **They are not equivalent — in particular, omitting the line and writing an empty value behave differently when the declaration has a default.**
+
+| In the impl...                                     | Constraints imposed              |
+|----------------------------------------------------|----------------------------------|
+| `trait Elem = Send + Clone;`                       | `Send + Clone`                   |
+| `trait Elem;` *(or equivalently `trait Elem = ;`)* | `()`                             |
+| *(line omitted from the impl)*                     | Inherited from trait declaration |
+
+The crucial distinction is that an explicit empty value is *still an explicit value*: it overrides any default, just as `trait Elem = Send + Clone;` would. Only by omitting the line entirely does the impl opt into the declaration's default.
+
+In all cases, the constraints imposed by an impl are required to satisfy any constraints in the trait declaration.
+
+Example:
+
+```rust
+trait Runtime {
+    trait FutureConstraint = Send;  // default is Send
+}
+
+impl Runtime for A {
+    // line omitted → FutureConstraint = Send (inherits default)
+}
+
+impl Runtime for B {
+    trait FutureConstraint;  // explicit empty → FutureConstraint imposes nothing
+                             // (the Send default is overridden, not merged)
+}
+
+impl Runtime for C {
+    trait FutureConstraint = 'static;  // explicit value → FutureConstraint = 'static
+                                       // (the Send default is overridden, not merged)
+}
+```
+
+For impls `B` and `C`, the default `Send` plays no role; only `A` gets `Send` as its `FutureConstraint`.
+
+This matches how default associated types behave (`type Item = i32;` default in the trait; the impl either omits `type Item` to inherit `i32`, or writes `type Item = u32;` to override — there is no "merge" semantics).
+
 The value may be:
+- Empty: `trait Elem;` (or `trait Elem = ;`) — no additional constraints beyond the declaration's supertraits
 - One or more trait bounds: `Send`, `Clone + Debug`
 - Trait bounds with associated type constraints: `IntoIterator<Item = i32>`
 - Lifetime bounds: `'static`, `Send + 'static`
 - Relaxed bounds: `?Sized`, `Send + ?Sized`
 - Any combination of the above: `Debug + Send + 'static`
 
-**Validation**: The compiler checks that the impl's value satisfies the declaration's supertrait bounds. If the declaration says `trait Elem: Clone;`, the impl value must include `Clone` (or a subtrait of `Clone`).
-
-Associated traits are **not permitted in inherent impls** — only in trait impls:
+Associated traits are not permitted in inherent impls — only in trait impls:
 
 ```rust
 impl MyStruct {
@@ -530,15 +592,15 @@ The concrete types used with associated traits participate in auto-trait inferen
 
 ### Comparison with associated types
 
-| Aspect | Associated Type | Associated Trait |
-|--------|----------------|-----------------|
-| Declaration | `type Foo;` | `trait Foo;` |
-| Value | `type Foo = i32;` | `trait Foo = Send;` |
-| Valid positions | Type position | Bound position |
-| Generics | Yes (GATs) | Yes (generic associated traits) |
-| Defaults | Yes | Yes |
-| UFCS | `<T as Trait>::Foo` | `<T as Trait>::Foo` |
-| `dyn` compatible | Yes (with limitations) | No |
+| Aspect           | Associated Type        | Associated Trait                |
+|------------------|------------------------|---------------------------------|
+| Declaration      | `type Foo;`            | `trait Foo;`                    |
+| Value            | `type Foo = i32;`      | `trait Foo = Send;`             |
+| Valid positions  | Type position          | Bound position                  |
+| Generics         | Yes (GATs)             | Yes (generic associated traits) |
+| Defaults         | Yes                    | Yes                             |
+| UFCS             | `<T as Trait>::Foo`    | `<T as Trait>::Foo`             |
+| `dyn` compatible | Yes (with limitations) | No                              |
 
 ## Drawbacks
 [drawbacks]: #drawbacks
@@ -616,3 +678,5 @@ None at this time.
 - **Non-lifetime HRTBs**: Combined with [non-lifetime higher-ranked trait bounds](https://github.com/rust-lang/rust/issues/108185) (`for<T: Foo> Bar<T>: Baz<T>`), associated traits would enable significantly more expressive generic constraint patterns.
 
 - **Const associated traits**: By analogy with const generics, one could imagine associated traits that are const-evaluable, though the motivation for this is unclear.
+
+- **Implication-based bound satisfaction**: Today `C::Elem: Debug` holds only when `Debug` is one of the impl's chosen traits or a transitive supertrait of one of them (see [Call-site value constraints](#call-site-value-constraints)). A possible extension is to admit it whenever the chosen value *implies* `Debug` for every relevant type — e.g., via a blanket `impl<T: Foo> Debug for T` that makes any `T: Foo` also `T: Debug`. This is strictly more expressive but considerably more complex in its interactions, so is left as a future consideration to control the scope of the RFC.


### PR DESCRIPTION
Allow traits to declare **associated traits** — named trait constraints that are defined abstractly in a trait and given concrete values in implementations. Just as associated types let a trait abstract over *which type* is used, associated traits let a trait abstract over *which constraints* are imposed. This is the trait-level analog of associated types.

```rust
#![feature(associated_traits)]

// 1. Declare an associated trait in a trait definition.
trait Container {
    trait Elem;
    fn process<T: Self::Elem>(&self, item: T);
}

// 2. Each impl chooses the concrete constraints.
impl Container for MyContainer {
    trait Elem = Send + Clone;
    fn process<T: Self::Elem>(&self, item: T) { /* ... */ }
}

// 3. Generic code outside the impl uses `C::Elem` as a bound.
//    This is the primary use case: the caller is generic over
//    the constraints without knowing what they are.
fn process_item<C: Container, T: C::Elem>(container: &C, item: T) {
    container.process(item);
}

// 4. Fully-qualified syntax also works.
fn process_qualified<C: Container, T: <C as Container>::Elem>(container: &C, item: T) {
    container.process(item);
}
```

Previous discussion in #2190.

Prototype implementation: https://github.com/sandersaares/rust/tree/associated-traits

[Rendered](https://github.com/rust-lang/rfcs/blob/eda316fd2f04ad50873b2e047235e3e54866064f/text/0000-associated-traits.md)

> [!IMPORTANT]  
> When responding to RFCs, try to use inline review comments (it is possible to leave an inline review comment for the entire file at the top) instead of direct comments for normal comments and keep normal comments for procedural matters like starting FCPs.
>
> This keeps the discussion more organized.
