### PR TITLE
update links in build-std context rfc

### DIFF
--- a/text/3873-build-std-context.md
+++ b/text/3873-build-std-context.md
@@ -1101,12 +1101,12 @@ standard library.
 
 [build-std project goal]: https://rust-lang.github.io/rust-project-goals/2025h2/build-std.html
 
-[rfcs#3874]: https://github.com/rust-lang/rfcs/pull/3874
-[rfcs#3874-proposal]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#proposal
-[rfcs#3874-rationale-and-alternatives]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#rationale-and-alternatives
-[rfcs#3874-unresolved-questions]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#unresolved-questions
-[rfcs#3874-future-possibilities]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#future-possibilities
-[rfcs#3874-summary]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#summary-of-proposed-changes
+[rfcs#3874]: https://rust-lang.github.io/rfcs/3874-build-std-always.html
+[rfcs#3874-proposal]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#proposal
+[rfcs#3874-rationale-and-alternatives]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#rationale-and-alternatives
+[rfcs#3874-unresolved-questions]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#unresolved-questions
+[rfcs#3874-future-possibilities]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#future-possibilities
+[rfcs#3874-summary]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#summary-of-proposed-changes
 [rfcs#3875]: https://github.com/rust-lang/rfcs/pull/3875
 [rfcs#3875-proposal]: https://github.com/davidtwco/rfcs/blob/build-std-part-three-explicit-dependencies/text/3875-build-std-explicit-dependencies.md#proposal
 [rfcs#3875-rationale-and-alternatives]: https://github.com/davidtwco/rfcs/blob/build-std-part-three-explicit-dependencies/text/3875-build-std-explicit-dependencies.md#rationale-and-alternatives


### PR DESCRIPTION
build-std RFCs have lots of interlinking and when an RFC is merged then the links in the others need to be updated to still work.

[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/3873-build-std-context.md)