### PR TITLE
Fix some links in the build-std RFCs

### DIFF
--- a/text/3874-build-std-always.md
+++ b/text/3874-build-std-always.md
@@ -74,7 +74,7 @@ library, so that the new surface area of the standard library exposed by
 build-std is minimal (while providing extension points for this to be changed in
 future in limited and controlled ways).
 
-[rfcs#3875-features]: https://github.com/davidtwco/rfcs/blob/build-std-part-three-explicit-dependencies/text/3875-build-std-explicit-dependencies.md#features
+[rfcs#3875-features]: https://rust-lang.github.io/rfcs/3875-build-std-explicit-dependencies.html#features
 
 ## Proposal
 [proposal]: #proposal
@@ -339,7 +339,7 @@ possibility for how the `no_std` mechanism could be replaced.
 
 - [*Replace `#![no_std]` as the source-of-truth for whether a crate depends on `std`*][future-replace-no_std] (RFC 3875)
 
-[future-replace-no_std]: https://github.com/davidtwco/rfcs/blob/build-std-part-three-explicit-dependencies/text/3875-build-std-explicit-dependencies.md#replace-no_std-as-the-source-of-truth-for-whether-a-crate-depends-on-std
+[future-replace-no_std]: https://rust-lang.github.io/rfcs/3875-build-std-explicit-dependencies.html#replace-no_std-as-the-source-of-truth-for-whether-a-crate-depends-on-std
 
 ### `restricted_std`
 [restricted_std]: #restricted_std
@@ -564,7 +564,7 @@ and is unchanged.
 See [*Allow local builds of `compiler-rt` intrinsics*][future-compiler-builtins-c]
 for discussion of the `compiler-builtins-c` feature.
 
-[future-compiler-builtins-c]: https://github.com/davidtwco/rfcs/blob/build-std-part-three-explicit-dependencies/text/3875-build-std-explicit-dependencies.md#allow-local-builds-of-compiler-rt-intrinsics
+[future-compiler-builtins-c]: https://rust-lang.github.io/rfcs/3875-build-std-explicit-dependencies.html#allow-local-builds-of-compiler-rt-intrinsics
 
 #### `compiler-builtins/mem`
 [compiler-builtins-mem]: #compiler-builtinsmem

--- a/text/3875-build-std-explicit-dependencies.md
+++ b/text/3875-build-std-explicit-dependencies.md
@@ -251,8 +251,8 @@ same behaviour and constraints apply.
 - [*Allow `builtin` source replacement*][future-source-replacement]
 - [*Remove `rustc_dep_of_std`*][future-rustc_dep_of_std]
 
-[rfcs#3874-standard-library-crate-stability]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#standard-library-crate-stability
-[rfcs#3874-noprelude]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#why-use-noprelude-with---extern
+[rfcs#3874-standard-library-crate-stability]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#standard-library-crate-stability
+[rfcs#3874-noprelude]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#why-use-noprelude-with---extern
 
 ### Non-`builtin` standard library dependencies
 [non-builtin-standard-library-dependencies]: #non-builtin-standard-library-dependencies
@@ -1301,8 +1301,8 @@ prevent some otherwise stable features from being toggled as it controls those.
 
 ↩ [*Features*][features]
 
-[rfcs#3874-panic-strategies]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#panic-strategies
-[rfcs#3874-compiler-builtins-mem]: https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md#compiler-builtinsmem
+[rfcs#3874-panic-strategies]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#panic-strategies
+[rfcs#3874-compiler-builtins-mem]: https://rust-lang.github.io/rfcs/3874-build-std-always.html#compiler-builtinsmem
 
 ### Allow local builds of `compiler-rt` intrinsics
 [future-compiler-builtins-c]: #allow-local-builds-of-compiler-rt-intrinsics


### PR DESCRIPTION
These links are 404. This updates them to the canonical link in the now published RFC.


[Rendered](https://github.com/rust-lang/rfcs/blob/master/text/3875-build-std-explicit-dependencies.md)