### PR TITLE
Not-RFC: Update thread-request box to be less leading and more helpful

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!-- Thank you for trying to improve Rust through the RFC process! -->
 <!-- Please add a short summary of your RFC below -->
 
-> [!IMPORTANT]  
-> When responding to RFCs, try to use inline review comments (it is possible to leave an inline review comment for the entire file at the top) instead of direct comments for normal comments and keep normal comments for procedural matters like starting FCPs.
+> [!IMPORTANT]
+> Since RFCs involve many conversations at once that can be difficult to follow, please use review comment threads on the text changes instead of direct comments on the RFC.
 >
-> This keeps the discussion more organized.
+> If you don't have a particular section of the RFC to comment on, you can click on the "Comment on this file" button on the top-right corner of the diff, to the right of the "Viewed" checkbox. This will create a separate thread even if others have commented on the file too.


### PR DESCRIPTION
<!-- Thank you for trying to improve Rust through the RFC process! -->
<!-- Please add a short summary of your RFC below -->

This is the previous box:

> [!IMPORTANT]  
> When responding to RFCs, try to use inline review comments (it is possible to leave an inline review comment for the entire file at the top) instead of direct comments for normal comments and keep normal comments for procedural matters like starting FCPs.
>
> This keeps the discussion more organized.

This is the new one:

> [!IMPORTANT]
> Since RFCs involve many conversations at once that can be difficult to follow, please use review comment threads on the text changes instead of direct comments on the RFC.
>
> If you don't have a particular section of the RFC to comment on, you can click on the "Comment on this file" button on the top-right corner of the diff, to the right of the "Viewed" checkbox. This will create a separate thread even if others have commented on the file too.

Reasoning:

* Suggestions of the form "try to do this" or "please remember to do this" (old wording) are rather shameful, implying that someone should have understood how to do this beforehand. This is not a standard procedure, so, we shouldn't pretend it is and explain it fully.
* People performing FCPs know that these can't happen in review threads, and they don't apply to most people, so, it's better to just suggest to always use threads and have the more savvy folks use direct comments only as needed.
* Also, the "you can just comment on the file" text is very confusing, and you just have to fumble around the UI to figure out how to do it. It's a very tiny button and originally I even thought we should include a picture, but since the markup isn't trivial, I decided against it. (Plus, the UI might change anyway.)
 
However, here is the picture I took for reference, with the markup that would be appropriate to include for accessibility etc.:

> <figure><img width="182" height="77" alt="Dark mode" src="https://github.com/user-attachments/assets/d8ccb80e-1231-4c6b-bcfd-9b1c52aeb2e5" /><img width="182" height="77" alt="Light mode" src="https://github.com/user-attachments/assets/c68f96a7-fdb2-4de5-bf19-491f74823830" /><figcaption><p>The top-right of each file in the "Changes" view includes, from right to left, an ellipsis menu, a speech bubble button labelled "Comment on this file", and a checkbox with the word "Viewed" next to it.</p></figcaption></figure>

```html
<figure><img width="182" height="77" alt="Dark mode" src="https://github.com/user-attachments/assets/d8ccb80e-1231-4c6b-bcfd-9b1c52aeb2e5" /><img width="182" height="77" alt="Light mode" src="https://github.com/user-attachments/assets/c68f96a7-fdb2-4de5-bf19-491f74823830" /><figcaption><p>The top-right of each file in the "Changes" view includes, from right to left, an ellipsis menu, a speech bubble button labelled "Comment on this file", and a checkbox with the word "Viewed" next to it.</p></figcaption></figure>
```

(Note that Microslop "Accessibility Is My Passion" GitHub doesn't actually include proper styling for figures, but this is the appropriate markup for something like this, since it makes more sense to explain the image with a full caption than include it directly in the alt text.)

----

Since this is now a well-established policy, we don't really need to argue about the merits of whether this message should be included, and rather can focus on its efficacy and wording. It's been around 1½ years since this was added, so, it's probably worth revisiting.