### PR TITLE
Named `Fn` trait parameters

### DIFF
--- a/text/0000-named-fn-trait-arguments.md
+++ b/text/0000-named-fn-trait-arguments.md
@@ -1,0 +1,185 @@
+- Feature Name: `named_fn_trait_arguments`
+- Start Date: 2026-04-24
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+## Summary
+[summary]: #summary
+
+Allow (optional) named function parameters in `Fn`, `FnMut`, and `FnOnce`.
+For example:
+```rust
+fn parse_my_data(
+    data: &str,
+    log: impl Fn(msg: String, priority: usize)
+) { }
+```
+Similar to named function parameters, these names don't affect rust's semantics.
+
+## Motivation
+[motivation]: #motivation
+
+### Benefit: Better documentation
+
+This allows users to better document the meaning of parameters in signatures. This is the primary benefit of this RFC.
+
+For example, it is not immediately clear what the `String` and `usize` refer to in the type of `log`, providing names like in the example above is much clearer.
+
+```rust
+fn parse_my_data(
+    data: &str,
+    log: impl Fn(String, usize)
+) { }
+```
+
+### Benefit: Better LSP hints
+
+When calling `log` in the body of `parse_my_data`, the LSP can provide the function parameter names as "inlay parameter name hints":
+log(`data: `"Message".to_string(), `priority: `1);
+
+This is a concrete advantage of this approach over using comments to do the same thing, such as in:
+```rust
+fn parse_my_data(
+    data: &str,
+    log: impl Fn(/* msg */ String, /* priority */ usize)
+) { }
+```
+
+### Benefit: Better consistency with `fn` pointers
+
+Imagine if `parse_my_data` looked like this:
+```rust
+fn parse_my_data(
+    data: &str,
+    log: fn(msg: String, priority: usize)
+) { }
+```
+
+If due to new requirements the user decides that `impl Fn` suits the usecase better, having to remove the parameter names is unintuive.
+This RFC removes this problem.
+
+Note that the syntax for this feature does not exactly match that of `fn` pointers, see the [reference level explanation](#reference-level-explanation).
+
+## Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+You can give names to parameters in the `Fn`, `FnMut` and `FnOnce` traits to better document the meaning of these parameters, to help people who call your function.
+These names are optional and don't have any semantic meaning. Named and unnamed parameters can be mixed, for example:
+
+```rust
+fn parse_my_data(
+    data: &str,
+    log: impl Fn(String, priority: usize)
+) { }
+```
+
+## Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The syntax `Fn`, `FnMut` and `FnOnce` traits is currently not documented in the reference. 
+
+Before this RFC, the syntax rules are:
+```grammar,types
+ImplTraitParen -> `impl` TraitBoundParen
+
+TraitBoundParen ->
+      ( `?` | ForLifetimes )? TypePath TraitBoundParenArgs
+    | `(` ( `?` | ForLifetimes )? TypePath TraitBoundParenArgs `)`
+    
+TraitBoundParenArgs -> `(` FunctionParametersNoAttr? `)` BareFunctionReturnType?
+
+FunctionParametersNoAttr ->
+    Type ( `,` Type )* `,`?
+    
+BareFunctionReturnType -> `->` TypeNoBounds
+```
+
+After this RFC, the following rules will change:
+
+```grammar,types
+TraitBoundParenArgs -> `(` MaybeNamedFunctionParametersNoAttr? `)` BareFunctionReturnType?
+
+MaybeNamedFunctionParametersNoAttr ->
+    MaybeNamedParamNoAttr ( `,` MaybeNamedParamNoAttr )* `,`?
+    
+MaybeNamedParamNoAttr ->
+    ( ( IDENTIFIER | `_` ) `:` )? Type
+```
+
+Note that this means that:
+
+- Attributes are not allowed on parameters of these traits. This remains unchanged from the current situation. The following will not work:
+  ```rust
+  fn test(x: impl Fn(#[allow(unused)] msg: String, priority: usize), y: usize) { }
+  ```
+  Note that attributes are already allowed on `fn` pointers:
+  ```rust
+  fn test(x: fn(#[allow(unused)] msg: String, priority: usize), y: usize) { }
+  ```
+  The reason why attributes are not allowed is to keep this RFC and the implementation simple, and because I don't see a use for them.
+  
+- This syntax does not match that of `fn` pointers exactly.
+  For historic reasons, the following `fn` pointer type is allowed:
+  ```rust
+  #[cfg(false)]
+  type T = fn(mut x: (), &x: (), &&x: (), false: (), &_: (), &true: ());
+  ```
+  But this RFC proposes that the following `impl Fn` type is not allowed:
+
+  ```rust
+  #[cfg(false)]
+  impl Fn(mut x: (), &x: (), &&x: (), false: (), &_: (), &true: ());
+  ```
+
+  The names of function parameters are limited to ``IDENTIFIER | `_` ``.
+  The reason why we don't match the syntax of `fn` pointer types is because the syntax was a historic mistake and we should not repeat that.
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+* This makes the syntax of `impl Fn` and friends slightly more complicated
+* This makes the syntax of `impl Fn` and friends inconsistent with that of `fn` pointers.
+
+## Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+* An alternative would be to match the `fn` pointer syntax perfectly. This would make the implementation more complicated, without much benefit other than consistency.
+* This needs to be implemented in the language, it cannot be provided by a macro or library as it 
+* This makes Rust code easier to read, as it adds better ways to document function signatures.
+
+## Prior art
+[prior-art]: #prior-art
+
+In Rust, this is already allowed in `fn` pointers:
+```rust
+type LogFunction = fn(msg: String, priority: usize);
+```
+
+In TypeScript:
+```ts
+type LogFunction = (msg: string, priority: number) => void;
+```
+
+In Kotlin:
+```kotlin
+fun log(data: String, logFunction: (msg: String, priority: Int) -> Unit) { }
+```
+
+## Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+* Should duplicate parameter names be allowed in named fn trait arguments? This is currently allowed for `fn` pointers and other functions without an accompanying `Body`.
+  ```rust
+  type T = fn(x: usize, x: usize);
+  ```
+  ```rust
+  trait Test {
+    fn thing(x: usize, x: usize);
+  }
+  ```
+
+## Future possibilities
+[future-possibilities]: #future-possibilities
+
+* We could allow attributes on `impl Fn` parameters in the future.
+

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -1,6 +1,6 @@
-- Feature Name: `named_fn_trait_arguments`
+- Feature Name: `named_fn_trait_parameters`
 - Start Date: 2026-04-24
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [rust-lang/rfcs#3955](https://github.com/rust-lang/rfcs/pull/3955)
 - Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
 
 ## Summary

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -14,7 +14,7 @@ fn parse_my_data(
     log: impl Fn(msg: String, priority: usize)
 ) { }
 ```
-Similar to named function parameters, these names don't affect rust's semantics.
+Similar to named function pointer parameters, these names don't affect rust's semantics.
 
 ## Motivation
 [motivation]: #motivation

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -32,6 +32,8 @@ fn parse_my_data(
 ) { }
 ```
 
+The parameter names should also show up on rustdoc.
+
 ### Benefit: Better LSP hints
 
 When calling `log` in the body of `parse_my_data`, the LSP can provide the function parameter names as "inlay parameter name hints":

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -6,7 +6,7 @@
 ## Summary
 [summary]: #summary
 
-Allow (optional) named function parameters in `Fn`, `FnMut`, and `FnOnce`.
+Allow (optional) named function parameters in parenthesized generic argument lists, such as those of `Fn`, `FnMut`, `FnOnce`, `AsyncFn`, `AsyncFnMut`, and `AsyncFnOnce`.
 For example:
 ```rust
 fn parse_my_data(
@@ -65,7 +65,7 @@ Note that the syntax for this feature does not exactly match that of `fn` pointe
 ## Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-You can give names to parameters in the `Fn`, `FnMut` and `FnOnce` traits to better document the meaning of these parameters, to help people who call your function.
+You can give names to parameters to the `Fn` trait and its friends to better document the meaning of these parameters, to help people who call your function.
 These names are optional and don't have any semantic meaning. Named and unnamed parameters can be mixed, for example:
 
 ```rust
@@ -75,7 +75,7 @@ fn parse_my_data(
 ) { }
 ```
 
-This same syntax also applies to `Fn`, `FnMut` and `FnOnce` trait bounds, for example:
+This same syntax also applies to trait bounds, for example:
 ```rust
 fn parse_my_data<
     L: Fn(msg: String, priority: usize)
@@ -88,9 +88,7 @@ fn parse_my_data<
 ## Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The syntax `Fn`, `FnMut` and `FnOnce` traits is currently not documented in the reference. 
-
-Before this RFC, the syntax rules are:
+Before this RFC, the syntax rules of parenthesized generic argument lists are:
 ```grammar,types
 TypePathFn -> `(` TypePathFnInputs? `)` (`->` TypeNoBounds)?
 

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -103,40 +103,54 @@ TypePathFnInputs -> TypePathFnInput (`,` TypePathFnInput)* `,`?
 TypePathFnInput -> ( ( IDENTIFIER | `_` ) `:` )? Type
 ```
 
-Note that this means that:
+Below are two chapters on some design tradeoffs made here.
 
-- Attributes are not allowed on parameters of these traits. This remains unchanged from the current situation. The following will not work:
-  ```rust
-  fn test(x: impl Fn(#[cfg(...)] msg: String, priority: usize), y: usize) { }
-  ```
-  Note that attributes are already allowed on `fn` pointers:
-  ```rust
-  fn test(x: fn(#[cfg(...)] msg: String, priority: usize), y: usize) { }
-  ```
-  The reason why attributes are not allowed is to keep this RFC and the implementation simple. 
-  Allowing attributes such as `#[cfg(...)]` could be useful, but is out of scope for this RFC.
+### Attributes are not allowed on parenthesized generic argument lists
+Attributes are not allowed on parameters of these traits. This remains unchanged from the current situation. The following will not work:
+```rust
+fn test(x: impl Fn(#[cfg(...)] msg: String, priority: usize), y: usize) { }
+```
+Note that attributes are already allowed on `fn` pointers:
+```rust
+fn test(x: fn(#[cfg(...)] msg: String, priority: usize), y: usize) { }
+```
+The reason why attributes are not allowed is to keep this RFC and the implementation simple.
+Allowing attributes such as `#[cfg(...)]` could be useful, but is out of scope for this RFC.
+This choice is the most safe and conservative choice, attributes could be allowed in the future.
   
-- This syntax does not match that of `fn` pointers exactly.
-  For historic reasons, the following `fn` pointer type is allowed:
-  ```rust
-  #[cfg(false)]
-  type T = fn(mut x: (), &x: (), &&x: (), false: (), &_: (), &true: ());
-  ```
-  But this RFC proposes that the following `impl Fn` type is not allowed:
+### Patterns are not allowed in parenthesized generic argument lists
+This syntax is not consistent with other features in the language.
+The names of function parameters are limited to ``IDENTIFIER | `_` ``.
+This choice is made because it is the most safe and conservative choice, keeping the option open to allow patterns in the future if desired.
+Below is a comparison with two other language features:  
 
-  ```rust
-  #[cfg(false)]
-  impl Fn(mut x: (), &x: (), &&x: (), false: (), &_: (), &true: ());
-  ```
+#### `fn` pointers
+This is unlike `fn` pointers, which allows a `RestrictedPat` (and then semantically rejects anything other than identifiers).
+Therefore, the following program compiles:
+```rust
+#[cfg(false)]
+type F = fn(mut x: (), &x: (), &&x: (), false: (), &_: (), &true: ());
+```
+```
+RestrictedPat = Ident | "&" Ident | "&&" Ident | "mut" CommonIdent;
+Ident = CommonIdent | ReservedIdent (* includes `_`, `false`, `true` *)
+```
 
-  The names of function parameters are limited to ``IDENTIFIER | `_` ``.
-  The reason why we don't match the syntax of `fn` pointer types is because the syntax was a historic mistake and we should not repeat that.
+#### trait functions without bodies 
+This is also unlike trait functions without bodies. Arbitrary patterns are allowed (and then semantically anything other than identifiers is rejected).
+Therefore, the following program compiles:
+```rust
+#[cfg(false)]
+trait Test {
+    fn x((x, y): usize);
+}
+```
 
 ## Drawbacks
 [drawbacks]: #drawbacks
 
 * This makes the syntax of `impl Fn` and friends slightly more complicated
-* This keeps the syntax of `impl Fn` and friends inconsistent with that of `fn` pointers, as to avoid the historic mistakes mentioned in the [reference level explanation](#reference-level-explanation).
+* This keeps the syntax of `impl Fn` and friends inconsistent with that of `fn` pointers nor functions in trait definitions, for the reasoning about this see  [reference level explanation](#reference-level-explanation).
 
 ## Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -107,13 +107,14 @@ Note that this means that:
 
 - Attributes are not allowed on parameters of these traits. This remains unchanged from the current situation. The following will not work:
   ```rust
-  fn test(x: impl Fn(#[allow(unused)] msg: String, priority: usize), y: usize) { }
+  fn test(x: impl Fn(#[cfg(...)] msg: String, priority: usize), y: usize) { }
   ```
   Note that attributes are already allowed on `fn` pointers:
   ```rust
-  fn test(x: fn(#[allow(unused)] msg: String, priority: usize), y: usize) { }
+  fn test(x: fn(#[cfg(...)] msg: String, priority: usize), y: usize) { }
   ```
-  The reason why attributes are not allowed is to keep this RFC and the implementation simple, and because I don't see a use for them.
+  The reason why attributes are not allowed is to keep this RFC and the implementation simple. 
+  Allowing attributes such as `#[cfg(...)]` could be useful, but is out of scope for this RFC.
   
 - This syntax does not match that of `fn` pointers exactly.
   For historic reasons, the following `fn` pointer type is allowed:

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -142,7 +142,7 @@ Note that this means that:
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 * An alternative would be to match the `fn` pointer syntax perfectly. This would make the implementation more complicated, without much benefit other than consistency.
-* This needs to be implemented in the language, it cannot be provided by a macro or library as it 
+* This needs to be implemented in the language, it cannot be provided by a macro or library as it affects syntactic sugar of the language itself.
 * This makes Rust code easier to read, as it adds better ways to document function signatures.
 
 ## Prior art

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -148,7 +148,7 @@ Note that this means that:
 [drawbacks]: #drawbacks
 
 * This makes the syntax of `impl Fn` and friends slightly more complicated
-* This makes the syntax of `impl Fn` and friends inconsistent with that of `fn` pointers.
+* This keeps the syntax of `impl Fn` and friends inconsistent with that of `fn` pointers, as to avoid the historic mistakes mentioned in the [reference level explanation](#reference-level-explanation).
 
 ## Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -92,30 +92,17 @@ The syntax `Fn`, `FnMut` and `FnOnce` traits is currently not documented in the 
 
 Before this RFC, the syntax rules are:
 ```grammar,types
-ImplTraitParen -> `impl` TraitBoundParen
+TypePathFn -> `(` TypePathFnInputs? `)` (`->` TypeNoBounds)?
 
-TraitBoundParen ->
-      ( `?` | ForLifetimes )? TypePath TraitBoundParenArgs
-    | `(` ( `?` | ForLifetimes )? TypePath TraitBoundParenArgs `)`
-    
-TraitBoundParenArgs -> `(` FunctionParametersNoAttr? `)` BareFunctionReturnType?
-
-FunctionParametersNoAttr ->
-    Type ( `,` Type )* `,`?
-    
-BareFunctionReturnType -> `->` TypeNoBounds
+TypePathFnInputs -> Type (`,` Type)* `,`?
 ```
 
-After this RFC, the following rules will change:
+After this RFC, the `TypePathFnInputs` rule will be replaced by:
 
 ```grammar,types
-TraitBoundParenArgs -> `(` MaybeNamedFunctionParametersNoAttr? `)` BareFunctionReturnType?
+TypePathFnInputs -> TypePathFnInput (`,` TypePathFnInput)* `,`?
 
-MaybeNamedFunctionParametersNoAttr ->
-    MaybeNamedParamNoAttr ( `,` MaybeNamedParamNoAttr )* `,`?
-    
-MaybeNamedParamNoAttr ->
-    ( ( IDENTIFIER | `_` ) `:` )? Type
+TypePathFnInput -> ( ( IDENTIFIER | `_` ) `:` )? Type
 ```
 
 Note that this means that:

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -73,6 +73,16 @@ fn parse_my_data(
 ) { }
 ```
 
+This same syntax also applies to `Fn`, `FnMut` and `FnOnce` trait bounds, for example:
+```rust
+fn parse_my_data<
+    L: Fn(msg: String, priority: usize)
+>(
+    data: &str,
+    log: L
+) { }
+```
+
 ## Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -1,7 +1,7 @@
 - Feature Name: `named_fn_trait_parameters`
 - Start Date: 2026-04-24
 - RFC PR: [rust-lang/rfcs#3955](https://github.com/rust-lang/rfcs/pull/3955)
-- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+- Rust Issue: [rust-lang/rust#158499](https://github.com/rust-lang/rust/issues/158499)
 
 ## Summary
 [summary]: #summary

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -88,17 +88,26 @@ fn parse_my_data<
 
 Before this RFC, the syntax rules of parenthesized generic argument lists are:
 ```grammar,types
-TypePathFn -> `(` TypePathFnInputs? `)` (`->` TypeNoBounds)?
+GenericArgs ->
+      `<` GenericArgList? `>`
+    | `(` TypeList? `)` ( `->` TypeNoBounds )?
 
-TypePathFnInputs -> Type (`,` Type)* `,`?
+TypeList ->
+    `(` Type `,` `)`* Type `,`?
 ```
 
-After this RFC, the `TypePathFnInputs` rule will be replaced by:
+After this RFC, these rules will be replaced by:
 
 ```grammar,types
-TypePathFnInputs -> TypePathFnInput (`,` TypePathFnInput)* `,`?
+GenericArgs ->
+      `<` GenericArgList? `>`
+    | `(` MaybeNamedFunctionParameters? `)` ( `->` TypeNoBounds )?
 
-TypePathFnInput -> OuterAttribute* ( ( RestrictedPat | `_` ) `:` )? Type
+MaybeNamedFunctionParameters →
+    `(` MaybeNamedParam `,` `)`* MaybeNamedParam `,`?
+    
+MaybeNamedParam →
+    OuterAttribute* (RestrictedPat `:`)? Type
 ```
 
 Below are two chapters on some design tradeoffs made here.
@@ -126,8 +135,9 @@ Therefore, the following program compiles:
 type F = fn(mut x: (), &x: (), &&x: (), false: (), &_: (), &true: ());
 ```
 ```
-RestrictedPat = Ident | "&" Ident | "&&" Ident | "mut" CommonIdent;
-Ident = CommonIdent | ReservedIdent (* includes `_`, `false`, `true` *)
+RestrictedPat ->
+      `mut`? IDENTIFIER
+    | ( `&` | `&&` )? ( `_` | `false` | `true` | IDENTIFIER )
 ```
 
 #### trait functions without bodies 

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -57,10 +57,8 @@ fn parse_my_data(
 ) { }
 ```
 
-If due to new requirements the user decides that `impl Fn` suits the usecase better, having to remove the parameter names is unintuive.
+If due to new requirements the user decides that `impl Fn` suits the usecase better, having to remove the parameter names is unintuitive.
 This RFC removes this problem.
-
-Note that the syntax for this feature does not exactly match that of `fn` pointers, see the [reference level explanation](#reference-level-explanation).
 
 ## Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -100,13 +98,13 @@ After this RFC, the `TypePathFnInputs` rule will be replaced by:
 ```grammar,types
 TypePathFnInputs -> TypePathFnInput (`,` TypePathFnInput)* `,`?
 
-TypePathFnInput -> ( ( IDENTIFIER | `_` ) `:` )? Type
+TypePathFnInput -> OuterAttribute* ( ( RestrictedPat | `_` ) `:` )? Type
 ```
 
 Below are two chapters on some design tradeoffs made here.
 
-### Attributes are not allowed on parenthesized generic argument lists
-Attributes are not allowed on parameters of these traits. This remains unchanged from the current situation. The following will not work:
+### Attributes are allowed on parenthesized generic argument lists
+Attributes are allowed on parameters in parenthesized generic argument lists:
 ```rust
 fn test(x: impl Fn(#[cfg(...)] msg: String, priority: usize), y: usize) { }
 ```
@@ -114,18 +112,14 @@ Note that attributes are already allowed on `fn` pointers:
 ```rust
 fn test(x: fn(#[cfg(...)] msg: String, priority: usize), y: usize) { }
 ```
-The reason why attributes are not allowed is to keep this RFC and the implementation simple.
-Allowing attributes such as `#[cfg(...)]` could be useful, but is out of scope for this RFC.
-This choice is the most safe and conservative choice, attributes could be allowed in the future.
   
-### Patterns are not allowed in parenthesized generic argument lists
-This syntax is not consistent with other features in the language.
-The names of function parameters are limited to ``IDENTIFIER | `_` ``.
-This choice is made because it is the most safe and conservative choice, keeping the option open to allow patterns in the future if desired.
+### Restricted patterns are syntactically but not semantically allowed in parenthesized generic argument lists
+This syntax is consistent with that of function pointers.
+Semantically, the names of function parameters are limited to ``IDENTIFIER | `_` ``.
 Below is a comparison with two other language features:  
 
-#### `fn` pointers
-This is unlike `fn` pointers, which allows a `RestrictedPat` (and then semantically rejects anything other than identifiers).
+#### Parameters of `fn` pointers and `Fn` trait
+Like on `fn` pointers, a `RestrictedPat` is syntactically allowed.
 Therefore, the following program compiles:
 ```rust
 #[cfg(false)]
@@ -137,7 +131,7 @@ Ident = CommonIdent | ReservedIdent (* includes `_`, `false`, `true` *)
 ```
 
 #### trait functions without bodies 
-This is also unlike trait functions without bodies. Arbitrary patterns are allowed (and then semantically anything other than identifiers is rejected).
+For comparison, trait functions without bodies are more permissive than this. Arbitrary patterns are allowed (and then semantically still anything other than identifiers is rejected).
 Therefore, the following program compiles:
 ```rust
 #[cfg(false)]
@@ -150,12 +144,11 @@ trait Test {
 [drawbacks]: #drawbacks
 
 * This makes the syntax of `impl Fn` and friends slightly more complicated
-* This keeps the syntax of `impl Fn` and friends inconsistent with that of `fn` pointers nor functions in trait definitions, for the reasoning about this see  [reference level explanation](#reference-level-explanation).
+* This keeps the syntax of `impl Fn` and friends inconsistent with that of functions in trait definitions, for the reasoning about this see  [reference level explanation](#reference-level-explanation).
 
 ## Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-* An alternative would be to match the `fn` pointer syntax perfectly. This would make the implementation more complicated, without much benefit other than consistency.
 * This needs to be implemented in the language, it cannot be provided by a macro or library as it affects syntactic sugar of the language itself.
 * This makes Rust code easier to read, as it adds better ways to document function signatures.
 
@@ -193,9 +186,10 @@ fun log(data: String, logFunction: (msg: String, priority: Int) -> Unit) { }
 ## Future possibilities
 [future-possibilities]: #future-possibilities
 
-* We could allow attributes on `impl Fn` parameters in the future.
-
 * We should figure out how this feature interacts with the "named arguments" feature. 
   One proposal is to mirror whatever solution we come up with for function pointers.
   For example, if named arguments used the syntax `fn f(pub a: T, pub b: U) -> R`, the function trait should be `Fn(pub a: T, pub b: U) -> R`.
+* Similarly, we should figure out how this feature interacts with the "defaulted arguments" feature.
+  Again, this should mirror function pointers.
+  For example, if default arguments used the syntax `fn(x: String, y: i32 = 0)`, the function trait should be `Fn(x: String, y: i32 = 0)`.
 

--- a/text/3955-named-fn-trait-parameters.md
+++ b/text/3955-named-fn-trait-parameters.md
@@ -195,3 +195,7 @@ fun log(data: String, logFunction: (msg: String, priority: Int) -> Unit) { }
 
 * We could allow attributes on `impl Fn` parameters in the future.
 
+* We should figure out how this feature interacts with the "named arguments" feature. 
+  One proposal is to mirror whatever solution we come up with for function pointers.
+  For example, if named arguments used the syntax `fn f(pub a: T, pub b: U) -> R`, the function trait should be `Fn(pub a: T, pub b: U) -> R`.
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rfcs/pull/3955)*

<!-- Thank you for trying to improve Rust through the RFC process! -->
<!-- Please add a short summary of your RFC below -->

Allow (optional) named function parameters in parenthesized generic argument lists, such as those of `Fn`, `FnMut`, `FnOnce`, `AsyncFn`, `AsyncFnMut`, and `AsyncFnOnce`.
For example:
```rust
fn parse_my_data(
    data: &str,
    log: impl Fn(msg: String, priority: usize)
) { }
```
Similar to named function pointer parameters, these names don't affect rust's semantics.

> [!IMPORTANT]
> Since RFCs involve many conversations at once that can be difficult to follow, please use review comment threads on the text changes instead of direct comments on the RFC.
>
> If you don't have a particular section of the RFC to comment on, you can click on the "Comment on this file" button on the top-right corner of the diff, to the right of the "Viewed" checkbox. This will create a separate thread even if others have commented on the file too.


[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/3955-named-fn-trait-parameters.md)